### PR TITLE
Issue #27: extract CommunityProvider for shared community lookup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,32 @@
 import Router from "preact-router";
 import { AuthProvider } from "./auth/AuthContext";
+import { CommunityProvider } from "./community/CommunityContext";
 import { AppShell } from "./components/layout/AppShell";
 import { SearchPage } from "./pages/SearchPage";
 import { RecordDetailPage } from "./pages/RecordDetailPage";
 import { NotFoundPage } from "./pages/NotFoundPage";
+import { URL_CHANGE_EVENT } from "./services/navigation";
+
+// preact-router intercepts internal <a href="/..."> clicks and updates the
+// URL via history.pushState without firing popstate or our URL_CHANGE_EVENT.
+// Bridging Router onChange into URL_CHANGE_EVENT keeps subscribers
+// (CommunityProvider, useUrlParams) in sync with router-driven navigation.
+function emitUrlChange() {
+  window.dispatchEvent(new Event(URL_CHANGE_EVENT));
+}
 
 export function App() {
   return (
     <AuthProvider>
-      <AppShell>
-        <Router>
-          <RecordDetailPage path="/:community/references/:id" />
-          <SearchPage path="/:community" />
-          <NotFoundPage default />
-        </Router>
-      </AppShell>
+      <CommunityProvider>
+        <AppShell>
+          <Router onChange={emitUrlChange}>
+            <RecordDetailPage path="/:community/references/:id" />
+            <SearchPage path="/:community" />
+            <NotFoundPage default />
+          </Router>
+        </AppShell>
+      </CommunityProvider>
     </AuthProvider>
   );
 }

--- a/src/community/CommunityContext.tsx
+++ b/src/community/CommunityContext.tsx
@@ -1,0 +1,43 @@
+import { createContext, type ComponentChildren } from "preact";
+import { useContext, useEffect, useState } from "preact/hooks";
+import { findCommunity } from "@/services/communities";
+import { URL_CHANGE_EVENT } from "@/services/navigation";
+import type { Community } from "@/types/models";
+
+// undefined default lets useCommunity() distinguish "outside provider"
+// (programming error) from "URL slug doesn't match a known community"
+// (legitimate null result).
+const CommunityContext = createContext<Community | null | undefined>(undefined);
+
+function getSlug(): string | undefined {
+  return window.location.pathname.split("/").filter(Boolean)[0];
+}
+
+export function CommunityProvider({ children }: { children: ComponentChildren }) {
+  const [slug, setSlug] = useState<string | undefined>(getSlug);
+
+  useEffect(() => {
+    const onChange = () => setSlug(getSlug());
+    window.addEventListener("popstate", onChange);
+    window.addEventListener(URL_CHANGE_EVENT, onChange);
+    return () => {
+      window.removeEventListener("popstate", onChange);
+      window.removeEventListener(URL_CHANGE_EVENT, onChange);
+    };
+  }, []);
+
+  const community = slug ? (findCommunity(slug) ?? null) : null;
+  return (
+    <CommunityContext.Provider value={community}>
+      {children}
+    </CommunityContext.Provider>
+  );
+}
+
+export function useCommunity(): Community | null {
+  const value = useContext(CommunityContext);
+  if (value === undefined) {
+    throw new Error("useCommunity must be used within a CommunityProvider");
+  }
+  return value;
+}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,30 +1,10 @@
-import { useState, useEffect } from "preact/hooks";
 import type { ComponentChildren } from "preact";
 import { useAuth } from "@/auth/AuthContext";
-import { URL_CHANGE_EVENT } from "@/services/navigation";
-import { findCommunity } from "@/services/communities";
-import type { Community } from "@/types/models";
+import { useCommunity } from "@/community/CommunityContext";
 import "./AppShell.css";
 
 interface AppShellProps {
   children: ComponentChildren;
-}
-
-// Header-only need: react to pathname changes (not just search) so the
-// community badge updates on route transitions.
-function useCurrentCommunity(): Community | undefined {
-  const [pathname, setPathname] = useState(() => window.location.pathname);
-  useEffect(() => {
-    const onChange = () => setPathname(window.location.pathname);
-    window.addEventListener(URL_CHANGE_EVENT, onChange);
-    window.addEventListener("popstate", onChange);
-    return () => {
-      window.removeEventListener(URL_CHANGE_EVENT, onChange);
-      window.removeEventListener("popstate", onChange);
-    };
-  }, []);
-  const slug = pathname.split("/").filter(Boolean)[0];
-  return slug ? findCommunity(slug) : undefined;
 }
 
 // Brand link target: there's no real "/" landing page yet — the router only
