### PR TITLE
Issue #29: Sort dropdown for search results

### DIFF
--- a/src/components/search/SortDropdown.css
+++ b/src/components/search/SortDropdown.css
@@ -1,0 +1,45 @@
+/* Wrapping span hosts the custom ▼ arrow as a pseudo-element overlay so the
+   <select> itself can stay a single unstyled control. The select keeps native
+   keyboard / screen-reader / mobile-picker behaviour; the wrapper just
+   restyles the chrome to match the prototype's button look. */
+.sort-dropdown {
+  position: relative;
+  display: inline-flex;
+}
+
+.sort-dropdown__select {
+  appearance: none;
+  -webkit-appearance: none;
+  background: var(--color-bg-inset);
+  border: 1px solid var(--color-border);
+  border-radius: 3px;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font-family: var(--font-body);
+  font-size: 12px;
+  line-height: 1.2;
+  /* Right padding leaves room for the ▼ overlay; left padding mirrors
+     the prototype's 12px button inset. */
+  padding: 5px 26px 5px 12px;
+}
+
+.sort-dropdown__select:focus {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -1px;
+}
+
+.sort-dropdown__select:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.sort-dropdown::after {
+  content: "▼";
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 9px;
+  color: var(--color-text-tertiary);
+  pointer-events: none;
+}

--- a/src/components/search/SortDropdown.css
+++ b/src/components/search/SortDropdown.css
@@ -1,7 +1,3 @@
-/* Wrapping span hosts the custom ▼ arrow as a pseudo-element overlay so the
-   <select> itself can stay a single unstyled control. The select keeps native
-   keyboard / screen-reader / mobile-picker behaviour; the wrapper just
-   restyles the chrome to match the prototype's button look. */
 .sort-dropdown {
   position: relative;
   display: inline-flex;
@@ -18,8 +14,6 @@
   font-family: var(--font-body);
   font-size: var(--font-size-xs);
   line-height: 1.2;
-  /* Right padding leaves room for the ▼ overlay; left padding mirrors
-     the prototype's 12px button inset. */
   padding: 5px 26px 5px 12px;
 }
 
@@ -34,12 +28,15 @@
 }
 
 .sort-dropdown::after {
-  content: "▼";
+  content: "";
   position: absolute;
   right: 10px;
   top: 50%;
-  transform: translateY(-50%);
-  font-size: 9px;
-  color: var(--color-text-tertiary);
+  width: 0;
+  height: 0;
+  margin-top: -2px;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 5px solid var(--color-text-tertiary);
   pointer-events: none;
 }

--- a/src/components/search/SortDropdown.css
+++ b/src/components/search/SortDropdown.css
@@ -12,11 +12,11 @@
   -webkit-appearance: none;
   background: var(--color-bg-inset);
   border: 1px solid var(--color-border);
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   color: var(--color-text-secondary);
   cursor: pointer;
   font-family: var(--font-body);
-  font-size: 12px;
+  font-size: var(--font-size-xs);
   line-height: 1.2;
   /* Right padding leaves room for the ▼ overlay; left padding mirrors
      the prototype's 12px button inset. */

