### PR TITLE
API client for destiny-repository

### DIFF
--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -1,0 +1,64 @@
+import { api } from "@/api/client";
+import type {
+  Reference,
+  SearchResult,
+  Enhancement,
+  BibliographicMetadataEnhancement,
+  LinkedDataEnhancement,
+} from "@/types/models";
+
+export interface SearchFilters {
+  page?: number;
+  annotation?: string[];
+  sort?: string[];
+}
+
+export async function searchReferences(
+  query: string,
+  filters: SearchFilters = {},
+): Promise<SearchResult> {
+  const params = new URLSearchParams();
+  params.set("q", query);
+  if (filters.page) {
+    params.set("page", String(filters.page));
+  }
+  if (filters.annotation) {
+    for (const a of filters.annotation) {
+      params.append("annotation", a);
+    }
+  }
+  if (filters.sort) {
+    for (const s of filters.sort) {
+      params.append("sort", s);
+    }
+  }
+  return api.get<SearchResult>(`/v1/search/?${params.toString()}`);
+}
+
+export async function getReference(id: string): Promise<Reference> {
+  return api.get<Reference>(`/v1/references/${id}/`);
+}
+
+export function extractBibliographic(
+  reference: Reference,
+): BibliographicMetadataEnhancement | null {
+  if (!reference.enhancements) return null;
+  const matches = reference.enhancements.filter(
+    (e): e is Enhancement & { content: BibliographicMetadataEnhancement } =>
+      e.content.enhancement_type === "bibliographic",
+  );
+  if (matches.length === 0) return null;
+  return matches[matches.length - 1].content;
+}
+
+export function extractLinkedData(
+  reference: Reference,
+): LinkedDataEnhancement | null {
+  if (!reference.enhancements) return null;
+  const matches = reference.enhancements.filter(
+    (e): e is Enhancement & { content: LinkedDataEnhancement } =>
+      e.content.enhancement_type === "linked_data",
+  );
+  if (matches.length === 0) return null;
+  return matches[matches.length - 1].content;
+}

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -3,6 +3,7 @@ import type {
   Reference,
   SearchResult,
   Enhancement,
+  EnhancementContent,
   BibliographicMetadataEnhancement,
   LinkedDataEnhancement,
 } from "@/types/models";