@@ -34,7 +14,7 @@ const BRAND_HREF = "/esea";
 
 export function AppShell({ children }: AppShellProps) {
   const { username, logout } = useAuth();
-  const community = useCurrentCommunity();
+  const community = useCommunity();
   return (
     <div class="app-shell">
       <header class="app-header">

--- a/src/hooks/useCorpusTotal.ts
+++ b/src/hooks/useCorpusTotal.ts
@@ -1,17 +1,20 @@
 import { useState, useEffect } from "preact/hooks";
 import { searchReferences } from "@/services/apiClient";
-import type { Community, SearchResultTotal } from "@/types/models";
+import { useCommunity } from "@/community/CommunityContext";
+import type { SearchResultTotal } from "@/types/models";
 
-export function useCorpusTotal(community: Community): {
+export function useCorpusTotal(): {
   total: SearchResultTotal | null;
   loading: boolean;
   error: Error | null;
 } {
+  const community = useCommunity();
   const [total, setTotal] = useState<SearchResultTotal | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
+    if (!community) return;
     let cancelled = false;
 
     setTotal(null);
@@ -27,7 +30,16 @@ export function useCorpusTotal(community: Community): {
     // Key on slug AND the annotation signature so changes to either force a
     // refetch. JSON.stringify is unambiguous for arbitrary strings — join(",")
     // would collapse ["a,b"] and ["a","b"] to the same key.
-  }, [community.slug, JSON.stringify(community.defaultAnnotations)]);
+  }, [community?.slug, JSON.stringify(community?.defaultAnnotations ?? [])]);
+
+  // Synthetic idle when no community is resolved (invalid slug, root path).
+  // Page-level NotFound rendering stays in SearchPage; this is a defensive
+  // fallback for any subtree under the provider. Internal total state from a
+  // prior fetch is masked but not cleared: a long-lived consumer that
+  // survives a valid->null->valid community transition would briefly show the
+  // prior total during the next fetch. SearchPage sidesteps this because it
+  // unmounts on the route-level gate.
+  if (!community) return { total: null, loading: false, error: null };
 
   return { total, loading, error };
 }

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,34 +1,32 @@
 import { useState, useEffect, useCallback } from "preact/hooks";
 import { searchReferences } from "@/services/apiClient";
+import { useCommunity } from "@/community/CommunityContext";
 import type { SearchResult } from "@/types/models";
 import type { SearchParams } from "@/services/searchParams";
 
