### PR TITLE
Fix storage account name length and SPA 404 on Front Door

### DIFF
--- a/infra/app/frontdoor.tf
+++ b/infra/app/frontdoor.tf
@@ -116,11 +116,42 @@ resource "azurerm_cdn_frontdoor_rule" "html_no_cache" {
   }
 }
 
+# SPA fallback: rewrite extensionless paths to /index.html so the origin
+# returns 200 instead of 404 (blob storage error_404_document preserves the
+# 404 status code, which breaks client-side routing).
+resource "azurerm_cdn_frontdoor_rule" "spa_rewrite" {
+  name                      = "SpaRewrite"
+  cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.cache.id
+  order                     = 3
+  behavior_on_match         = "Continue"
+
+  conditions {
+    url_file_extension_condition {
+      operator         = "LessThan"
+      match_values     = ["1"]
+      negate_condition = false
+    }
+  }
+
+  actions {
+    url_rewrite_action {
+      source_pattern          = "/"
+      destination             = "/index.html"
+      preserve_unmatched_path = false
+    }
+    response_header_action {
+      header_action = "Overwrite"
+      header_name   = "Cache-Control"
+      value         = "no-cache"
+    }
+  }
+}
+
 # Catch-all: everything not matched above revalidates on every request
 resource "azurerm_cdn_frontdoor_rule" "default_no_cache" {
   name                      = "DefaultNoCache"
   cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.cache.id
-  order                     = 3
+  order                     = 4
 
   actions {
     response_header_action {

--- a/infra/app/locals.tf
+++ b/infra/app/locals.tf
@@ -1,7 +1,7 @@
 locals {
   name          = "${var.app_name}-${var.environment}"
   environment_short = var.environment == "development" ? "dev" : var.environment
-  name_short    = "${replace(var.app_name, "-", "")}${local.environment_short}"
+  name_short    = substr("${replace(var.app_name, "-", "")}${local.environment_short}", 0, 22)
   is_production     = var.environment == "production"
   custom_domain     = local.is_production ? "${var.subdomain}.${var.custom_domain}" : "${var.subdomain}.${local.environment_short}.${var.custom_domain}"
   dns_record_name   = local.is_production ? var.subdomain : "${var.subdomain}.${local.environment_short}"

--- a/infra/app/locals.tf
+++ b/infra/app/locals.tf
@@ -1,7 +1,7 @@
 locals {
   name          = "${var.app_name}-${var.environment}"
-  environment_short = var.environment == "development" ? "dev" : var.environment
-  name_short    = substr("${replace(var.app_name, "-", "")}${local.environment_short}", 0, 22)
+  environment_short = substr(var.environment, 0, 4)
+  name_short        = "evrepoui${local.environment_short}"
   is_production     = var.environment == "production"
   custom_domain     = local.is_production ? "${var.subdomain}.${var.custom_domain}" : "${var.subdomain}.${local.environment_short}.${var.custom_domain}"
   dns_record_name   = local.is_production ? var.subdomain : "${var.subdomain}.${local.environment_short}"


### PR DESCRIPTION
## Summary

- Storage account name `feevidencerepouiproduction` (26 chars) exceeds Azure's 24-character limit — truncates `name_short` to 22 chars so the `fe` prefix stays within bounds
- SPA routes (e.g. `/esea`) return HTTP 404 from blob storage even though the page renders — adds a Front Door URL rewrite rule to serve `/index.html` for extensionless paths so the origin returns 200