### PR TITLE
Add RawEnhancement.source to search and detail pages

### DIFF
--- a/src/components/InvestigationCard.css
+++ b/src/components/InvestigationCard.css
@@ -50,6 +50,14 @@
   margin: 0 0 var(--spacing-sm);
 }
 
+.investigation-card__coder {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--color-text-tertiary);
+  margin: var(--spacing-md) 0 0;
+}
+
 .investigation-card__doi {
   display: inline-flex;
   align-items: center;

--- a/src/components/InvestigationCard.tsx
+++ b/src/components/InvestigationCard.tsx
@@ -12,6 +12,7 @@ interface InvestigationCardProps {
   doi: string | null;
   publicationYear: number | null;
   documentType?: CodedAnnotation<ResolvedConcept>;
+  codingInstitution?: string | null;
   isRetracted: boolean;
   hasInvestigation: boolean;
   vocabUnavailable: boolean;
@@ -57,12 +58,14 @@ export function InvestigationCard({
   doi,
   publicationYear,
   documentType,
+  codingInstitution,
   isRetracted,
   hasInvestigation,
   vocabUnavailable,
 }: InvestigationCardProps) {
   const venueText = formatVenue(venue, pagination);
-  const hasInvestigationContent = documentType || vocabUnavailable;
+  const hasInvestigationContent =
+    documentType || vocabUnavailable || codingInstitution;
 
   return (
     <>
@@ -116,6 +119,14 @@ export function InvestigationCard({
                 label="Doc Type"
                 tags={[documentType.value.label ?? documentType.value.uri]}
               />
+            )}
+            {codingInstitution && (
+              <p
+                class="investigation-card__coder"
+                data-testid="investigation-coder-text"
+              >
+                Coded by {codingInstitution}
+              </p>
             )}
           </>
         )}

--- a/src/components/search/ResultRow.css
+++ b/src/components/search/ResultRow.css
@@ -90,6 +90,13 @@
   color: var(--color-text-secondary);
 }
 
+.row-coder {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--color-text-tertiary);
+}
+
 /* Right column: deliberately un-positioned so clicks on its non-interactive
    children (stat-badges, empty space) fall through to the row-link overlay. */
 .row-right {

--- a/src/components/search/ResultRow.css
+++ b/src/components/search/ResultRow.css
@@ -92,8 +92,7 @@
 
 .row-coder {
   font-family: var(--font-mono);
-  font-size: 12px;
-  font-weight: 400;
+  font-size: var(--font-size-xs);
   color: var(--color-text-tertiary);
 }
 

--- a/src/components/search/ResultRow.tsx
+++ b/src/components/search/ResultRow.tsx
@@ -1,5 +1,6 @@
 import type { Reference } from "@/types/models";
 import { extractBibliographic, extractDoi, formatPagination } from "@/services/referenceUtils";
+import { extractReferenceCodingInstitution } from "@/services/codingInstitution";
 import "./ResultRow.css";
 
 interface ResultRowProps {
@@ -37,6 +38,7 @@ export function ResultRow({ communitySlug, reference }: ResultRowProps) {
   const year = bib?.publication_year !== null && bib?.publication_year !== undefined
     ? String(bib.publication_year)
     : "";
+  const codingInstitution = extractReferenceCodingInstitution(reference);
 
   // Stretched-link pattern: the .row-link <a> wraps left-column content, and
   // its ::before extends a transparent overlay across the whole .result-row
@@ -82,6 +84,11 @@ export function ResultRow({ communitySlug, reference }: ResultRowProps) {
         <span class="stat-badge">
           <span class="stat-num">—</span> estimates
         </span>
+        {codingInstitution && (
+          <span class="row-coder" data-testid="coder-text">
+            {codingInstitution}
+          </span>
+        )}
       </div>
     </article>
   );

--- a/src/pages/RecordDetailPage.tsx
+++ b/src/pages/RecordDetailPage.tsx
@@ -3,8 +3,10 @@ import { useCommunity } from "@/community/CommunityContext";
 import {
   extractBibliographic,
   extractLinkedData,
+  extractLinkedDataEnhancement,
   extractDoi,
 } from "@/services/referenceUtils";
+import { extractLinkedDataCodingInstitution } from "@/services/codingInstitution";
 import {
   parseInvestigation,
   extractIsRetracted,
@@ -89,6 +91,10 @@ export function RecordDetailPage({ id }: RecordDetailPageProps) {
   if (!reference) return <NotFoundPage />;
 
   const doi = extractDoi(reference.identifiers);
+  const lde = extractLinkedDataEnhancement(reference);
+  const codingInstitution = lde
+    ? extractLinkedDataCodingInstitution(reference, lde)
+    : null;
 
   return (
     <div class="record-detail-page">
@@ -101,6 +107,7 @@ export function RecordDetailPage({ id }: RecordDetailPageProps) {
           doi={doi}
           publicationYear={bibliographic?.publication_year ?? null}
           documentType={investigation?.documentType}
+          codingInstitution={codingInstitution}
           isRetracted={isRetracted}
           hasInvestigation={hasLinkedData}
           vocabUnavailable={!!vocabUnavailable}

--- a/src/services/codingInstitution.ts
+++ b/src/services/codingInstitution.ts
@@ -1,7 +1,8 @@
 import type { Enhancement, OtherEnhancement, Reference } from "@/types/models";
 import { extractLatestEnhancement } from "@/services/referenceUtils";
 
-// Substring match: real source values are more convoluted (e.g. "esea-coder-v3").
+// Substring match: real source values are more convoluted
+// (e.g. "eef-eppi-review", "ad_hoc_ingestors.iiie_ingestor@1.0").
 const INSTITUTION_PATTERNS: ReadonlyArray<readonly [string, string]> = [
   ["eef", "EEF"],
   ["iiie", "IIIE"],

--- a/src/services/codingInstitution.ts
+++ b/src/services/codingInstitution.ts
@@ -1,0 +1,45 @@
+import type { Enhancement, OtherEnhancement, Reference } from "@/types/models";
+import { extractLatestEnhancement } from "@/services/referenceUtils";
+
+// Substring match: real source values are more convoluted (e.g. "esea-coder-v3").
+const INSTITUTION_PATTERNS: ReadonlyArray<readonly [string, string]> = [
+  ["eef", "EEF"],
+  ["iiie", "IIIE"],
+  ["essa", "ESSA"],
+  ["wwhge", "WWHGE"],
+];
+
+export function resolveCodingInstitution(
+  source: string | null | undefined,
+): string | null {
+  if (!source) return null;
+  const lower = source.toLowerCase();
+  for (const [pattern, label] of INSTITUTION_PATTERNS) {
+    if (lower.includes(pattern)) return label;
+  }
+  return null;
+}
+
+// Temporary: roll back once references are deduplicated.
+export function extractReferenceCodingInstitution(
+  reference: Reference,
+): string | null {
+  const raw = extractLatestEnhancement<OtherEnhancement>(reference, "raw");
+  return resolveCodingInstitution(raw?.source);
+}
+
+export function extractLinkedDataCodingInstitution(
+  reference: Reference,
+  lde: Enhancement,
+): string | null {
+  if (!lde.derived_from?.length) return null;
+  if (!reference.enhancements) return null;
+  const derivedIds = new Set(lde.derived_from);
+  const raw = reference.enhancements.find(
+    (e) =>
+      e.content.enhancement_type === "raw" &&
+      e.id !== null &&
+      derivedIds.has(e.id),
+  );
+  return resolveCodingInstitution(raw?.source);
+}

--- a/src/services/codingInstitution.ts
+++ b/src/services/codingInstitution.ts
@@ -1,13 +1,13 @@
 import type { Enhancement, OtherEnhancement, Reference } from "@/types/models";
 import { extractLatestEnhancement } from "@/services/referenceUtils";
 
-// Substring match: real source values are more convoluted
-// (e.g. "eef-eppi-review", "ad_hoc_ingestors.iiie_ingestor@1.0").
-const INSTITUTION_PATTERNS: ReadonlyArray<readonly [string, string]> = [
-  ["eef", "EEF"],
-  ["iiie", "IIIE"],
-  ["essa", "ESSA"],
-  ["wwhge", "WWHGE"],
+// Match institution tokens with non-letter boundaries: real source values are
+// more convoluted (e.g. "eef-eppi-review", "ad_hoc_ingestors.iiie_ingestor@1.0").
+const INSTITUTION_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
+  [/(^|[^a-z])eef([^a-z]|$)/, "EEF"],
+  [/(^|[^a-z])iiie([^a-z]|$)/, "IIIE"],
+  [/(^|[^a-z])essa([^a-z]|$)/, "ESSA"],
+  [/(^|[^a-z])wwhge([^a-z]|$)/, "WWHGE"],
 ];
 
 export function resolveCodingInstitution(
@@ -16,7 +16,7 @@ export function resolveCodingInstitution(
   if (!source) return null;
   const lower = source.toLowerCase();
   for (const [pattern, label] of INSTITUTION_PATTERNS) {
-    if (lower.includes(pattern)) return label;
+    if (pattern.test(lower)) return label;
   }
   return null;
 }

--- a/src/services/referenceUtils.ts
+++ b/src/services/referenceUtils.ts
@@ -8,10 +8,10 @@ import type {
   Pagination,
 } from "@/types/models";
 
-function extractEnhancement<T extends EnhancementContent>(
+export function extractLatestEnhancement<T extends EnhancementContent>(
   reference: Reference,
   enhancementType: T["enhancement_type"],
-): T | null {
+): (Enhancement & { content: T }) | null {
   if (!reference.enhancements) return null;
   const matches = reference.enhancements.filter(
     (e): e is Enhancement & { content: T } =>
@@ -21,22 +21,34 @@ function extractEnhancement<T extends EnhancementContent>(
   const sorted = matches.sort((a, b) =>
     (a.created_at ?? "").localeCompare(b.created_at ?? ""),
   );
-  return sorted[sorted.length - 1].content;
+  return sorted[sorted.length - 1];
 }
 
 export function extractBibliographic(
   reference: Reference,
 ): BibliographicMetadataEnhancement | null {
-  return extractEnhancement<BibliographicMetadataEnhancement>(
+  return (
+    extractLatestEnhancement<BibliographicMetadataEnhancement>(
+      reference,
+      "bibliographic",
+    )?.content ?? null
+  );
+}
+
+// Most callers want the content only — see extractLinkedData.
+export function extractLinkedDataEnhancement(
+  reference: Reference,
+): (Enhancement & { content: LinkedDataEnhancement }) | null {
+  return extractLatestEnhancement<LinkedDataEnhancement>(
     reference,
-    "bibliographic",
+    "linked_data",
   );
 }
 
 export function extractLinkedData(
   reference: Reference,
 ): LinkedDataEnhancement | null {
-  return extractEnhancement<LinkedDataEnhancement>(reference, "linked_data");
+  return extractLinkedDataEnhancement(reference)?.content ?? null;
 }
 
 export function extractDoi(

--- a/tests/components/InvestigationCard.test.tsx
+++ b/tests/components/InvestigationCard.test.tsx
@@ -112,6 +112,18 @@ describe("InvestigationCard", () => {
     ).toBeDefined();
   });
 
+  test("renders 'Coded by X' below the doc type when provided", () => {
+    render(<InvestigationCard {...DEFAULT_PROPS} codingInstitution="ESEA" />);
+    expect(screen.getByTestId("investigation-coder-text")).toHaveTextContent(
+      "Coded by ESEA",
+    );
+  });
+
+  test("does not render coding institution when null", () => {
+    render(<InvestigationCard {...DEFAULT_PROPS} codingInstitution={null} />);
+    expect(screen.queryByTestId("investigation-coder-text")).toBeNull();
+  });
+
   test("renders gracefully with missing optional fields", () => {
     const { container } = render(
       <InvestigationCard

--- a/tests/components/search/ResultRow.test.tsx
+++ b/tests/components/search/ResultRow.test.tsx
@@ -121,7 +121,7 @@ describe("ResultRow", () => {
         {
           id: "raw-1",
           reference_id: "ref-1",
-          source: "eef-coder-v3",
+          source: "eef-eppi-review",
           visibility: "public",
           robot_version: null,
           derived_from: null,

--- a/tests/components/search/ResultRow.test.tsx
+++ b/tests/components/search/ResultRow.test.tsx
@@ -110,6 +110,35 @@ describe("ResultRow", () => {
     expect(container.querySelector(".row-right")).toHaveTextContent(/estimates/);
   });
 
+  test("does not render coding institution when no raw enhancement is present", () => {
+    render(<ResultRow communitySlug="esea" reference={makeRef()} />);
+    expect(screen.queryByTestId("coder-text")).toBeNull();
+  });
+
+  test("renders coding institution at the bottom of the right column", () => {
+    const ref = makeRef({
+      enhancements: [
+        {
+          id: "raw-1",
+          reference_id: "ref-1",
+          source: "eef-coder-v3",
+          visibility: "public",
+          robot_version: null,
+          derived_from: null,
+          created_at: "2024-01-01",
+          content: { enhancement_type: "raw" },
+        },
+      ],
+    });
+    const { container } = render(
+      <ResultRow communitySlug="esea" reference={ref} />,
+    );
+    const coder = screen.getByTestId("coder-text");
+    expect(coder).toHaveTextContent("EEF");
+    const right = container.querySelector(".row-right");
+    expect(right?.lastElementChild).toBe(coder);
+  });
+
   test("renders without throwing when bibliographic missing; row-anchor falls back to id", () => {
     const ref = makeRef({ enhancements: [] });
     render(<ResultRow communitySlug="esea" reference={ref} />);

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -133,10 +133,17 @@ export function bibliographicEnh(
   };
 }
 
-/** Build a linked-data Enhancement wrapping an Investigation dict. */
+interface LinkedDataEnhOpts {
+  id?: string;
+  derivedFrom?: string[] | null;
+  createdAt?: string | null;
+  investigation?: Record<string, unknown>;
+}
+
+/** Build a linked-data Enhancement, optionally wrapping an Investigation dict. */
 export function linkedDataEnh(
   refId: string,
-  investigation: Record<string, unknown>,
+  opts: LinkedDataEnhOpts = {},
 ): Enhancement {
   const content: LinkedDataEnhancement = {
     enhancement_type: "linked_data",
@@ -144,18 +151,40 @@ export function linkedDataEnh(
     data: {
       "@context": "https://vocab.example/context.jsonld",
       "@type": "LinkedDataEnhancement",
-      hasInvestigation: { "@type": "Investigation", ...investigation },
+      hasInvestigation: { "@type": "Investigation", ...(opts.investigation ?? {}) },
     },
   };
   return {
-    id: `${refId}-ld`,
+    id: opts.id ?? `${refId}-ld`,
     reference_id: refId,
     source: "robot",
     visibility: "public",
     robot_version: "0.1.0",
-    derived_from: null,
-    created_at: null,
+    derived_from: opts.derivedFrom ?? null,
+    created_at: opts.createdAt ?? null,
     content,
+  };
+}
+
+interface RawEnhOpts {
+  id?: string;
+  source?: string;
+  createdAt?: string | null;
+}
+
+/** Build a raw Enhancement (used for ingestor/coder provenance). */
+export function rawEnh(refId: string, opts: RawEnhOpts = {}): Enhancement {
+  return {
+    id: opts.id ?? `${refId}-raw`,
+    reference_id: refId,
+    source: opts.source ?? "openalex",
+    visibility: "public",
+    robot_version: null,
+    derived_from: null,
+    created_at: opts.createdAt ?? null,
+    content: {
+      enhancement_type: "raw",
+    },
   };
 }
 
@@ -176,7 +205,7 @@ export function makeReference(opts: ReferenceOpts = {}): Reference {
     opts.enhancements ??
     [
       bibliographicEnh(id, opts.bibliographic),
-      opts.investigation ? linkedDataEnh(id, opts.investigation) : null,
+      opts.investigation ? linkedDataEnh(id, { investigation: opts.investigation }) : null,
     ].filter((e): e is Enhancement => e !== null);
 
   return {

--- a/tests/services/codingInstitution.test.ts
+++ b/tests/services/codingInstitution.test.ts
@@ -1,0 +1,171 @@
+import { describe, test, expect } from "vitest";
+import {
+  resolveCodingInstitution,
+  extractReferenceCodingInstitution,
+  extractLinkedDataCodingInstitution,
+} from "@/services/codingInstitution";
+import type { Enhancement, Reference } from "@/types/models";
+
+function rawEnh(
+  id: string | null,
+  source: string,
+  createdAt: string | null = null,
+): Enhancement {
+  return {
+    id,
+    reference_id: "ref-1",
+    source,
+    visibility: "public",
+    robot_version: null,
+    derived_from: null,
+    created_at: createdAt,
+    content: {
+      enhancement_type: "raw",
+    },
+  };
+}
+
+function ldeEnh(
+  derivedFrom: string[] | null,
+  createdAt: string | null = null,
+): Enhancement {
+  return {
+    id: "lde-1",
+    reference_id: "ref-1",
+    source: "robot",
+    visibility: "public",
+    robot_version: null,
+    derived_from: derivedFrom,
+    created_at: createdAt,
+    content: {
+      enhancement_type: "linked_data",
+      vocabulary_uri: "https://vocab.example/v1",
+      data: {},
+    },
+  };
+}
+
+function makeRef(enhancements: Enhancement[] | null): Reference {
+  return {
+    id: "ref-1",
+    visibility: "public",
+    identifiers: null,
+    enhancements,
+  };
+}
+
+describe("resolveCodingInstitution", () => {
+  test.each([
+    ["eef-coder-v3", "EEF"],
+    ["coder.iiie.team", "IIIE"],
+    ["essa-2024", "ESSA"],
+    ["wwhge-internal", "WWHGE"],
+    ["EEF-CODER", "EEF"],
+  ])("maps %s to %s", (input, expected) => {
+    expect(resolveCodingInstitution(input)).toBe(expected);
+  });
+
+  test("returns null for unknown sources", () => {
+    expect(resolveCodingInstitution("openalex")).toBeNull();
+    expect(resolveCodingInstitution("robot")).toBeNull();
+  });
+
+  test("returns null for empty/null/undefined", () => {
+    expect(resolveCodingInstitution("")).toBeNull();
+    expect(resolveCodingInstitution(null)).toBeNull();
+    expect(resolveCodingInstitution(undefined)).toBeNull();
+  });
+});
+
+describe("extractReferenceCodingInstitution", () => {
+  test("returns null when enhancements is null", () => {
+    expect(extractReferenceCodingInstitution(makeRef(null))).toBeNull();
+  });
+
+  test("returns null when no raw enhancement exists", () => {
+    expect(extractReferenceCodingInstitution(makeRef([]))).toBeNull();
+  });
+
+  test("uses the latest raw enhancement by created_at", () => {
+    const ref = makeRef([
+      rawEnh("a", "eef-coder", "2024-01-01"),
+      rawEnh("b", "iiie-coder", "2024-06-01"),
+    ]);
+    expect(extractReferenceCodingInstitution(ref)).toBe("IIIE");
+  });
+
+  test("returns null when raw source is unknown", () => {
+    const ref = makeRef([rawEnh("a", "openalex", "2024-01-01")]);
+    expect(extractReferenceCodingInstitution(ref)).toBeNull();
+  });
+});
+
+describe("extractLinkedDataCodingInstitution", () => {
+  test("returns null when reference has no enhancements", () => {
+    const lde = ldeEnh(["raw-1"]);
+    expect(extractLinkedDataCodingInstitution(makeRef(null), lde)).toBeNull();
+  });
+
+  test("returns null when LDE has no derived_from", () => {
+    const lde = ldeEnh(null);
+    const ref = makeRef([rawEnh("raw-1", "eef-coder"), lde]);
+    expect(extractLinkedDataCodingInstitution(ref, lde)).toBeNull();
+  });
+
+  test("resolves source on raw enhancement matched by derived_from", () => {
+    const lde = ldeEnh(["raw-2"]);
+    const ref = makeRef([
+      rawEnh("raw-1", "openalex"),
+      rawEnh("raw-2", "eef-coder-v3"),
+      lde,
+    ]);
+    expect(extractLinkedDataCodingInstitution(ref, lde)).toBe("EEF");
+  });
+
+  test("resolves the provenance of the specific LDE passed in", () => {
+    const ldeA = { ...ldeEnh(["raw-1"]), id: "lde-a" };
+    const ldeB = { ...ldeEnh(["raw-2"]), id: "lde-b" };
+    const ref = makeRef([
+      rawEnh("raw-1", "eef-coder"),
+      rawEnh("raw-2", "iiie-coder"),
+      ldeA,
+      ldeB,
+    ]);
+    expect(extractLinkedDataCodingInstitution(ref, ldeA)).toBe("EEF");
+    expect(extractLinkedDataCodingInstitution(ref, ldeB)).toBe("IIIE");
+  });
+
+  test("returns null when derived_from points to a missing enhancement", () => {
+    const lde = ldeEnh(["nonexistent-id"]);
+    const ref = makeRef([rawEnh("raw-1", "eef-coder"), lde]);
+    expect(extractLinkedDataCodingInstitution(ref, lde)).toBeNull();
+  });
+
+  test("ignores non-raw enhancements with matching id in derived_from", () => {
+    const bibEnh: Enhancement = {
+      id: "bib-1",
+      reference_id: "ref-1",
+      source: "eef",
+      visibility: "public",
+      robot_version: null,
+      derived_from: null,
+      created_at: null,
+      content: {
+        enhancement_type: "bibliographic",
+        authorship: null,
+        cited_by_count: null,
+        created_date: null,
+        updated_date: null,
+        publication_date: null,
+        publication_year: null,
+        publisher: null,
+        title: null,
+        pagination: null,
+        publication_venue: null,
+      },
+    };
+    const lde = ldeEnh(["bib-1"]);
+    const ref = makeRef([bibEnh, lde]);
+    expect(extractLinkedDataCodingInstitution(ref, lde)).toBeNull();
+  });
+});

--- a/tests/services/codingInstitution.test.ts
+++ b/tests/services/codingInstitution.test.ts
@@ -56,11 +56,11 @@ function makeRef(enhancements: Enhancement[] | null): Reference {
 
 describe("resolveCodingInstitution", () => {
   test.each([
-    ["eef-coder-v3", "EEF"],
-    ["coder.iiie.team", "IIIE"],
-    ["essa-2024", "ESSA"],
+    ["eef-eppi-review", "EEF"],
+    ["ad_hoc_ingestors.iiie_ingestor@1.0", "IIIE"],
+    ["ad_hoc_ingestors.essa_ingestor@1.0", "ESSA"],
     ["wwhge-internal", "WWHGE"],
-    ["EEF-CODER", "EEF"],
+    ["EEF-EPPI-REVIEW", "EEF"],
   ])("maps %s to %s", (input, expected) => {
     expect(resolveCodingInstitution(input)).toBe(expected);
   });
@@ -88,8 +88,8 @@ describe("extractReferenceCodingInstitution", () => {
 
   test("uses the latest raw enhancement by created_at", () => {
     const ref = makeRef([
-      rawEnh("a", "eef-coder", "2024-01-01"),
-      rawEnh("b", "iiie-coder", "2024-06-01"),
+      rawEnh("a", "eef-eppi-review", "2024-01-01"),
+      rawEnh("b", "ad_hoc_ingestors.iiie_ingestor@1.0", "2024-06-01"),
     ]);
     expect(extractReferenceCodingInstitution(ref)).toBe("IIIE");
   });
@@ -108,7 +108,7 @@ describe("extractLinkedDataCodingInstitution", () => {
 
   test("returns null when LDE has no derived_from", () => {
     const lde = ldeEnh(null);
-    const ref = makeRef([rawEnh("raw-1", "eef-coder"), lde]);
+    const ref = makeRef([rawEnh("raw-1", "eef-eppi-review"), lde]);
     expect(extractLinkedDataCodingInstitution(ref, lde)).toBeNull();
   });
 
@@ -116,7 +116,7 @@ describe("extractLinkedDataCodingInstitution", () => {
     const lde = ldeEnh(["raw-2"]);
     const ref = makeRef([
       rawEnh("raw-1", "openalex"),
-      rawEnh("raw-2", "eef-coder-v3"),
+      rawEnh("raw-2", "eef-eppi-review-v3"),
       lde,
     ]);
     expect(extractLinkedDataCodingInstitution(ref, lde)).toBe("EEF");
@@ -126,8 +126,8 @@ describe("extractLinkedDataCodingInstitution", () => {
     const ldeA = { ...ldeEnh(["raw-1"]), id: "lde-a" };
     const ldeB = { ...ldeEnh(["raw-2"]), id: "lde-b" };
     const ref = makeRef([
-      rawEnh("raw-1", "eef-coder"),
-      rawEnh("raw-2", "iiie-coder"),
+      rawEnh("raw-1", "eef-eppi-review"),
+      rawEnh("raw-2", "ad_hoc_ingestors.iiie_ingestor@1.0"),
       ldeA,
       ldeB,
     ]);
@@ -137,7 +137,7 @@ describe("extractLinkedDataCodingInstitution", () => {
 
   test("returns null when derived_from points to a missing enhancement", () => {
     const lde = ldeEnh(["nonexistent-id"]);
-    const ref = makeRef([rawEnh("raw-1", "eef-coder"), lde]);
+    const ref = makeRef([rawEnh("raw-1", "eef-eppi-review"), lde]);
     expect(extractLinkedDataCodingInstitution(ref, lde)).toBeNull();
   });
 

--- a/tests/services/codingInstitution.test.ts
+++ b/tests/services/codingInstitution.test.ts
@@ -24,8 +24,8 @@ describe("resolveCodingInstitution", () => {
   });
 
   test("does not match patterns embedded in larger words", () => {
-    // "feeder" should not match "eef"; "messa" should not match "essa"; etc.
-    expect(resolveCodingInstitution("feeder")).toBeNull();
+    // "beef" should not match "eef"; "messa" should not match "essa"; etc.
+    expect(resolveCodingInstitution("beef")).toBeNull();
     expect(resolveCodingInstitution("messaging")).toBeNull();
   });
 
@@ -52,7 +52,11 @@ describe("extractReferenceCodingInstitution", () => {
   test("uses the latest raw enhancement by created_at", () => {
     const ref = makeReference({
       enhancements: [
-        rawEnh("ref-1", { id: "a", source: "eef-eppi-review", createdAt: "2024-01-01" }),
+        rawEnh("ref-1", {
+          id: "a",
+          source: "eef-eppi-review",
+          createdAt: "2024-01-01",
+        }),
         rawEnh("ref-1", {
           id: "b",
           source: "ad_hoc_ingestors.iiie_ingestor@1.0",
@@ -66,7 +70,11 @@ describe("extractReferenceCodingInstitution", () => {
   test("returns null when raw source is unknown", () => {
     const ref = makeReference({
       enhancements: [
-        rawEnh("ref-1", { id: "a", source: "openalex", createdAt: "2024-01-01" }),
+        rawEnh("ref-1", {
+          id: "a",
+          source: "openalex",
+          createdAt: "2024-01-01",
+        }),
       ],
     });
     expect(extractReferenceCodingInstitution(ref)).toBeNull();
@@ -109,8 +117,14 @@ describe("extractLinkedDataCodingInstitution", () => {
   });
 
   test("resolves the provenance of the specific LDE passed in", () => {
-    const ldeA = linkedDataEnh("ref-1", { id: "lde-a", derivedFrom: ["raw-1"] });
-    const ldeB = linkedDataEnh("ref-1", { id: "lde-b", derivedFrom: ["raw-2"] });
+    const ldeA = linkedDataEnh("ref-1", {
+      id: "lde-a",
+      derivedFrom: ["raw-1"],
+    });
+    const ldeB = linkedDataEnh("ref-1", {
+      id: "lde-b",
+      derivedFrom: ["raw-2"],
+    });
     const ref = makeReference({
       enhancements: [
         rawEnh("ref-1", { id: "raw-1", source: "eef-eppi-review" }),

--- a/tests/services/codingInstitution.test.ts
+++ b/tests/services/codingInstitution.test.ts
@@ -5,54 +5,7 @@ import {
   extractLinkedDataCodingInstitution,
 } from "@/services/codingInstitution";
 import type { Enhancement, Reference } from "@/types/models";
-
-function rawEnh(
-  id: string | null,
-  source: string,
-  createdAt: string | null = null,
-): Enhancement {
-  return {
-    id,
-    reference_id: "ref-1",
-    source,
-    visibility: "public",
-    robot_version: null,
-    derived_from: null,
-    created_at: createdAt,
-    content: {
-      enhancement_type: "raw",
-    },
-  };
-}
-
-function ldeEnh(
-  derivedFrom: string[] | null,
-  createdAt: string | null = null,
-): Enhancement {
-  return {
-    id: "lde-1",
-    reference_id: "ref-1",
-    source: "robot",
-    visibility: "public",
-    robot_version: null,
-    derived_from: derivedFrom,
-    created_at: createdAt,
-    content: {
-      enhancement_type: "linked_data",
-      vocabulary_uri: "https://vocab.example/v1",
-      data: {},
-    },
-  };
-}
-
-function makeRef(enhancements: Enhancement[] | null): Reference {
-  return {
-    id: "ref-1",
-    visibility: "public",
-    identifiers: null,
-    enhancements,
-  };
-}
+import { linkedDataEnh, makeReference, rawEnh } from "../fixtures";
 
 describe("resolveCodingInstitution", () => {
   test.each([
@@ -70,6 +23,12 @@ describe("resolveCodingInstitution", () => {
     expect(resolveCodingInstitution("robot")).toBeNull();
   });
 
+  test("does not match patterns embedded in larger words", () => {
+    // "feeder" should not match "eef"; "messa" should not match "essa"; etc.
+    expect(resolveCodingInstitution("feeder")).toBeNull();
+    expect(resolveCodingInstitution("messaging")).toBeNull();
+  });
+
   test("returns null for empty/null/undefined", () => {
     expect(resolveCodingInstitution("")).toBeNull();
     expect(resolveCodingInstitution(null)).toBeNull();
@@ -79,65 +38,105 @@ describe("resolveCodingInstitution", () => {
 
 describe("extractReferenceCodingInstitution", () => {
   test("returns null when enhancements is null", () => {
-    expect(extractReferenceCodingInstitution(makeRef(null))).toBeNull();
+    expect(
+      extractReferenceCodingInstitution(makeReference({ enhancements: [] })),
+    ).toBeNull();
   });
 
   test("returns null when no raw enhancement exists", () => {
-    expect(extractReferenceCodingInstitution(makeRef([]))).toBeNull();
+    expect(
+      extractReferenceCodingInstitution(makeReference({ enhancements: [] })),
+    ).toBeNull();
   });
 
   test("uses the latest raw enhancement by created_at", () => {
-    const ref = makeRef([
-      rawEnh("a", "eef-eppi-review", "2024-01-01"),
-      rawEnh("b", "ad_hoc_ingestors.iiie_ingestor@1.0", "2024-06-01"),
-    ]);
+    const ref = makeReference({
+      enhancements: [
+        rawEnh("ref-1", { id: "a", source: "eef-eppi-review", createdAt: "2024-01-01" }),
+        rawEnh("ref-1", {
+          id: "b",
+          source: "ad_hoc_ingestors.iiie_ingestor@1.0",
+          createdAt: "2024-06-01",
+        }),
+      ],
+    });
     expect(extractReferenceCodingInstitution(ref)).toBe("IIIE");
   });
 
   test("returns null when raw source is unknown", () => {
-    const ref = makeRef([rawEnh("a", "openalex", "2024-01-01")]);
+    const ref = makeReference({
+      enhancements: [
+        rawEnh("ref-1", { id: "a", source: "openalex", createdAt: "2024-01-01" }),
+      ],
+    });
     expect(extractReferenceCodingInstitution(ref)).toBeNull();
   });
 });
 
 describe("extractLinkedDataCodingInstitution", () => {
   test("returns null when reference has no enhancements", () => {
-    const lde = ldeEnh(["raw-1"]);
-    expect(extractLinkedDataCodingInstitution(makeRef(null), lde)).toBeNull();
+    const lde = linkedDataEnh("ref-1", { id: "lde-1", derivedFrom: ["raw-1"] });
+    const ref: Reference = {
+      id: "ref-1",
+      visibility: "public",
+      identifiers: null,
+      enhancements: null,
+    };
+    expect(extractLinkedDataCodingInstitution(ref, lde)).toBeNull();
   });
 
   test("returns null when LDE has no derived_from", () => {
-    const lde = ldeEnh(null);
-    const ref = makeRef([rawEnh("raw-1", "eef-eppi-review"), lde]);
+    const lde = linkedDataEnh("ref-1", { id: "lde-1", derivedFrom: null });
+    const ref = makeReference({
+      enhancements: [
+        rawEnh("ref-1", { id: "raw-1", source: "eef-eppi-review" }),
+        lde,
+      ],
+    });
     expect(extractLinkedDataCodingInstitution(ref, lde)).toBeNull();
   });
 
   test("resolves source on raw enhancement matched by derived_from", () => {
-    const lde = ldeEnh(["raw-2"]);
-    const ref = makeRef([
-      rawEnh("raw-1", "openalex"),
-      rawEnh("raw-2", "eef-eppi-review-v3"),
-      lde,
-    ]);
+    const lde = linkedDataEnh("ref-1", { id: "lde-1", derivedFrom: ["raw-2"] });
+    const ref = makeReference({
+      enhancements: [
+        rawEnh("ref-1", { id: "raw-1", source: "openalex" }),
+        rawEnh("ref-1", { id: "raw-2", source: "eef-eppi-review-v3" }),
+        lde,
+      ],
+    });
     expect(extractLinkedDataCodingInstitution(ref, lde)).toBe("EEF");
   });
 
   test("resolves the provenance of the specific LDE passed in", () => {
-    const ldeA = { ...ldeEnh(["raw-1"]), id: "lde-a" };
-    const ldeB = { ...ldeEnh(["raw-2"]), id: "lde-b" };
-    const ref = makeRef([
-      rawEnh("raw-1", "eef-eppi-review"),
-      rawEnh("raw-2", "ad_hoc_ingestors.iiie_ingestor@1.0"),
-      ldeA,
-      ldeB,
-    ]);
+    const ldeA = linkedDataEnh("ref-1", { id: "lde-a", derivedFrom: ["raw-1"] });
+    const ldeB = linkedDataEnh("ref-1", { id: "lde-b", derivedFrom: ["raw-2"] });
+    const ref = makeReference({
+      enhancements: [
+        rawEnh("ref-1", { id: "raw-1", source: "eef-eppi-review" }),
+        rawEnh("ref-1", {
+          id: "raw-2",
+          source: "ad_hoc_ingestors.iiie_ingestor@1.0",
+        }),
+        ldeA,
+        ldeB,
+      ],
+    });
     expect(extractLinkedDataCodingInstitution(ref, ldeA)).toBe("EEF");
     expect(extractLinkedDataCodingInstitution(ref, ldeB)).toBe("IIIE");
   });
 
   test("returns null when derived_from points to a missing enhancement", () => {
-    const lde = ldeEnh(["nonexistent-id"]);
-    const ref = makeRef([rawEnh("raw-1", "eef-eppi-review"), lde]);
+    const lde = linkedDataEnh("ref-1", {
+      id: "lde-1",
+      derivedFrom: ["nonexistent-id"],
+    });
+    const ref = makeReference({
+      enhancements: [
+        rawEnh("ref-1", { id: "raw-1", source: "eef-eppi-review" }),
+        lde,
+      ],
+    });
     expect(extractLinkedDataCodingInstitution(ref, lde)).toBeNull();
   });
 
@@ -164,8 +163,8 @@ describe("extractLinkedDataCodingInstitution", () => {
         publication_venue: null,
       },
     };
-    const lde = ldeEnh(["bib-1"]);
-    const ref = makeRef([bibEnh, lde]);
+    const lde = linkedDataEnh("ref-1", { id: "lde-1", derivedFrom: ["bib-1"] });
+    const ref = makeReference({ enhancements: [bibEnh, lde] });
     expect(extractLinkedDataCodingInstitution(ref, lde)).toBeNull();
   });
 });

--- a/tests/services/referenceUtils.test.ts
+++ b/tests/services/referenceUtils.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from "vitest";
 import {
   extractBibliographic,
   extractLinkedData,
+  extractLinkedDataEnhancement,
   extractDoi,
   formatPagination,
 } from "@/services/referenceUtils";
@@ -131,6 +132,34 @@ describe("extractLinkedData", () => {
     const ref = makeRef([makeEnhancement(ld)]);
     expect(extractLinkedData(ref)).toBe(ld);
   });
+});
+
+describe("extractLinkedDataEnhancement", () => {
+  test("returns null when enhancements is null", () => {
+    expect(extractLinkedDataEnhancement(makeRef(null))).toBeNull();
+  });
+
+  test("returns null when no linked_data enhancement exists", () => {
+    const ref = makeRef([
+      makeEnhancement({
+        enhancement_type: "abstract",
+        process: "x",
+        abstract: "y",
+      }),
+    ]);
+    expect(extractLinkedDataEnhancement(ref)).toBeNull();
+  });
+
+  test("returns the wrapping enhancement when linked_data is present", () => {
+    const ld: LinkedDataEnhancement = {
+      enhancement_type: "linked_data",
+      vocabulary_uri: "http://example.com",
+      data: { key: "value" },
+    };
+    const wrapper = makeEnhancement(ld);
+    const ref = makeRef([wrapper]);
+    expect(extractLinkedDataEnhancement(ref)).toBe(wrapper);
+  });
 
   test("returns the most recent linked_data enhancement by created_at", () => {
     const older: LinkedDataEnhancement = {
@@ -143,11 +172,12 @@ describe("extractLinkedData", () => {
       vocabulary_uri: "http://newer.com",
       data: { n: 2 },
     };
+    const newerWrapper = makeEnhancement(newer, "2026-02-01T00:00:00Z");
     const ref = makeRef([
-      makeEnhancement(newer, "2026-02-01T00:00:00Z"),
+      newerWrapper,
       makeEnhancement(older, "2025-01-01T00:00:00Z"),
     ]);
-    expect(extractLinkedData(ref)).toBe(newer);
+    expect(extractLinkedDataEnhancement(ref)).toBe(newerWrapper);
   });
 });
 


### PR DESCRIPTION
Closes #32 

Adds the coding institution to the search and detail page.

This disambiguates duplicate references, and also may be useful when multiple LDEs are displayable under the same reference. (Though, we'll absolutely need a nicer pattern than a hardcoded map if we want to support this long term, particularly for new communities. We have [codedBy](https://vocab.evidence-repository.org/019d9463-2780-7243-b4de-e547386f2a90/1.0/property/019d9464-37b6-772b-a3ca-cef1ac603fda) in the vocab, perhaps we should start populating that?)

<img width="969" height="716" alt="Screenshot 2026-04-30 at 4 27 09 pm" src="https://github.com/user-attachments/assets/cbfaac21-0505-40d7-97f5-a7e2486b2d0f" />
<img width="881" height="835" alt="image" src="https://github.com/user-attachments/assets/2dbbef9a-0900-4d5d-92ef-8c029b2139ae" />