@@ -19,7 +20,7 @@ export async function searchReferences(
 ): Promise<SearchResult> {
   const params = new URLSearchParams();
   params.set("q", query);
-  if (filters.page) {
+  if (filters.page !== undefined) {
     params.set("page", String(filters.page));
   }
   if (filters.annotation) {
@@ -32,33 +33,40 @@ export async function searchReferences(
       params.append("sort", s);
     }
   }
-  return api.get<SearchResult>(`/v1/search/?${params.toString()}`);
+  return api.get<SearchResult>(`/v1/references/search/?${params.toString()}`);
 }
 
 export async function getReference(id: string): Promise<Reference> {
   return api.get<Reference>(`/v1/references/${id}/`);
 }
 
+function extractEnhancement<T extends EnhancementContent>(
+  reference: Reference,
+  enhancementType: T["enhancement_type"],
+): T | null {
+  if (!reference.enhancements) return null;
+  const matches = reference.enhancements.filter(
+    (e): e is Enhancement & { content: T } =>
+      e.content.enhancement_type === enhancementType,
+  );
+  if (matches.length === 0) return null;
+  const sorted = matches.sort((a, b) =>
+    (a.created_at ?? "").localeCompare(b.created_at ?? ""),
+  );
+  return sorted[sorted.length - 1].content;
+}
+
 export function extractBibliographic(
   reference: Reference,
 ): BibliographicMetadataEnhancement | null {
-  if (!reference.enhancements) return null;
-  const matches = reference.enhancements.filter(
-    (e): e is Enhancement & { content: BibliographicMetadataEnhancement } =>
-      e.content.enhancement_type === "bibliographic",
+  return extractEnhancement<BibliographicMetadataEnhancement>(
+    reference,
+    "bibliographic",
   );
-  if (matches.length === 0) return null;
-  return matches[matches.length - 1].content;
 }
 
 export function extractLinkedData(
   reference: Reference,
 ): LinkedDataEnhancement | null {
-  if (!reference.enhancements) return null;
-  const matches = reference.enhancements.filter(
-    (e): e is Enhancement & { content: LinkedDataEnhancement } =>
-      e.content.enhancement_type === "linked_data",
-  );
-  if (matches.length === 0) return null;
-  return matches[matches.length - 1].content;
+  return extractEnhancement<LinkedDataEnhancement>(reference, "linked_data");
 }

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -36,8 +36,11 @@ export async function searchReferences(
   return api.get<SearchResult>(`/v1/references/search/?${params.toString()}`);
 }
 
-export async function getReference(id: string): Promise<Reference> {
-  return api.get<Reference>(`/v1/references/${id}/`);
+export async function getReference(id: string): Promise<Reference | null> {
+  const results = await api.get<Reference[]>(
+    `/v1/references/?identifier=${encodeURIComponent(id)}`,
+  );
+  return results[0] ?? null;
 }
 
 function extractEnhancement<T extends EnhancementContent>(

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -115,6 +115,7 @@ export interface Enhancement {
   visibility: Visibility;
   robot_version: string | null;
   derived_from: string[] | null;
+  created_at: string | null;
   content: EnhancementContent;
 }
 

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -3,6 +3,124 @@ export interface Community {
   name: string;
 }
 
+export type Visibility = "public" | "restricted" | "hidden";
+
+export interface SearchResultTotal {
+  count: number;
+  is_lower_bound: boolean;
+}
+
+export interface SearchResultPage {
+  count: number;
+  number: number;
+}
+
+export interface SearchResult {
+  total: SearchResultTotal;
+  page: SearchResultPage;
+  references: Reference[];
+}
+
+export interface ExternalIdentifier {
+  identifier: {
+    identifier: string;
+    identifier_type: string | null;
+    other_identifier_name: string | null;
+  };
+  reference_id?: string;
+}
+
+export type EnhancementType =
+  | "bibliographic"
+  | "abstract"
+  | "annotation"
+  | "location"
+  | "reference_association"
+  | "linked_data"
+  | "raw"
+  | "full_text";
+
+export type AuthorPosition = "first" | "middle" | "last";
+
+export interface Authorship {
+  display_name: string;
+  orcid: string | null;
+  position: AuthorPosition;
+}
+
+export interface Pagination {
+  volume: string | null;
+  issue: string | null;
+  first_page: string | null;
+  last_page: string | null;
+}
+
+export type PublicationVenueType =
+  | "journal"
+  | "repository"
+  | "conference"
+  | "ebook_platform"
+  | "book_series"
+  | "other";
+
+export interface PublicationVenue {
+  display_name: string | null;
+  venue_type: PublicationVenueType | null;
+}
+
+export interface BibliographicMetadataEnhancement {
+  enhancement_type: "bibliographic";
+  authorship: Authorship[] | null;
+  cited_by_count: number | null;
+  created_date: string | null;
+  updated_date: string | null;
+  publication_date: string | null;
+  publication_year: number | null;
+  publisher: string | null;
+  title: string | null;
+  pagination: Pagination | null;
+  publication_venue: PublicationVenue | null;
+}
+
+export interface AbstractContentEnhancement {
+  enhancement_type: "abstract";
+  process: string;
+  abstract: string;
+}
+
+export interface LinkedDataEnhancement {
+  enhancement_type: "linked_data";
+  vocabulary_uri: string;
+  data: Record<string, unknown>;
+}
+
+export interface OtherEnhancement {
+  enhancement_type: Exclude<
+    EnhancementType,
+    "bibliographic" | "abstract" | "linked_data"
+  >;
+  [key: string]: unknown;
+}
+
+export type EnhancementContent =
+  | BibliographicMetadataEnhancement
+  | AbstractContentEnhancement
+  | LinkedDataEnhancement
+  | OtherEnhancement;
+
+export interface Enhancement {
+  id: string | null;
+  reference_id: string;
+  source: string;
+  visibility: Visibility;
+  robot_version: string | null;
+  derived_from: string[] | null;
+  content: EnhancementContent;
+}
+
 export interface Reference {
   id: string;
+  visibility: Visibility;
+  identifiers: ExternalIdentifier[] | null;
+  enhancements: Enhancement[] | null;
 }

--- a/tests/services/apiClient.test.ts
+++ b/tests/services/apiClient.test.ts
@@ -1,0 +1,208 @@
+import { vi } from "vitest";
+import { api } from "@/api/client";
+import {
+  searchReferences,
+  getReference,
+  extractBibliographic,
+  extractLinkedData,
+} from "@/services/apiClient";
+import type {
+  Reference,
+  SearchResult,
+  Enhancement,
+  BibliographicMetadataEnhancement,
+  LinkedDataEnhancement,
+} from "@/types/models";
+
+vi.mock("@/api/client", () => ({
+  api: {
+    get: vi.fn(),
+  },
+}));
+
+const mockedGet = vi.mocked(api.get);
+
+beforeEach(() => {
+  mockedGet.mockReset();
+});
+
+describe("searchReferences", () => {
+  const result: SearchResult = {
+    total: { count: 1, is_lower_bound: false },
+    page: { count: 10, number: 1 },
+    references: [],
+  };
+
+  test("calls the correct endpoint with query", async () => {
+    mockedGet.mockResolvedValue(result);
+    await searchReferences("climate change");
+    expect(mockedGet).toHaveBeenCalledWith("/v1/search/?q=climate+change");
+  });
+
+  test("appends page filter", async () => {
+    mockedGet.mockResolvedValue(result);
+    await searchReferences("test", { page: 3 });
+    expect(mockedGet).toHaveBeenCalledWith("/v1/search/?q=test&page=3");
+  });
+
+  test("appends multiple annotation params", async () => {
+    mockedGet.mockResolvedValue(result);
+    await searchReferences("test", { annotation: ["foo", "bar"] });
+    const url = mockedGet.mock.calls[0][0];
+    const params = new URLSearchParams(url.split("?")[1]);
+    expect(params.getAll("annotation")).toEqual(["foo", "bar"]);
+  });
+
+  test("appends multiple sort params", async () => {
+    mockedGet.mockResolvedValue(result);
+    await searchReferences("test", { sort: ["date", "-relevance"] });
+    const url = mockedGet.mock.calls[0][0];
+    const params = new URLSearchParams(url.split("?")[1]);
+    expect(params.getAll("sort")).toEqual(["date", "-relevance"]);
+  });
+
+  test("returns the result from api.get", async () => {
+    mockedGet.mockResolvedValue(result);
+    const res = await searchReferences("test");
+    expect(res).toBe(result);
+  });
+});
+
+describe("getReference", () => {
+  test("calls the correct endpoint", async () => {
+    const ref = { id: "abc-123" } as Reference;
+    mockedGet.mockResolvedValue(ref);
+    await getReference("abc-123");
+    expect(mockedGet).toHaveBeenCalledWith("/v1/references/abc-123/");
+  });
+
+  test("returns the result", async () => {
+    const ref = { id: "abc-123" } as Reference;
+    mockedGet.mockResolvedValue(ref);
+    const res = await getReference("abc-123");
+    expect(res).toBe(ref);
+  });
+});
+
+function makeEnhancement(
+  content: Enhancement["content"],
+): Enhancement {
+  return {
+    id: null,
+    reference_id: "ref-1",
+    source: "test",
+    visibility: "public",
+    robot_version: null,
+    derived_from: null,
+    content,
+  };
+}
+
+function makeRef(enhancements: Enhancement[] | null): Reference {
+  return {
+    id: "ref-1",
+    visibility: "public",
+    identifiers: null,
+    enhancements,
+  };
+}
+
+describe("extractBibliographic", () => {
+  test("returns null when enhancements is null", () => {
+    expect(extractBibliographic(makeRef(null))).toBeNull();
+  });
+
+  test("returns null when no bibliographic enhancement exists", () => {
+    const ref = makeRef([
+      makeEnhancement({ enhancement_type: "abstract", process: "x", abstract: "y" }),
+    ]);
+    expect(extractBibliographic(ref)).toBeNull();
+  });
+
+  test("returns bibliographic content when present", () => {
+    const bib: BibliographicMetadataEnhancement = {
+      enhancement_type: "bibliographic",
+      authorship: null,
+      cited_by_count: 5,
+      created_date: null,
+      updated_date: null,
+      publication_date: null,
+      publication_year: 2024,
+      publisher: null,
+      title: "Test",
+      pagination: null,
+      publication_venue: null,
+    };
+    const ref = makeRef([makeEnhancement(bib)]);
+    expect(extractBibliographic(ref)).toBe(bib);
+  });
+
+  test("returns the last bibliographic enhancement when multiple exist", () => {
+    const bib1: BibliographicMetadataEnhancement = {
+      enhancement_type: "bibliographic",
+      authorship: null,
+      cited_by_count: null,
+      created_date: null,
+      updated_date: null,
+      publication_date: null,
+      publication_year: 2020,
+      publisher: null,
+      title: "First",
+      pagination: null,
+      publication_venue: null,
+    };
+    const bib2: BibliographicMetadataEnhancement = {
+      enhancement_type: "bibliographic",
+      authorship: null,
+      cited_by_count: null,
+      created_date: null,
+      updated_date: null,
+      publication_date: null,
+      publication_year: 2024,
+      publisher: null,
+      title: "Second",
+      pagination: null,
+      publication_venue: null,
+    };
+    const ref = makeRef([makeEnhancement(bib1), makeEnhancement(bib2)]);
+    expect(extractBibliographic(ref)).toBe(bib2);
+  });
+});
+
+describe("extractLinkedData", () => {
+  test("returns null when enhancements is null", () => {
+    expect(extractLinkedData(makeRef(null))).toBeNull();
+  });
+
+  test("returns null when no linked_data enhancement exists", () => {
+    const ref = makeRef([
+      makeEnhancement({ enhancement_type: "abstract", process: "x", abstract: "y" }),
+    ]);
+    expect(extractLinkedData(ref)).toBeNull();
+  });
+
+  test("returns linked_data content when present", () => {
+    const ld: LinkedDataEnhancement = {
+      enhancement_type: "linked_data",
+      vocabulary_uri: "http://example.com",
+      data: { key: "value" },
+    };
+    const ref = makeRef([makeEnhancement(ld)]);
+    expect(extractLinkedData(ref)).toBe(ld);
+  });
+
+  test("returns the last linked_data enhancement when multiple exist", () => {
+    const ld1: LinkedDataEnhancement = {
+      enhancement_type: "linked_data",
+      vocabulary_uri: "http://first.com",
+      data: { n: 1 },
+    };
+    const ld2: LinkedDataEnhancement = {
+      enhancement_type: "linked_data",
+      vocabulary_uri: "http://second.com",
+      data: { n: 2 },
+    };
+    const ref = makeRef([makeEnhancement(ld1), makeEnhancement(ld2)]);
+    expect(extractLinkedData(ref)).toBe(ld2);
+  });
+});

--- a/tests/services/apiClient.test.ts
+++ b/tests/services/apiClient.test.ts
@@ -36,13 +36,25 @@ describe("searchReferences", () => {
   test("calls the correct endpoint with query", async () => {
     mockedGet.mockResolvedValue(result);
     await searchReferences("climate change");
-    expect(mockedGet).toHaveBeenCalledWith("/v1/search/?q=climate+change");
+    expect(mockedGet).toHaveBeenCalledWith(
+      "/v1/references/search/?q=climate+change",
+    );
   });
 
   test("appends page filter", async () => {
     mockedGet.mockResolvedValue(result);
     await searchReferences("test", { page: 3 });
-    expect(mockedGet).toHaveBeenCalledWith("/v1/search/?q=test&page=3");
+    expect(mockedGet).toHaveBeenCalledWith(
+      "/v1/references/search/?q=test&page=3",
+    );
+  });
+
+  test("appends page=0 when explicitly set", async () => {
+    mockedGet.mockResolvedValue(result);
+    await searchReferences("test", { page: 0 });
+    expect(mockedGet).toHaveBeenCalledWith(
+      "/v1/references/search/?q=test&page=0",
+    );
   });
 
   test("appends multiple annotation params", async () => {
@@ -86,6 +98,7 @@ describe("getReference", () => {
 
 function makeEnhancement(
   content: Enhancement["content"],
+  createdAt: string | null = null,
 ): Enhancement {
   return {
     id: null,
@@ -94,6 +107,7 @@ function makeEnhancement(
     visibility: "public",
     robot_version: null,
     derived_from: null,
+    created_at: createdAt,
     content,
   };
 }
@@ -114,7 +128,11 @@ describe("extractBibliographic", () => {
 
   test("returns null when no bibliographic enhancement exists", () => {
     const ref = makeRef([
-      makeEnhancement({ enhancement_type: "abstract", process: "x", abstract: "y" }),
+      makeEnhancement({
+        enhancement_type: "abstract",
+        process: "x",
+        abstract: "y",
+      }),
     ]);
     expect(extractBibliographic(ref)).toBeNull();
   });
@@ -133,11 +151,11 @@ describe("extractBibliographic", () => {
       pagination: null,
       publication_venue: null,
     };
-    const ref = makeRef([makeEnhancement(bib)]);
+    const ref = makeRef([makeEnhancement(bib, "2026-01-01T00:00:00Z")]);
     expect(extractBibliographic(ref)).toBe(bib);
   });
 
-  test("returns the last bibliographic enhancement when multiple exist", () => {
+  test("returns the most recent bibliographic enhancement by created_at", () => {
     const bib1: BibliographicMetadataEnhancement = {
       enhancement_type: "bibliographic",
       authorship: null,
@@ -147,7 +165,7 @@ describe("extractBibliographic", () => {
       publication_date: null,
       publication_year: 2020,
       publisher: null,
-      title: "First",
+      title: "Older",
       pagination: null,
       publication_venue: null,
     };
@@ -160,11 +178,14 @@ describe("extractBibliographic", () => {
       publication_date: null,
       publication_year: 2024,
       publisher: null,
-      title: "Second",
+      title: "Newer",
       pagination: null,
       publication_venue: null,
     };
-    const ref = makeRef([makeEnhancement(bib1), makeEnhancement(bib2)]);
+    const ref = makeRef([
+      makeEnhancement(bib2, "2026-01-01T00:00:00Z"),
+      makeEnhancement(bib1, "2025-01-01T00:00:00Z"),
+    ]);
     expect(extractBibliographic(ref)).toBe(bib2);
   });
 });
@@ -176,7 +197,11 @@ describe("extractLinkedData", () => {
 
   test("returns null when no linked_data enhancement exists", () => {
     const ref = makeRef([
-      makeEnhancement({ enhancement_type: "abstract", process: "x", abstract: "y" }),
+      makeEnhancement({
+        enhancement_type: "abstract",
+        process: "x",
+        abstract: "y",
+      }),
     ]);
     expect(extractLinkedData(ref)).toBeNull();
   });
@@ -187,22 +212,25 @@ describe("extractLinkedData", () => {
       vocabulary_uri: "http://example.com",
       data: { key: "value" },
     };
-    const ref = makeRef([makeEnhancement(ld)]);
+    const ref = makeRef([makeEnhancement(ld, "2026-01-01T00:00:00Z")]);
     expect(extractLinkedData(ref)).toBe(ld);
   });
 
-  test("returns the last linked_data enhancement when multiple exist", () => {
+  test("returns the most recent linked_data enhancement by created_at", () => {
     const ld1: LinkedDataEnhancement = {
       enhancement_type: "linked_data",
-      vocabulary_uri: "http://first.com",
+      vocabulary_uri: "http://older.com",
       data: { n: 1 },
     };
     const ld2: LinkedDataEnhancement = {
       enhancement_type: "linked_data",
-      vocabulary_uri: "http://second.com",
+      vocabulary_uri: "http://newer.com",
       data: { n: 2 },
     };
-    const ref = makeRef([makeEnhancement(ld1), makeEnhancement(ld2)]);
+    const ref = makeRef([
+      makeEnhancement(ld2, "2026-02-01T00:00:00Z"),
+      makeEnhancement(ld1, "2025-01-01T00:00:00Z"),
+    ]);
     expect(extractLinkedData(ref)).toBe(ld2);
   });
 });

--- a/tests/services/apiClient.test.ts
+++ b/tests/services/apiClient.test.ts
@@ -81,18 +81,34 @@ describe("searchReferences", () => {
 });
 
 describe("getReference", () => {
-  test("calls the correct endpoint", async () => {
+  test("calls the identifier lookup endpoint", async () => {
     const ref = { id: "abc-123" } as Reference;
-    mockedGet.mockResolvedValue(ref);
+    mockedGet.mockResolvedValue([ref]);
     await getReference("abc-123");
-    expect(mockedGet).toHaveBeenCalledWith("/v1/references/abc-123/");
+    expect(mockedGet).toHaveBeenCalledWith(
+      "/v1/references/?identifier=abc-123",
+    );
   });
 
-  test("returns the result", async () => {
+  test("returns the first result", async () => {
     const ref = { id: "abc-123" } as Reference;
-    mockedGet.mockResolvedValue(ref);
+    mockedGet.mockResolvedValue([ref]);
     const res = await getReference("abc-123");
     expect(res).toBe(ref);
+  });
+
+  test("returns null when no results", async () => {
+    mockedGet.mockResolvedValue([]);
+    const res = await getReference("nonexistent");
+    expect(res).toBeNull();
+  });
+
+  test("encodes identifier in URL", async () => {
+    mockedGet.mockResolvedValue([]);
+    await getReference("doi:10.1000/abc123");
+    expect(mockedGet).toHaveBeenCalledWith(
+      "/v1/references/?identifier=doi%3A10.1000%2Fabc123",
+    );
   });
 });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,8 +15,9 @@ export default defineConfig({
     port: 3000,
     proxy: {
       "/api": {
-        target: process.env.VITE_API_TARGET || "http://localhost:8080",
+        target: process.env.VITE_API_TARGET || "http://localhost:8000",
         changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ""),
       },
     },
   },


### PR DESCRIPTION
## Summary
- Expand `src/types/models.ts` with full TypeScript types matching the backend SDK (Reference, Enhancement, SearchResult, pagination, etc.)
- Add `src/services/apiClient.ts` with `searchReferences()`, `getReference()`, and helpers to extract the most recent bibliographic/linked-data enhancements
- Add unit tests covering all API client functions and extraction helpers (15 tests)

Closes #4

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run test` — all 16 tests pass (15 new + 1 existing)