-function paramsKey(params: SearchParams, annotations: string[]): string {
+function paramsKey(params: SearchParams, slug: string, annotations: string[]): string {
   // JSON.stringify is unambiguous for arbitrary string arrays — two distinct
   // inputs can never collapse to the same key even if annotations contain commas,
   // quotes, or other delimiters. Ad hoc joins are brittle here.
   // Intentionally order-sensitive: ["a","b"] and ["b","a"] are different keys.
-  // Worst case is an unnecessary refetch when caller varies order; the alternative
-  // (sort-then-stringify) would silently mask callers passing inconsistent orders.
   return [
     `q=${params.q}`,
     `page=${params.page}`,
     `start=${params.startYear ?? ""}`,
     `end=${params.endYear ?? ""}`,
+    `slug=${slug}`,
     `ann=${JSON.stringify(annotations)}`,
   ].join("&");
 }
 
-export function useSearch(
-  params: SearchParams,
-  annotations: string[],
-): {
+export function useSearch(params: SearchParams): {
   results: SearchResult | null;
   loading: boolean;
   error: Error | null;
   retry: () => void;
 } {
-  const key = paramsKey(params, annotations);
+  const community = useCommunity();
+  const key = paramsKey(params, community?.slug ?? "", community?.defaultAnnotations ?? []);
   const [results, setResults] = useState<SearchResult | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
@@ -39,6 +37,7 @@ export function useSearch(
   }, []);
 
   useEffect(() => {
+    if (!community) return;
     let cancelled = false;
 
     // Do NOT clear results here: keeping prior rows on screen enables the
@@ -50,7 +49,7 @@ export function useSearch(
       page: params.page,
       startYear: params.startYear,
       endYear: params.endYear,
-      annotation: annotations,
+      annotation: community.defaultAnnotations,
     })
       .then((r) => { if (!cancelled) setResults(r); })
       .catch((e) => {
@@ -63,6 +62,16 @@ export function useSearch(
     return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [key, retryTick]);
+
+  // Synthetic idle when no community is resolved. Page-level NotFound rendering
+  // stays in SearchPage; this is a defensive fallback for any subtree under the
+  // provider. Internal results state from a prior fetch is masked but not
+  // cleared: a long-lived consumer that survives a valid->null->valid community
+  // transition would briefly show prior results during the next fetch (the
+  // existing dim-while-updating UX). SearchPage sidesteps this because it
+  // unmounts on the route-level gate. retry's identity is stable (useCallback
+  // with empty deps), so returning it in idle is safe.
+  if (!community) return { results: null, loading: false, error: null, retry };
 
   return { results, loading, error, retry };
 }

--- a/src/pages/RecordDetailPage.tsx
+++ b/src/pages/RecordDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "preact/hooks";
-import { findCommunity } from "@/services/communities";
+import { useCommunity } from "@/community/CommunityContext";
 import {
   extractBibliographic,
   extractLinkedData,
@@ -19,15 +19,11 @@ import "./RecordDetailPage.css";
 
 interface RecordDetailPageProps {
   path?: string;
-  community?: string;
   id?: string;
 }
 
-export function RecordDetailPage({
-  community: slug,
-  id,
-}: RecordDetailPageProps) {
-  const community = slug ? findCommunity(slug) : undefined;
+export function RecordDetailPage({ id }: RecordDetailPageProps) {
+  const community = useCommunity();
 
   const { reference, loading: refLoading, error: refError } = useReference(id);
   const bibliographic = reference ? extractBibliographic(reference) : null;

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -68,8 +68,8 @@ function SearchPageInner({ community }: { community: Community }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [canonicalQs, community.slug]);
 
-  const corpus = useCorpusTotal(community);
-  const results = useSearch(params, community.defaultAnnotations);
+  const corpus = useCorpusTotal();
+  const results = useSearch(params);
 
   // Meta-bar appears whenever the user has narrowed from browse mode (a query
   // or a year filter), or whenever an error needs surfacing. Empty q + no

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "preact/hooks";
-import { findCommunity } from "@/services/communities";
+import { useCommunity } from "@/community/CommunityContext";
 import type { Community } from "@/types/models";
 import { parseSearchParams, toQueryString, buildSearchUrl } from "@/services/searchParams";
 import { navigate } from "@/services/navigation";
@@ -14,7 +14,6 @@ import "./SearchPage.css";
 
 interface SearchPageProps {
   path?: string;
-  community?: string;
 }
 
 // ES caps deep pagination at 10k; when the true count exceeds that, the
@@ -48,8 +47,8 @@ function formatResultsSummary(
   );
 }
 
-export function SearchPage({ community: slug }: SearchPageProps) {
-  const community = slug ? findCommunity(slug) : undefined;
+export function SearchPage(_props: SearchPageProps) {
+  const community = useCommunity();
   if (!community) return <NotFoundPage />;
   return <SearchPageInner community={community} />;
 }

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/preact";
+import { render, screen, fireEvent } from "@testing-library/preact";
 import { App } from "@/App";
 
 test("renders the app header", () => {
@@ -26,4 +26,21 @@ test("renders not found for invalid community", () => {
   history.pushState({}, "", "/banana");
   render(<App />);
   expect(screen.getByText("Page not found")).toBeInTheDocument();
+});
+
+// Regression test for issue #27 review finding: preact-router intercepts
+// internal anchor clicks and routes via history.pushState without firing
+// popstate or our URL_CHANGE_EVENT. Without bridging that gap, the
+// CommunityProvider stays on the old slug and SearchPage falls back to
+// NotFound even though the router moved to /esea.
+test("clicking Go to search from /banana shows the search page", () => {
+  history.pushState({}, "", "/banana");
+  render(<App />);
+  expect(screen.getByText("Page not found")).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole("link", { name: /go to search/i }));
+
+  expect(
+    screen.getByRole("heading", { name: /search the evidence/i }),
+  ).toBeInTheDocument();
 });

--- a/tests/community/CommunityContext.test.tsx
+++ b/tests/community/CommunityContext.test.tsx
@@ -1,0 +1,82 @@
+import { describe, test, expect, beforeEach, vi } from "vitest";
+import { render, screen, act } from "@testing-library/preact";
+import { CommunityProvider, useCommunity } from "@/community/CommunityContext";
+import { URL_CHANGE_EVENT } from "@/services/navigation";
+
+function TestConsumer() {
+  const community = useCommunity();
+  return (
+    <span data-testid="community">{community ? community.name : "null"}</span>
+  );
+}
+
+function setPath(path: string) {
+  window.history.replaceState(null, "", path);
+}
+
+describe("useCommunity", () => {
+  beforeEach(() => {
+    setPath("/");
+  });
+
+  test("returns the community matching the URL's first path segment on mount", () => {
+    setPath("/esea");
+    render(
+      <CommunityProvider>
+        <TestConsumer />
+      </CommunityProvider>,
+    );
+    expect(screen.getByTestId("community")).toHaveTextContent("Education");
+  });
+
+  test("updates when the browser fires popstate", () => {
+    setPath("/");
+    render(
+      <CommunityProvider>
+        <TestConsumer />
+      </CommunityProvider>,
+    );
+    expect(screen.getByTestId("community")).toHaveTextContent("null");
+
+    act(() => {
+      setPath("/esea");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+    expect(screen.getByTestId("community")).toHaveTextContent("Education");
+  });
+
+  test("returns null when the slug does not match any registered community", () => {
+    setPath("/not-a-real-community");
+    render(
+      <CommunityProvider>
+        <TestConsumer />
+      </CommunityProvider>,
+    );
+    expect(screen.getByTestId("community")).toHaveTextContent("null");
+  });
+
+  test("updates when navigation fires URL_CHANGE_EVENT", () => {
+    setPath("/");
+    render(
+      <CommunityProvider>
+        <TestConsumer />
+      </CommunityProvider>,
+    );
+    expect(screen.getByTestId("community")).toHaveTextContent("null");
+
+    act(() => {
+      setPath("/esea");
+      window.dispatchEvent(new Event(URL_CHANGE_EVENT));
+    });
+    expect(screen.getByTestId("community")).toHaveTextContent("Education");
+  });
+
+  test("throws when used outside CommunityProvider", () => {
+    // Suppress Preact's expected error noise from the throw during render.
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<TestConsumer />)).toThrow(
+      /useCommunity must be used within a CommunityProvider/,
+    );
+    spy.mockRestore();
+  });
+});

--- a/tests/components/layout/AppShell.test.tsx
+++ b/tests/components/layout/AppShell.test.tsx
@@ -1,20 +1,27 @@
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/preact";
 import { AppShell } from "@/components/layout/AppShell";
 import { AuthProvider } from "@/auth/AuthContext";
+import { CommunityProvider } from "@/community/CommunityContext";
 import { keycloak } from "@/auth/keycloak";
 
 function renderShell() {
   return render(
     <AuthProvider>
-      <AppShell>
-        <div>child</div>
-      </AppShell>
+      <CommunityProvider>
+        <AppShell>
+          <div>child</div>
+        </AppShell>
+      </CommunityProvider>
     </AuthProvider>,
   );
 }
 
 describe("AppShell header", () => {
+  beforeEach(() => {
+    history.replaceState(null, "", "/");
+  });
+
   test("renders the username and Sign out button when authenticated", () => {
     renderShell();
     expect(screen.getByText("Test User")).toBeInTheDocument();
@@ -25,5 +32,17 @@ describe("AppShell header", () => {
     renderShell();
     screen.getByRole("button", { name: "Sign out" }).click();
     expect(keycloak.logout).toHaveBeenCalled();
+  });
+
+  test("renders the community name in the brand when on a community route", () => {
+    history.replaceState(null, "", "/esea");
+    renderShell();
+    expect(screen.getByText("Education")).toBeInTheDocument();
+  });
+
+  test("omits the community name when not on a community route", () => {
+    history.replaceState(null, "", "/");
+    renderShell();
+    expect(screen.queryByText("Education")).not.toBeInTheDocument();
   });
 });

--- a/tests/hooks/useCorpusTotal.test.tsx
+++ b/tests/hooks/useCorpusTotal.test.tsx
@@ -1,7 +1,10 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
-import { renderHook, waitFor } from "@testing-library/preact";
+import { renderHook, waitFor, act } from "@testing-library/preact";
+import type { ComponentChildren } from "preact";
 import { useCorpusTotal } from "@/hooks/useCorpusTotal";
-import type { Community, SearchResult } from "@/types/models";
+import { CommunityProvider } from "@/community/CommunityContext";
+import { URL_CHANGE_EVENT } from "@/services/navigation";
+import type { SearchResult } from "@/types/models";
 
 vi.mock("@/services/apiClient", () => ({
   searchReferences: vi.fn(),
@@ -10,26 +13,33 @@ vi.mock("@/services/apiClient", () => ({
 import { searchReferences } from "@/services/apiClient";
 const mockSearch = vi.mocked(searchReferences);
 
-const community: Community = {
-  slug: "esea",
-  name: "Education",
-  defaultAnnotations: ["domain-inclusion/jacobs-education"],
-};
-
 const result: SearchResult = {
   total: { count: 5721, is_lower_bound: false },
   page: { count: 20, number: 1 },
   references: [],
 };
 
+// Drive the real CommunityProvider through the URL the way the runtime does.
+// Tests stay at the integration layer instead of leaking a context-injection
+// API just to satisfy synthetic fixtures.
+function withCommunityPath(path: string) {
+  window.history.replaceState(null, "", path);
+  return ({ children }: { children: ComponentChildren }) => (
+    <CommunityProvider>{children}</CommunityProvider>
+  );
+}
+
 beforeEach(() => {
   mockSearch.mockReset();
+  window.history.replaceState(null, "", "/");
 });
 
 describe("useCorpusTotal", () => {
   test("fires once with browse-mode query and community annotations", async () => {
     mockSearch.mockResolvedValue(result);
-    const { result: hook } = renderHook(() => useCorpusTotal(community));
+    const { result: hook } = renderHook(() => useCorpusTotal(), {
+      wrapper: withCommunityPath("/esea"),
+    });
     await waitFor(() => expect(hook.current.loading).toBe(false));
     expect(mockSearch).toHaveBeenCalledTimes(1);
     expect(mockSearch).toHaveBeenCalledWith(undefined, {
@@ -39,64 +49,52 @@ describe("useCorpusTotal", () => {
     expect(hook.current.error).toBeNull();
   });
 
-  test("does not refetch when community prop is stable", async () => {
+  test("does not refetch when URL stays on the same community", async () => {
     mockSearch.mockResolvedValue(result);
-    const { rerender } = renderHook(
-      ({ c }) => useCorpusTotal(c),
-      { initialProps: { c: community } },
-    );
+    const { rerender } = renderHook(() => useCorpusTotal(), {
+      wrapper: withCommunityPath("/esea"),
+    });
     await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
-    rerender({ c: community });
-    rerender({ c: community });
+    rerender();
+    rerender();
     expect(mockSearch).toHaveBeenCalledTimes(1);
   });
 
-  test("refetches when community slug changes", async () => {
+  test("returns idle (no fetch, no loading) when slug resolves to no community", () => {
     mockSearch.mockResolvedValue(result);
-    const other: Community = { slug: "other", name: "Other", defaultAnnotations: [] };
-    const { rerender } = renderHook(
-      ({ c }) => useCorpusTotal(c),
-      { initialProps: { c: community } },
-    );
-    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
-    rerender({ c: other });
-    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(2));
-  });
-
-  test("refetches when annotations change for same slug", async () => {
-    mockSearch.mockResolvedValue(result);
-    const reannotated: Community = {
-      ...community,
-      defaultAnnotations: ["domain-inclusion/jacobs-education", "source/extra-filter"],
-    };
-    const { rerender } = renderHook(
-      ({ c }) => useCorpusTotal(c),
-      { initialProps: { c: community } },
-    );
-    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
-    rerender({ c: reannotated });
-    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(2));
-    expect(mockSearch).toHaveBeenLastCalledWith(undefined, {
-      annotation: ["domain-inclusion/jacobs-education", "source/extra-filter"],
+    const { result: hook } = renderHook(() => useCorpusTotal(), {
+      wrapper: withCommunityPath("/banana"),
     });
+    expect(hook.current.total).toBeNull();
+    expect(hook.current.loading).toBe(false);
+    expect(hook.current.error).toBeNull();
+    expect(mockSearch).not.toHaveBeenCalled();
   });
 
-  test("key disambiguates annotation arrays even when an element contains a comma", async () => {
+  test("transitions to idle when navigating away to an unknown slug", async () => {
     mockSearch.mockResolvedValue(result);
-    const c1: Community = { ...community, defaultAnnotations: ["a,b"] };
-    const c2: Community = { ...community, defaultAnnotations: ["a", "b"] };
-    const { rerender } = renderHook(
-      ({ c }) => useCorpusTotal(c),
-      { initialProps: { c: c1 } },
-    );
-    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
-    rerender({ c: c2 });
-    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(2));
+    const { result: hook } = renderHook(() => useCorpusTotal(), {
+      wrapper: withCommunityPath("/esea"),
+    });
+    await waitFor(() => expect(hook.current.total).not.toBeNull());
+
+    act(() => {
+      window.history.replaceState(null, "", "/banana");
+      window.dispatchEvent(new Event(URL_CHANGE_EVENT));
+    });
+
+    await waitFor(() => {
+      expect(hook.current.total).toBeNull();
+      expect(hook.current.loading).toBe(false);
+      expect(hook.current.error).toBeNull();
+    });
   });
 
   test("surfaces error", async () => {
     mockSearch.mockRejectedValue(new Error("boom"));
-    const { result: hook } = renderHook(() => useCorpusTotal(community));
+    const { result: hook } = renderHook(() => useCorpusTotal(), {
+      wrapper: withCommunityPath("/esea"),
+    });
     await waitFor(() => {
       expect(hook.current.error).toBeDefined();
       expect(hook.current.error!.message).toBe("boom");

--- a/tests/hooks/useSearch.test.tsx
+++ b/tests/hooks/useSearch.test.tsx
@@ -1,6 +1,8 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor, act } from "@testing-library/preact";
+import type { ComponentChildren } from "preact";
 import { useSearch } from "@/hooks/useSearch";
+import { CommunityProvider } from "@/community/CommunityContext";
 import type { SearchResult } from "@/types/models";
 import type { SearchParams } from "@/services/searchParams";
 
@@ -12,7 +14,14 @@ import { searchReferences } from "@/services/apiClient";
 const mockSearch = vi.mocked(searchReferences);
 
 const baseParams: SearchParams = { q: "phonics", page: 1, startYear: undefined, endYear: undefined };
-const annotations = ["domain-inclusion/jacobs-education"];
+
+// Drive the real CommunityProvider through the URL the way the runtime does.
+function withCommunityPath(path: string) {
+  window.history.replaceState(null, "", path);
+  return ({ children }: { children: ComponentChildren }) => (
+    <CommunityProvider>{children}</CommunityProvider>
+  );
+}
 
 function makeResult(count: number): SearchResult {
   return {
@@ -24,27 +33,33 @@ function makeResult(count: number): SearchResult {
 
 beforeEach(() => {
   mockSearch.mockReset();
+  window.history.replaceState(null, "", "/");
 });
 
 describe("useSearch", () => {
-  test("fetches on mount", async () => {
+  test("fetches on mount with community-derived annotations", async () => {
     mockSearch.mockResolvedValue(makeResult(47));
-    const { result } = renderHook(() => useSearch(baseParams, annotations));
+    const { result } = renderHook(() => useSearch(baseParams), {
+      wrapper: withCommunityPath("/esea"),
+    });
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.results?.total.count).toBe(47);
     expect(mockSearch).toHaveBeenCalledWith("phonics", {
       page: 1,
       startYear: undefined,
       endYear: undefined,
-      annotation: annotations,
+      annotation: ["domain-inclusion/jacobs-education"],
     });
   });
 
   test("no refetch on stable key", async () => {
     mockSearch.mockResolvedValue(makeResult(5));
     const { rerender } = renderHook(
-      ({ p }) => useSearch(p, annotations),
-      { initialProps: { p: { ...baseParams } } },
+      ({ p }) => useSearch(p),
+      {
+        wrapper: withCommunityPath("/esea"),
+        initialProps: { p: { ...baseParams } },
+      },
     );
     await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
     rerender({ p: { ...baseParams } });
@@ -55,22 +70,14 @@ describe("useSearch", () => {
   test("refetches when params change", async () => {
     mockSearch.mockResolvedValue(makeResult(5));
     const { rerender } = renderHook(
-      ({ p }) => useSearch(p, annotations),
-      { initialProps: { p: baseParams } },
+      ({ p }) => useSearch(p),
+      {
+        wrapper: withCommunityPath("/esea"),
+        initialProps: { p: baseParams },
+      },
     );
     await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
     rerender({ p: { ...baseParams, page: 2 } });
-    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(2));
-  });
-
-  test("refetches when annotations change", async () => {
-    mockSearch.mockResolvedValue(makeResult(5));
-    const { rerender } = renderHook(
-      ({ a }) => useSearch(baseParams, a),
-      { initialProps: { a: annotations } },
-    );
-    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
-    rerender({ a: ["other-annotation"] });
     await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(2));
   });
 
@@ -81,14 +88,16 @@ describe("useSearch", () => {
     );
 
     const { result, rerender } = renderHook(
-      ({ p }) => useSearch(p, annotations),
-      { initialProps: { p: baseParams } },
+      ({ p }) => useSearch(p),
+      {
+        wrapper: withCommunityPath("/esea"),
+        initialProps: { p: baseParams },
+      },
     );
     resolvers[0](makeResult(10));
     await waitFor(() => expect(result.current.results?.total.count).toBe(10));
 
     rerender({ p: { ...baseParams, page: 2 } });
-    // Prior results stay on screen; loading flips to true.
     expect(result.current.results?.total.count).toBe(10);
     expect(result.current.loading).toBe(true);
 
@@ -99,8 +108,11 @@ describe("useSearch", () => {
   test("clears results to null on settled error", async () => {
     mockSearch.mockResolvedValueOnce(makeResult(10));
     const { result, rerender } = renderHook(
-      ({ p }) => useSearch(p, annotations),
-      { initialProps: { p: baseParams } },
+      ({ p }) => useSearch(p),
+      {
+        wrapper: withCommunityPath("/esea"),
+        initialProps: { p: baseParams },
+      },
     );
     await waitFor(() => expect(result.current.results?.total.count).toBe(10));
 
@@ -121,19 +133,24 @@ describe("useSearch", () => {
       .mockImplementationOnce(() => new Promise<SearchResult>((r) => { secondResolve = r; }));
 
     const { result, rerender } = renderHook(
-      ({ p }) => useSearch(p, annotations),
-      { initialProps: { p: baseParams } },
+      ({ p }) => useSearch(p),
+      {
+        wrapper: withCommunityPath("/esea"),
+        initialProps: { p: baseParams },
+      },
     );
     rerender({ p: { ...baseParams, page: 2 } });
 
-    firstResolve(makeResult(999));  // stale — must not appear
+    firstResolve(makeResult(999));
     secondResolve(makeResult(2));
     await waitFor(() => expect(result.current.results?.total.count).toBe(2));
   });
 
   test("error from initial fetch populates error (results stays null — nothing to preserve)", async () => {
     mockSearch.mockRejectedValue(new Error("boom"));
-    const { result } = renderHook(() => useSearch(baseParams, annotations));
+    const { result } = renderHook(() => useSearch(baseParams), {
+      wrapper: withCommunityPath("/esea"),
+    });
     await waitFor(() => {
       expect(result.current.error?.message).toBe("boom");
       expect(result.current.results).toBeNull();
@@ -142,10 +159,13 @@ describe("useSearch", () => {
   });
 
   test("retry refetches without mutating URL", async () => {
+    window.history.replaceState(null, "", "/esea");
     const pushSpy = vi.spyOn(history, "pushState");
     const replaceSpy = vi.spyOn(history, "replaceState");
     mockSearch.mockResolvedValue(makeResult(1));
-    const { result } = renderHook(() => useSearch(baseParams, annotations));
+    const { result } = renderHook(() => useSearch(baseParams), {
+      wrapper: ({ children }) => <CommunityProvider>{children}</CommunityProvider>,
+    });
     await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
 
     act(() => { result.current.retry(); });
@@ -162,12 +182,13 @@ describe("useSearch", () => {
       () => new Promise<SearchResult>((r) => { resolvers.push(r); }),
     );
 
-    const { result } = renderHook(() => useSearch(baseParams, annotations));
+    const { result } = renderHook(() => useSearch(baseParams), {
+      wrapper: withCommunityPath("/esea"),
+    });
     resolvers[0](makeResult(10));
     await waitFor(() => expect(result.current.results?.total.count).toBe(10));
 
     act(() => { result.current.retry(); });
-    // Prior results remain visible during the retry in-flight.
     expect(result.current.results?.total.count).toBe(10);
     expect(result.current.loading).toBe(true);
 
@@ -175,15 +196,15 @@ describe("useSearch", () => {
     await waitFor(() => expect(result.current.results?.total.count).toBe(11));
   });
 
-  test("key disambiguates annotation arrays even when an element contains a comma", async () => {
+  test("returns idle (no fetch) when slug resolves to no community", () => {
     mockSearch.mockResolvedValue(makeResult(1));
-    const { rerender } = renderHook(
-      ({ a }) => useSearch(baseParams, a),
-      { initialProps: { a: ["a,b"] } },
-    );
-    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
-    // Two annotations "a" + "b" must be distinct from one "a,b" entry.
-    rerender({ a: ["a", "b"] });
-    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(2));
+    const { result } = renderHook(() => useSearch(baseParams), {
+      wrapper: withCommunityPath("/banana"),
+    });
+    expect(result.current.results).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(typeof result.current.retry).toBe("function");
+    expect(mockSearch).not.toHaveBeenCalled();
   });
 });

--- a/tests/pages/RecordDetailPage.test.tsx
+++ b/tests/pages/RecordDetailPage.test.tsx
@@ -1,7 +1,16 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/preact";
 import { RecordDetailPage } from "@/pages/RecordDetailPage";
+import { CommunityProvider } from "@/community/CommunityContext";
 import { makeReference } from "../fixtures";
+
+function renderRecordDetail(id: string) {
+  return render(
+    <CommunityProvider>
+      <RecordDetailPage id={id} />
+    </CommunityProvider>,
+  );
+}
 
 vi.mock("@/hooks/useReference");
 vi.mock("@/hooks/useVocabulary");
@@ -26,6 +35,7 @@ const mockLabels = new Map([
 
 beforeEach(() => {
   vi.clearAllMocks();
+  history.replaceState(null, "", "/esea");
   mockUseVocabulary.mockReturnValue({
     labels: null,
     broader: null,
@@ -47,7 +57,8 @@ describe("RecordDetailPage", () => {
       loading: false,
       error: null,
     });
-    render(<RecordDetailPage community="banana" id="abc" />);
+    history.replaceState(null, "", "/banana");
+    renderRecordDetail("abc");
     expect(screen.getByText("Page not found")).toBeDefined();
   });
 
@@ -57,7 +68,7 @@ describe("RecordDetailPage", () => {
       loading: true,
       error: null,
     });
-    render(<RecordDetailPage community="esea" id="abc" />);
+    renderRecordDetail("abc");
     expect(screen.getByText("Loading…")).toBeDefined();
   });
 
@@ -67,7 +78,7 @@ describe("RecordDetailPage", () => {
       loading: false,
       error: new Error("Network failure"),
     });
-    render(<RecordDetailPage community="esea" id="abc" />);
+    renderRecordDetail("abc");
     expect(
       screen.getByText("We couldn't load this reference."),
     ).toBeDefined();
@@ -108,7 +119,7 @@ describe("RecordDetailPage", () => {
       error: null,
     });
 
-    render(<RecordDetailPage community="esea" id="abc-123" />);
+    renderRecordDetail("abc-123");
 
     expect(screen.getByText("Test Investigation")).toBeDefined();
     expect(screen.getByText("Smith, J. (2024)")).toBeDefined();
@@ -149,9 +160,7 @@ describe("RecordDetailPage", () => {
       error: new Error("Network failure"),
     });
 
-    const { container } = render(
-      <RecordDetailPage community="esea" id="abc-123" />,
-    );
+    const { container } = renderRecordDetail("abc-123");
 
     // Banner above the findings section explains the degraded state.
     const banner = container.querySelector(".record-detail-page__vocab-banner");
@@ -175,7 +184,7 @@ describe("RecordDetailPage", () => {
       error: null,
     });
 
-    render(<RecordDetailPage community="esea" id="abc-123" />);
+    renderRecordDetail("abc-123");
 
     expect(screen.getByText("Bibliographic Only")).toBeDefined();
     expect(screen.getByText("Jones, K. (2023)")).toBeDefined();

--- a/tests/pages/SearchPage.test.tsx
+++ b/tests/pages/SearchPage.test.tsx
@@ -1,7 +1,16 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/preact";
 import { SearchPage } from "@/pages/SearchPage";
+import { CommunityProvider } from "@/community/CommunityContext";
 import type { SearchResult } from "@/types/models";
+
+function renderSearchPage() {
+  return render(
+    <CommunityProvider>
+      <SearchPage />
+    </CommunityProvider>,
+  );
+}
 
 vi.mock("@/services/apiClient", () => ({
   searchReferences: vi.fn(),
@@ -63,7 +72,7 @@ describe("SearchPage", () => {
     // Browse mode: corpus and search fetches are identical (both q=undefined),
     // so corpus defaults to mirror results.
     mockBoth({ results: makeResult(5721, ["r1", "r2", "r3"]) });
-    render(<SearchPage community="esea" />);
+    renderSearchPage();
 
     await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
     expect(screen.getByText(/5,721 investigations across education research/i)).toBeInTheDocument();
@@ -73,7 +82,7 @@ describe("SearchPage", () => {
   test("year-only filter shows meta-bar count without 'for' framing", async () => {
     history.replaceState(null, "", "/esea?start_year=2015");
     mockBoth({ results: makeResult(120, ["r1"]) });
-    render(<SearchPage community="esea" />);
+    renderSearchPage();
 
     await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
     expect(screen.getByText(/results from/i)).toHaveTextContent(/120 results from 2015/i);
@@ -83,7 +92,7 @@ describe("SearchPage", () => {
   test("URL params on mount drive the fetch", async () => {
     history.replaceState(null, "", "/esea?q=phonics&start_year=2015&page=2");
     mockBoth({ results: makeResult(47, ["r1"]) });
-    render(<SearchPage community="esea" />);
+    renderSearchPage();
 
     await waitFor(() => {
       const queryCall = mockSearch.mock.calls.find(
@@ -104,7 +113,7 @@ describe("SearchPage", () => {
       return Promise.resolve(postSubmitResponse);
     });
 
-    render(<SearchPage community="esea" />);
+    renderSearchPage();
     await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
     expect(screen.getByText(/5,721 investigations/i)).toBeInTheDocument();
 
@@ -126,7 +135,7 @@ describe("SearchPage", () => {
     replaceSpy.mockClear();
     mockBoth({ results: makeResult(1, []) });
 
-    render(<SearchPage community="esea" />);
+    renderSearchPage();
     await waitFor(() => {
       expect(window.location.search).toBe("?q=phonics");
     });
@@ -135,7 +144,8 @@ describe("SearchPage", () => {
   });
 
   test("unknown community renders NotFoundPage", () => {
-    render(<SearchPage community="unknown-slug" />);
+    history.replaceState(null, "", "/unknown-slug");
+    renderSearchPage();
     expect(screen.getByRole("heading", { name: /not found/i })).toBeInTheDocument();
   });
 
@@ -148,7 +158,7 @@ describe("SearchPage", () => {
       if (q === undefined) return Promise.reject(new Error("corpus failed"));
       return Promise.resolve(makeResult(1, ["r1"]));
     });
-    render(<SearchPage community="esea" />);
+    renderSearchPage();
 
     await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
     expect(screen.getByText(/Education/)).toBeInTheDocument();
@@ -157,7 +167,7 @@ describe("SearchPage", () => {
 
   test("corpus subtitle suffixes '+' when total.is_lower_bound is true", async () => {
     mockBoth({ results: makeResult(10000, ["r1"], true) });
-    render(<SearchPage community="esea" />);
+    renderSearchPage();
 
     await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
     expect(screen.getByText(/10,000\+ investigations across Education/i)).toBeInTheDocument();
@@ -169,7 +179,7 @@ describe("SearchPage", () => {
       corpus: makeResult(5721, ["c1"]),
       results: makeResult(10000, ["r1"], true),
     });
-    render(<SearchPage community="esea" />);
+    renderSearchPage();
 
     await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
     expect(screen.getByText(/results for/i)).toHaveTextContent(/10,000\+ results for “education”/i);
@@ -179,7 +189,7 @@ describe("SearchPage", () => {
     history.replaceState(null, "", "/esea?q=phonics");
     const pushSpy = vi.spyOn(history, "pushState");
     mockSearch.mockRejectedValue(new Error("search failed"));
-    render(<SearchPage community="esea" />);
+    renderSearchPage();
 
     await waitFor(() => expect(screen.getByText(/couldn't load results/i)).toBeInTheDocument());
     const retryButton = screen.getByRole("button", { name: /try again/i });


### PR DESCRIPTION
Closes #27.

## Summary
- New `src/community/CommunityContext.tsx` with `CommunityProvider` and `useCommunity()`. Provider derives the community from the URL's first path segment and subscribes to `popstate`, `URL_CHANGE_EVENT`, and `<Router onChange>`.
- AppShell, SearchPage, and RecordDetailPage drop their per-call `findCommunity()` lookups for the shared context. NotFound rendering on null community is unchanged.
- `useCommunity()` throws when used outside `CommunityProvider` so missing-provider bugs surface loudly instead of rendering NotFound silently.

## Notes
- **Anchor-click bridge:** preact-router's global click handler calls `history.pushState` directly without firing `popstate` or our `URL_CHANGE_EVENT`. `<Router onChange>` now dispatches `URL_CHANGE_EVENT` so `<a href="/esea">` clicks stay in sync with the provider. This is load-bearing for `NotFoundPage`'s "Go to search" link and the AppShell brand link, both of which are plain anchors. Same fix incidentally protects `useUrlParams` from the same class of staleness.

## Validations performed
- 271 unit tests passing across 33 files (`vitest run`)
- `npm run typecheck` clean; `npm run build` clean
- New regression test in `tests/App.test.tsx`: starting at `/banana`, clicking "Go to search" navigates to the search page (would fail without the `Router onChange` bridge)
- New test in `tests/community/CommunityContext.test.tsx`: `useCommunity()` outside `CommunityProvider` throws
- Manual walkthrough on localhost: golden path, search submit, pagination, click-through to detail, browser back/forward, cold deep-link, `/` (no community), `/banana` (invalid slug), anchor-click bridge from NotFound, invalid reference id. Brand display followed the community-on/off rules at every step; search annotation pass-through (`domain-inclusion/jacobs-education`) verified in Network tab.

## Out of scope
- Multi-community switcher UI.
- Pre-existing dev-only sign-out redirect issue: signing out from localhost hits "Invalid redirect uri" because Keycloak admin needs `http://localhost:3000/*` added to **Valid Post Logout Redirect URIs** on `evidence-repo-ui-client-development`. Staging client verified correctly configured.