--- a/src/components/search/SortDropdown.tsx
+++ b/src/components/search/SortDropdown.tsx
@@ -1,4 +1,4 @@
-import type { SortOption } from "@/services/searchParams";
+import { parseSort, type SortOption } from "@/services/searchParams";
 import "./SortDropdown.css";
 
 interface SortDropdownProps {
@@ -12,8 +12,7 @@ interface SortDropdownProps {
 // to undefined so the URL stays clean (no `sort` param) for the default.
 export function SortDropdown({ value, onChange, disabled = false }: SortDropdownProps) {
   function handleChange(e: Event) {
-    const raw = (e.target as HTMLSelectElement).value;
-    onChange(raw === "newest" || raw === "oldest" ? raw : undefined);
+    onChange(parseSort((e.target as HTMLSelectElement).value));
   }
 
   return (

--- a/src/components/search/SortDropdown.tsx
+++ b/src/components/search/SortDropdown.tsx
@@ -7,9 +7,6 @@ interface SortDropdownProps {
   disabled?: boolean;
 }
 
-// Native <select> for free keyboard nav, screen-reader semantics, and the
-// mobile native picker. Empty string value (option label "Relevance") maps
-// to undefined so the URL stays clean (no `sort` param) for the default.
 export function SortDropdown({ value, onChange, disabled = false }: SortDropdownProps) {
   function handleChange(e: Event) {
     onChange(parseSort((e.target as HTMLSelectElement).value));

--- a/src/components/search/SortDropdown.tsx
+++ b/src/components/search/SortDropdown.tsx
@@ -1,0 +1,34 @@
+import type { SortOption } from "@/services/searchParams";
+import "./SortDropdown.css";
+
+interface SortDropdownProps {
+  value: SortOption | undefined;
+  onChange: (next: SortOption | undefined) => void;
+  disabled?: boolean;
+}
+
+// Native <select> for free keyboard nav, screen-reader semantics, and the
+// mobile native picker. Empty string value (option label "Relevance") maps
+// to undefined so the URL stays clean (no `sort` param) for the default.
+export function SortDropdown({ value, onChange, disabled = false }: SortDropdownProps) {
+  function handleChange(e: Event) {
+    const raw = (e.target as HTMLSelectElement).value;
+    onChange(raw === "newest" || raw === "oldest" ? raw : undefined);
+  }
+
+  return (
+    <span class="sort-dropdown">
+      <select
+        class="sort-dropdown__select"
+        aria-label="Sort results"
+        value={value ?? ""}
+        onChange={handleChange}
+        disabled={disabled}
+      >
+        <option value="">Relevance</option>
+        <option value="newest">Publication year (newest)</option>
+        <option value="oldest">Publication year (oldest)</option>
+      </select>
+    </span>
+  );
+}

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "preact/hooks";
-import { searchReferences } from "@/services/apiClient";
+import { searchReferences, SORT_BACKEND, type SearchFilters } from "@/services/apiClient";
 import { useCommunity } from "@/community/CommunityContext";
 import type { SearchResult } from "@/types/models";
 import type { SearchParams } from "@/services/searchParams";
@@ -14,6 +14,7 @@ function paramsKey(params: SearchParams, slug: string, annotations: string[]): s
     `page=${params.page}`,
     `start=${params.startYear ?? ""}`,
     `end=${params.endYear ?? ""}`,
+    `sort=${params.sort ?? ""}`,
     `slug=${slug}`,
     `ann=${JSON.stringify(annotations)}`,
   ].join("&");
@@ -45,12 +46,15 @@ export function useSearch(params: SearchParams): {
     setError(null);
     setLoading(true);
 
-    searchReferences(params.q || undefined, {
+    const filters: SearchFilters = {
       page: params.page,
       startYear: params.startYear,
       endYear: params.endYear,
       annotation: community.defaultAnnotations,
-    })
+    };
+    if (params.sort !== undefined) filters.sort = [SORT_BACKEND[params.sort]];
+
+    searchReferences(params.q || undefined, filters)
       .then((r) => { if (!cancelled) setResults(r); })
       .catch((e) => {
         if (cancelled) return;

--- a/src/pages/SearchPage.css
+++ b/src/pages/SearchPage.css
@@ -43,12 +43,23 @@
 .search-results__meta {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: var(--spacing-md);
   padding: var(--spacing-sm) var(--spacing-md);
   font-size: var(--font-size-small);
   color: var(--color-text-secondary);
   border-bottom: 1px solid var(--color-border);
   background: var(--color-bg-inset);
+}
+
+/* Inner flex so summary text and the retry button stay grouped together
+   on the left while space-between pushes the dropdown to the right.
+   Empty span (browse mode) collapses to width 0 but still anchors the
+   left side of the bar. */
+.search-results__meta-left {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-sm);
 }
 
 .search-results__meta-count {

--- a/src/pages/SearchPage.css
+++ b/src/pages/SearchPage.css
@@ -52,10 +52,6 @@
   background: var(--color-bg-inset);
 }
 
-/* Inner flex so summary text and the retry button stay grouped together
-   on the left while space-between pushes the dropdown to the right.
-   Empty span (browse mode) collapses to width 0 but still anchors the
-   left side of the bar. */
 .search-results__meta-left {
   display: inline-flex;
   align-items: center;

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,12 +1,13 @@
 import { useEffect } from "preact/hooks";
 import { useCommunity } from "@/community/CommunityContext";
 import type { Community } from "@/types/models";
-import { parseSearchParams, toQueryString, buildSearchUrl } from "@/services/searchParams";
+import { parseSearchParams, toQueryString, buildSearchUrl, type SortOption } from "@/services/searchParams";
 import { navigate } from "@/services/navigation";
 import { useUrlParams } from "@/hooks/useUrlParams";
 import { useCorpusTotal } from "@/hooks/useCorpusTotal";
 import { useSearch } from "@/hooks/useSearch";
 import { SearchBar } from "@/components/search/SearchBar";
+import { SortDropdown } from "@/components/search/SortDropdown";
 import { ResultRow } from "@/components/search/ResultRow";
 import { Pagination } from "@/components/Pagination";
 import { NotFoundPage } from "./NotFoundPage";
@@ -71,11 +72,21 @@ function SearchPageInner({ community }: { community: Community }) {
   const corpus = useCorpusTotal();
   const results = useSearch(params);
 
-  // Meta-bar appears whenever the user has narrowed from browse mode (a query
-  // or a year filter), or whenever an error needs surfacing. Empty q + no
-  // year filters = browse mode, where the hero subtitle already carries the
-  // corpus count.
+  // The bar itself shows whenever there's anything to put in it: the sort
+  // dropdown (once results exist), an error to surface, or the
+  // narrowed/loading summary text. Initial browse-mode load (no results
+  // yet, no error) keeps the bar hidden so the skeleton has the full bar's
+  // worth of vertical space.
   const showMetaBar =
+    results.results !== null ||
+    results.error !== null ||
+    params.q !== "" ||
+    params.startYear !== undefined ||
+    params.endYear !== undefined;
+
+  // The left summary slot stays empty in browse mode so we don't duplicate
+  // the corpus count the hero subtitle already shows.
+  const showSummary =
     params.q !== "" ||
     params.startYear !== undefined ||
     params.endYear !== undefined ||
@@ -91,6 +102,10 @@ function SearchPageInner({ community }: { community: Community }) {
 
   function handlePageChange(page: number) {
     navigate(buildSearchUrl(community.slug, { ...params, page }));
+  }
+
+  function handleSortChange(sort: SortOption | undefined) {
+    navigate(buildSearchUrl(community.slug, { ...params, sort, page: 1 }));
   }
 
   // Page size comes from the API response (page.count) so the UI stays in
@@ -125,27 +140,38 @@ function SearchPageInner({ community }: { community: Community }) {
 
       <section class="search-results">
         {showMetaBar && (
-          <div class="search-results__meta" aria-live="polite">
-            {results.error
-              ? (
-                <>
-                  <span>Couldn't load results.</span>
-                  <button
-                    type="button"
-                    class="search-results__retry"
-                    onClick={() => results.retry()}
-                  >
-                    Try again
-                  </button>
-                </>
-              )
-              : results.loading && results.results === null
-                ? "Searching…"
-                : results.loading
-                  ? "Updating results…"
-                  : results.results
-                    ? formatResultsSummary(params.q, params.startYear, params.endYear, results.results.total)
-                    : null}
+          <div class="search-results__meta">
+            <span class="search-results__meta-left" aria-live="polite">
+              {showSummary
+                ? results.error
+                  ? (
+                    <>
+                      <span>Couldn't load results.</span>
+                      <button
+                        type="button"
+                        class="search-results__retry"
+                        onClick={() => results.retry()}
+                      >
+                        Try again
+                      </button>
+                    </>
+                  )
+                  : results.loading && results.results === null
+                    ? "Searching…"
+                    : results.loading
+                      ? "Updating results…"
+                      : results.results
+                        ? formatResultsSummary(params.q, params.startYear, params.endYear, results.results.total)
+                        : null
+                : null}
+            </span>
+            {results.results && (
+              <SortDropdown
+                value={params.sort}
+                onChange={handleSortChange}
+                disabled={results.loading}
+              />
+            )}
           </div>
         )}
 

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -82,7 +82,10 @@ function SearchPageInner({ community }: { community: Community }) {
     results.error !== null;
 
   function handleSubmit(q: string, startYear: number | undefined, endYear: number | undefined) {
-    const nextParams = { q, page: 1, startYear, endYear };
+    // Preserve sort across query submit. Sort is a presentation preference
+    // orthogonal to the query terms; clearing it on every submit would silently
+    // strand a user who picked "newest" and then refined their query.
+    const nextParams = { ...params, q, page: 1, startYear, endYear };
     navigate(buildSearchUrl(community.slug, nextParams));
   }
 

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -72,11 +72,8 @@ function SearchPageInner({ community }: { community: Community }) {
   const corpus = useCorpusTotal();
   const results = useSearch(params);
 
-  // The bar itself shows whenever there's anything to put in it: the sort
-  // dropdown (once results exist), an error to surface, or the
-  // narrowed/loading summary text. Initial browse-mode load (no results
-  // yet, no error) keeps the bar hidden so the skeleton has the full bar's
-  // worth of vertical space.
+  // Hide the bar on the initial browse-mode load so the skeleton owns the
+  // full vertical space; show it as soon as there's anything to put in it.
   const showMetaBar =
     results.results !== null ||
     results.error !== null ||
@@ -84,8 +81,7 @@ function SearchPageInner({ community }: { community: Community }) {
     params.startYear !== undefined ||
     params.endYear !== undefined;
 
-  // The left summary slot stays empty in browse mode so we don't duplicate
-  // the corpus count the hero subtitle already shows.
+  // Browse mode skips the summary text to avoid duplicating the hero's corpus count.
   const showSummary =
     params.q !== "" ||
     params.startYear !== undefined ||
@@ -93,11 +89,7 @@ function SearchPageInner({ community }: { community: Community }) {
     results.error !== null;
 
   function handleSubmit(q: string, startYear: number | undefined, endYear: number | undefined) {
-    // Preserve sort across query submit. Sort is a presentation preference
-    // orthogonal to the query terms; clearing it on every submit would silently
-    // strand a user who picked "newest" and then refined their query.
-    const nextParams = { ...params, q, page: 1, startYear, endYear };
-    navigate(buildSearchUrl(community.slug, nextParams));
+    navigate(buildSearchUrl(community.slug, { ...params, q, page: 1, startYear, endYear }));
   }
 
   function handlePageChange(page: number) {

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -10,10 +10,7 @@ export interface SearchFilters {
   sort?: string[];
 }
 
-// Translation between the user-facing URL alias and the backend's ES-style
-// `[-]field_name` wire format. Lives here (the API boundary) so callers
-// upstream stay in alias space and a future backend rename of
-// `publication_year` only touches one map.
+// URL alias → backend ES-style `[-]field_name` wire format.
 export const SORT_BACKEND: Record<SortOption, string> = {
   newest: "-publication_year",
   oldest: "publication_year",

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -1,5 +1,6 @@
 import { api } from "@/api/client";
 import type { Reference, SearchResult } from "@/types/models";
+import type { SortOption } from "@/services/searchParams";
 
 export interface SearchFilters {
   page?: number;
@@ -8,6 +9,15 @@ export interface SearchFilters {
   annotation?: string[];
   sort?: string[];
 }
+
+// Translation between the user-facing URL alias and the backend's ES-style
+// `[-]field_name` wire format. Lives here (the API boundary) so callers
+// upstream stay in alias space and a future backend rename of
+// `publication_year` only touches one map.
+export const SORT_BACKEND: Record<SortOption, string> = {
+  newest: "-publication_year",
+  oldest: "publication_year",
+};
 
 // Mirrors parseSearchParams: page must be >= 1, years > 0, all safe integers.
 // Defends the API boundary against NaN/Infinity/floats from programmatic callers.

--- a/src/services/searchParams.ts
+++ b/src/services/searchParams.ts
@@ -13,7 +13,7 @@ export interface SearchParams {
 // Strict whitelist: anything outside this set parses as undefined (relevance).
 // Decouples the user-facing URL from the backend's ES field naming so a future
 // rename of `publication_year` doesn't break shared bookmarks.
-function parseSort(raw: string | null): SortOption | undefined {
+export function parseSort(raw: string | null): SortOption | undefined {
   return raw === "newest" || raw === "oldest" ? raw : undefined;
 }
 

--- a/src/services/searchParams.ts
+++ b/src/services/searchParams.ts
@@ -1,10 +1,20 @@
 import { parseYear } from "@/utils/year";
 
+export type SortOption = "newest" | "oldest";
+
 export interface SearchParams {
   q: string;
   page: number;
   startYear: number | undefined;
   endYear: number | undefined;
+  sort: SortOption | undefined;
+}
+
+// Strict whitelist: anything outside this set parses as undefined (relevance).
+// Decouples the user-facing URL from the backend's ES field naming so a future
+// rename of `publication_year` doesn't break shared bookmarks.
+function parseSort(raw: string | null): SortOption | undefined {
+  return raw === "newest" || raw === "oldest" ? raw : undefined;
 }
 
 // Strict: plain decimal digits only, safe integer range. Used here for `page`;
@@ -32,7 +42,9 @@ export function parseSearchParams(search: string): SearchParams {
     endYear = undefined;
   }
 
-  return { q, page, startYear, endYear };
+  const sort = parseSort(params.get("sort"));
+
+  return { q, page, startYear, endYear, sort };
 }
 
 export function toQueryString(params: SearchParams): string {
@@ -40,6 +52,7 @@ export function toQueryString(params: SearchParams): string {
   if (params.q) out.set("q", params.q);
   if (params.startYear !== undefined) out.set("start_year", String(params.startYear));
   if (params.endYear !== undefined) out.set("end_year", String(params.endYear));
+  if (params.sort !== undefined) out.set("sort", params.sort);
   if (params.page !== 1) out.set("page", String(params.page));
   return out.toString();
 }

--- a/src/services/searchParams.ts
+++ b/src/services/searchParams.ts
@@ -10,9 +10,7 @@ export interface SearchParams {
   sort: SortOption | undefined;
 }
 
-// Strict whitelist: anything outside this set parses as undefined (relevance).
-// Decouples the user-facing URL from the backend's ES field naming so a future
-// rename of `publication_year` doesn't break shared bookmarks.
+// Unknown values fall back to undefined (relevance).
 export function parseSort(raw: string | null): SortOption | undefined {
   return raw === "newest" || raw === "oldest" ? raw : undefined;
 }

--- a/tests/components/search/SortDropdown.test.tsx
+++ b/tests/components/search/SortDropdown.test.tsx
@@ -1,0 +1,71 @@
+import { describe, test, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/preact";
+import { SortDropdown } from "@/components/search/SortDropdown";
+import type { SortOption } from "@/services/searchParams";
+
+describe("SortDropdown", () => {
+  test("renders three options with correct labels", () => {
+    render(<SortDropdown value={undefined} onChange={() => {}} />);
+    const select = screen.getByLabelText(/sort/i) as HTMLSelectElement;
+    const labels = Array.from(select.options).map((o) => o.textContent);
+    expect(labels).toEqual([
+      "Relevance",
+      "Publication year (newest)",
+      "Publication year (oldest)",
+    ]);
+  });
+
+  test("selection reflects value=undefined as Relevance", () => {
+    render(<SortDropdown value={undefined} onChange={() => {}} />);
+    const select = screen.getByLabelText(/sort/i) as HTMLSelectElement;
+    expect(select.value).toBe("");
+  });
+
+  test("selection reflects value=newest", () => {
+    render(<SortDropdown value="newest" onChange={() => {}} />);
+    const select = screen.getByLabelText(/sort/i) as HTMLSelectElement;
+    expect(select.value).toBe("newest");
+  });
+
+  test("selection reflects value=oldest", () => {
+    render(<SortDropdown value="oldest" onChange={() => {}} />);
+    const select = screen.getByLabelText(/sort/i) as HTMLSelectElement;
+    expect(select.value).toBe("oldest");
+  });
+
+  test("onChange fires with newest when newest selected", () => {
+    const onChange = vi.fn<(next: SortOption | undefined) => void>();
+    render(<SortDropdown value={undefined} onChange={onChange} />);
+    const select = screen.getByLabelText(/sort/i) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "newest" } });
+    expect(onChange).toHaveBeenCalledWith("newest");
+  });
+
+  test("onChange fires with oldest when oldest selected", () => {
+    const onChange = vi.fn<(next: SortOption | undefined) => void>();
+    render(<SortDropdown value="newest" onChange={onChange} />);
+    const select = screen.getByLabelText(/sort/i) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "oldest" } });
+    expect(onChange).toHaveBeenCalledWith("oldest");
+  });
+
+  test("onChange fires with undefined when Relevance selected (empty value)", () => {
+    const onChange = vi.fn<(next: SortOption | undefined) => void>();
+    render(<SortDropdown value="newest" onChange={onChange} />);
+    const select = screen.getByLabelText(/sort/i) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "" } });
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  test("respects disabled prop", () => {
+    render(<SortDropdown value={undefined} onChange={() => {}} disabled />);
+    const select = screen.getByLabelText(/sort/i) as HTMLSelectElement;
+    expect(select.disabled).toBe(true);
+  });
+
+  test("not disabled by default", () => {
+    render(<SortDropdown value={undefined} onChange={() => {}} />);
+    const select = screen.getByLabelText(/sort/i) as HTMLSelectElement;
+    expect(select.disabled).toBe(false);
+  });
+});

--- a/tests/hooks/useSearch.test.tsx
+++ b/tests/hooks/useSearch.test.tsx
@@ -6,14 +6,15 @@ import { CommunityProvider } from "@/community/CommunityContext";
 import type { SearchResult } from "@/types/models";
 import type { SearchParams } from "@/services/searchParams";
 
-vi.mock("@/services/apiClient", () => ({
-  searchReferences: vi.fn(),
-}));
+vi.mock("@/services/apiClient", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/services/apiClient")>();
+  return { ...actual, searchReferences: vi.fn() };
+});
 
 import { searchReferences } from "@/services/apiClient";
 const mockSearch = vi.mocked(searchReferences);
 
-const baseParams: SearchParams = { q: "phonics", page: 1, startYear: undefined, endYear: undefined };
+const baseParams: SearchParams = { q: "phonics", page: 1, startYear: undefined, endYear: undefined, sort: undefined };
 
 // Drive the real CommunityProvider through the URL the way the runtime does.
 function withCommunityPath(path: string) {
@@ -194,6 +195,44 @@ describe("useSearch", () => {
 
     resolvers[1](makeResult(11));
     await waitFor(() => expect(result.current.results?.total.count).toBe(11));
+  });
+
+  test.each([
+    { sort: "newest" as const, wire: "-publication_year" },
+    { sort: "oldest" as const, wire: "publication_year" },
+  ])("translates sort=$sort to backend wire format $wire", async ({ sort, wire }) => {
+    mockSearch.mockResolvedValue(makeResult(1));
+    renderHook(() => useSearch({ ...baseParams, sort }), {
+      wrapper: withCommunityPath("/esea"),
+    });
+    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
+    expect(mockSearch).toHaveBeenCalledWith("phonics", expect.objectContaining({ sort: [wire] }));
+  });
+
+  test("omits sort filter when params.sort is undefined", async () => {
+    mockSearch.mockResolvedValue(makeResult(1));
+    renderHook(() => useSearch(baseParams), {
+      wrapper: withCommunityPath("/esea"),
+    });
+    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
+    const [, filters] = mockSearch.mock.calls[0];
+    expect(filters).not.toHaveProperty("sort");
+  });
+
+  test("refetches when sort changes (cache key includes sort)", async () => {
+    mockSearch.mockResolvedValue(makeResult(1));
+    const { rerender } = renderHook(
+      ({ p }) => useSearch(p),
+      {
+        wrapper: withCommunityPath("/esea"),
+        initialProps: { p: baseParams },
+      },
+    );
+    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
+    rerender({ p: { ...baseParams, sort: "newest" as const } });
+    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(2));
+    rerender({ p: { ...baseParams, sort: "oldest" as const } });
+    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(3));
   });
 
   test("returns idle (no fetch) when slug resolves to no community", () => {

--- a/tests/pages/SearchPage.test.tsx
+++ b/tests/pages/SearchPage.test.tsx
@@ -12,9 +12,10 @@ function renderSearchPage() {
   );
 }
 
-vi.mock("@/services/apiClient", () => ({
-  searchReferences: vi.fn(),
-}));
+vi.mock("@/services/apiClient", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/services/apiClient")>();
+  return { ...actual, searchReferences: vi.fn() };
+});
 
 import { searchReferences } from "@/services/apiClient";
 const mockSearch = vi.mocked(searchReferences);
@@ -127,6 +128,21 @@ describe("SearchPage", () => {
     expect(window.location.search).toBe("?q=phonics");
     // Corpus subtitle is unchanged throughout the transition.
     expect(screen.getByText(/5,721 investigations/i)).toBeInTheDocument();
+  });
+
+  test("submitting a query preserves an existing sort selection", async () => {
+    history.replaceState(null, "", "/esea?sort=newest");
+    mockBoth({ results: makeResult(3, ["r1"]) });
+
+    renderSearchPage();
+    await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
+
+    fireEvent.input(screen.getByRole("searchbox"), { target: { value: "phonics" } });
+    fireEvent.click(screen.getByRole("button", { name: /search/i }));
+
+    await waitFor(() => expect(window.location.search).toContain("q=phonics"));
+    expect(window.location.search).toContain("sort=newest");
+    expect(window.location.search).not.toContain("page=");
   });
 
   test("invalid URL params canonicalize via replaceState exactly once", async () => {

--- a/tests/pages/SearchPage.test.tsx
+++ b/tests/pages/SearchPage.test.tsx
@@ -69,7 +69,7 @@ beforeEach(() => {
 });
 
 describe("SearchPage", () => {
-  test("browse mode on mount: hero shows corpus count, rows render, meta-bar hidden", async () => {
+  test("browse mode on mount: hero shows corpus count, rows render, meta-bar shows sort but no summary", async () => {
     // Browse mode: corpus and search fetches are identical (both q=undefined),
     // so corpus defaults to mirror results.
     mockBoth({ results: makeResult(5721, ["r1", "r2", "r3"]) });
@@ -77,7 +77,51 @@ describe("SearchPage", () => {
 
     await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
     expect(screen.getByText(/5,721 investigations across education research/i)).toBeInTheDocument();
+    // Summary text only renders when narrowed; browse mode shows the bar
+    // with just the sort dropdown so users can flip relevance ↔ newest.
     expect(screen.queryByText(/results for/i)).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/sort results/i)).toBeInTheDocument();
+  });
+
+  test("sort change navigates to URL with new alias and resets page to 1", async () => {
+    history.replaceState(null, "", "/esea?q=phonics&page=3");
+    mockBoth({ results: makeResult(47, ["r1"]) });
+    renderSearchPage();
+
+    await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText(/sort results/i), {
+      target: { value: "newest" },
+    });
+
+    await waitFor(() => expect(window.location.search).toContain("sort=newest"));
+    expect(window.location.search).toContain("q=phonics");
+    expect(window.location.search).not.toContain("page=");
+  });
+
+  test("sort dropdown reflects current URL sort param", async () => {
+    history.replaceState(null, "", "/esea?sort=oldest");
+    mockBoth({ results: makeResult(47, ["r1"]) });
+    renderSearchPage();
+
+    await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
+    const select = screen.getByLabelText(/sort results/i) as HTMLSelectElement;
+    expect(select.value).toBe("oldest");
+  });
+
+  test("clearing sort to Relevance drops the URL param", async () => {
+    history.replaceState(null, "", "/esea?q=phonics&sort=newest");
+    mockBoth({ results: makeResult(3, ["r1"]) });
+    renderSearchPage();
+
+    await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText(/sort results/i), {
+      target: { value: "" },
+    });
+
+    await waitFor(() => expect(window.location.search).not.toContain("sort="));
+    expect(window.location.search).toContain("q=phonics");
   });
 
   test("year-only filter shows meta-bar count without 'for' framing", async () => {

--- a/tests/services/searchParams.test.ts
+++ b/tests/services/searchParams.test.ts
@@ -13,16 +13,18 @@ describe("parseSearchParams", () => {
       page: 1,
       startYear: undefined,
       endYear: undefined,
+      sort: undefined,
     });
   });
 
   test("full params round-trip", () => {
-    const input = "?q=phonics&page=3&start_year=2010&end_year=2024";
+    const input = "?q=phonics&page=3&start_year=2010&end_year=2024&sort=newest";
     expect(parseSearchParams(input)).toEqual({
       q: "phonics",
       page: 3,
       startYear: 2010,
       endYear: 2024,
+      sort: "newest",
     });
   });
 
@@ -84,31 +86,61 @@ describe("parseSearchParams", () => {
   test("q is trimmed", () => {
     expect(parseSearchParams("?q=%20%20hello%20%20").q).toBe("hello");
   });
+
+  test.each([
+    { label: "newest", raw: "newest", expected: "newest" as const },
+    { label: "oldest", raw: "oldest", expected: "oldest" as const },
+  ])("sort=$label is accepted", ({ raw, expected }) => {
+    expect(parseSearchParams(`?sort=${raw}`).sort).toBe(expected);
+  });
+
+  test.each([
+    { label: "garbage",   raw: "garbage" },
+    { label: "relevance", raw: "relevance" },
+    { label: "empty",     raw: "" },
+    { label: "uppercase", raw: "NEWEST" },
+    { label: "wire form", raw: "-publication_year" },
+  ])("sort=$label → undefined (strict whitelist)", ({ raw }) => {
+    expect(parseSearchParams(`?sort=${raw}`).sort).toBeUndefined();
+  });
 });
 
 describe("toQueryString", () => {
   test("omits defaults", () => {
-    const p: SearchParams = { q: "", page: 1, startYear: undefined, endYear: undefined };
+    const p: SearchParams = { q: "", page: 1, startYear: undefined, endYear: undefined, sort: undefined };
     expect(toQueryString(p)).toBe("");
   });
 
-  test("fixed key order: q, start_year, end_year, page", () => {
-    const p: SearchParams = { q: "phonics", page: 3, startYear: 2010, endYear: 2024 };
-    expect(toQueryString(p)).toBe("q=phonics&start_year=2010&end_year=2024&page=3");
+  test("fixed key order: q, start_year, end_year, sort, page", () => {
+    const p: SearchParams = { q: "phonics", page: 3, startYear: 2010, endYear: 2024, sort: "newest" };
+    expect(toQueryString(p)).toBe("q=phonics&start_year=2010&end_year=2024&sort=newest&page=3");
   });
 
   test("page=1 (default) is dropped from output, q is kept", () => {
-    const p: SearchParams = { q: "phonics", page: 1, startYear: undefined, endYear: undefined };
+    const p: SearchParams = { q: "phonics", page: 1, startYear: undefined, endYear: undefined, sort: undefined };
     expect(toQueryString(p)).toBe("q=phonics");
   });
 
   test("URL-encodes q", () => {
-    const p: SearchParams = { q: "a b&c", page: 1, startYear: undefined, endYear: undefined };
+    const p: SearchParams = { q: "a b&c", page: 1, startYear: undefined, endYear: undefined, sort: undefined };
     expect(toQueryString(p)).toBe("q=a+b%26c");
   });
 
+  test("sort omitted when undefined (relevance default)", () => {
+    const p: SearchParams = { q: "phonics", page: 1, startYear: undefined, endYear: undefined, sort: undefined };
+    expect(toQueryString(p)).toBe("q=phonics");
+  });
+
+  test.each([
+    { sort: "newest" as const },
+    { sort: "oldest" as const },
+  ])("sort=$sort is emitted", ({ sort }) => {
+    const p: SearchParams = { q: "", page: 1, startYear: undefined, endYear: undefined, sort };
+    expect(toQueryString(p)).toBe(`sort=${sort}`);
+  });
+
   test("round-trip normalization", () => {
-    const raw = "?page=abc&q=%20hello%20&start_year=2024&end_year=2010";
+    const raw = "?page=abc&q=%20hello%20&start_year=2024&end_year=2010&sort=garbage";
     const canonical = toQueryString(parseSearchParams(raw));
     expect(canonical).toBe("q=hello");
   });
@@ -116,12 +148,12 @@ describe("toQueryString", () => {
 
 describe("buildSearchUrl", () => {
   test("empty params → bare slug path", () => {
-    const p: SearchParams = { q: "", page: 1, startYear: undefined, endYear: undefined };
+    const p: SearchParams = { q: "", page: 1, startYear: undefined, endYear: undefined, sort: undefined };
     expect(buildSearchUrl("esea", p)).toBe("/esea");
   });
 
   test("with params → slug + querystring", () => {
-    const p: SearchParams = { q: "phonics", page: 2, startYear: undefined, endYear: undefined };
+    const p: SearchParams = { q: "phonics", page: 2, startYear: undefined, endYear: undefined, sort: undefined };
     expect(buildSearchUrl("esea", p)).toBe("/esea?q=phonics&page=2");
   });
 });


### PR DESCRIPTION
## Summary

Adds the Issue #29 search-results sort dropdown.

- Adds a native sort `<select>` to the search results meta bar with `Relevance`, `Publication year (newest)`, and `Publication year (oldest)`.
- Persists sort in the URL as `?sort=newest|oldest`; default relevance omits the param.
- Resets `page` to 1 when sort changes, while preserving query and year filters.
- Translates URL aliases to backend wire format at the API boundary: `newest -> -publication_year`, `oldest -> publication_year`.
- Shows the dropdown in browse mode once results have loaded, so users can sort before narrowing.

Closes #29.

## Implementation Notes

Sort plumbing is split by responsibility:

- `searchParams` owns URL parsing, canonicalization, and serialization.
- `apiClient` owns the backend sort mapping.
- `useSearch` includes sort in the cache key and passes the translated backend value.
- `SearchPage` owns navigation behavior: sort changes preserve current filters, clear `page`, and update the URL.

The dropdown uses a native `<select>` for keyboard, screen-reader, and mobile picker behavior. Styling only changes the chrome and arrow treatment.

This branch is rebased onto post-#31 `main`, so the sort code follows the new `useCommunity()`-sourced hook shape.

## Validation

Automated checks:

- `npm test -- --run` passes: 296 tests.
- `npm run typecheck` passes.
- `npm run build` passes.
- Targeted sort/search suites pass: `SortDropdown`, `SearchPage`, `useSearch`, `searchParams`, `apiClient`, `useCorpusTotal`.

Live checks on local dev:

- Browse mode shows dropdown with `Relevance` selected and no `sort` param.
- `?sort=newest` rehydrates the dropdown and sends `sort=-publication_year`.
- `?sort=oldest` rehydrates the dropdown and sends `sort=publication_year`.
- Switching back to `Relevance` removes `sort` from the URL and request.
- Browser back/forward restores the dropdown state for each URL.
- Changing sort from `?q=phonics&start_year=2015&end_year=2020&page=2` preserves `q` and year filters, drops `page`, and adds the selected sort.
- API calls returned 200 OK.

## Reviewer Notes

Oldest sort exposed an unrelated source-data anomaly: `"Let's do the time warp again"` appears with `publication_year=1902`, but the real publication date is 11 Jul 2020 in *Interactive Learning Environments*. This looks like an ingest-side EEF data issue.

## Out of Scope

- Citation-count sort, since the backend search projection does not expose `cited_by_count`.
- Multi-field sort UI. The API client can already pass multiple sort values, but this PR intentionally exposes one sort choice at a time.
- Custom open-state dropdown styling.