### PR TITLE
Add effect estimate and arm data cards (#10)

### DIFF
--- a/src/components/ArmDataTable.css
+++ b/src/components/ArmDataTable.css
@@ -1,0 +1,53 @@
+.arm-data {
+  margin-top: 18px;
+}
+
+.arm-data__heading {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-text-tertiary);
+  margin: 0 0 var(--spacing-sm);
+}
+
+.arm-data__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.arm-data__header {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: var(--color-text-tertiary);
+  text-align: left;
+  padding: 8px 14px;
+  border-bottom: 2px solid var(--color-border-strong);
+}
+
+.arm-data__cell {
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-text-secondary);
+}
+
+.arm-data__cell--name {
+  font-family: var(--font-body);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.arm-data__cell--data {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.arm-data__table tr:last-child .arm-data__cell {
+  border-bottom: none;
+}

--- a/src/components/ArmDataTable.tsx
+++ b/src/components/ArmDataTable.tsx
@@ -1,0 +1,95 @@
+import type {
+  ArmData,
+  ControlConditionData,
+  InterventionData,
+} from "@/types/investigation";
+import "./ArmDataTable.css";
+
+interface ArmDataTableProps {
+  arms: ArmData[];
+  intervention: InterventionData | null;
+  control: ControlConditionData | null;
+}
+
+const COLUMNS = [
+  { key: "n", label: "n", integer: true },
+  { key: "mean", label: "Mean", integer: false },
+  { key: "sd", label: "SD", integer: false },
+  { key: "se", label: "SE", integer: false },
+  { key: "preMean", label: "Pre mean", integer: false },
+  { key: "preSd", label: "Pre SD", integer: false },
+  { key: "clusterCount", label: "Clusters", integer: true },
+  { key: "icc", label: "ICC", integer: false },
+  { key: "events", label: "Events", integer: true },
+] as const;
+
+// Union of every `key` literal in COLUMNS, e.g. "n" | "mean" | "sd" | ...
+type ColumnKey = (typeof COLUMNS)[number]["key"];
+
+function armLabel(
+  arm: ArmData,
+  intervention: InterventionData | null,
+  control: ControlConditionData | null,
+  index: number,
+): string {
+  if (arm.conditionRef) {
+    if (intervention && arm.conditionRef === intervention.id) {
+      return intervention.name?.trim() || "Intervention";
+    }
+    if (control && arm.conditionRef === control.id) {
+      return "Control";
+    }
+  }
+  return `Arm ${index + 1}`;
+}
+
+function formatCell(value: number | undefined, integer: boolean): string {
+  if (value === undefined) return "—";
+  if (integer) return String(Math.round(value));
+  return String(value);
+}
+
+export function ArmDataTable({
+  arms,
+  intervention,
+  control,
+}: ArmDataTableProps) {
+  if (arms.length === 0) return null;
+
+  const visibleColumns = COLUMNS.filter((col) =>
+    arms.some((arm) => arm[col.key as ColumnKey] !== undefined),
+  );
+  if (visibleColumns.length === 0) return null;
+
+  return (
+    <div class="arm-data">
+      <h4 class="arm-data__heading">Arm data</h4>
+      <table class="arm-data__table">
+        <thead>
+          <tr>
+            <th class="arm-data__header">Arm</th>
+            {visibleColumns.map((col) => (
+              <th key={col.key} class="arm-data__header">
+                {col.label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {arms.map((arm, i) => (
+            <tr key={arm.id || `arm-${i}`}>
+              <td class="arm-data__cell arm-data__cell--name">
+                {armLabel(arm, intervention, control, i)}
+              </td>
+              {visibleColumns.map((col) => (
+                <td key={col.key} class="arm-data__cell arm-data__cell--data">
+                  {formatCell(arm[col.key as ColumnKey], col.integer)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/CIVisualization.css
+++ b/src/components/CIVisualization.css
@@ -1,0 +1,116 @@
+.ci-viz {
+  --ee-pos-bar-fill: rgba(36, 57, 107, 0.08);
+  --ee-pos-bar-border: rgba(36, 57, 107, 0.2);
+  --ee-neg-bar-fill: rgba(120, 40, 40, 0.06);
+  --ee-neg-bar-border: rgba(120, 40, 40, 0.18);
+  --ee-ns-bar-fill: rgba(154, 74, 18, 0.08);
+  --ee-ns-bar-border: rgba(154, 74, 18, 0.18);
+  --ee-pos-dot: #24396b;
+  --ee-neg-dot: #6b2020;
+  --ee-ns-dot: var(--color-text-tertiary);
+
+  position: relative;
+  height: 48px;
+  margin: 14px 0 16px;
+}
+
+/* Inner container insets the plot 20px on each side; track, zero line,
+   bar, dot, and scale are all positioned within this inner box so a single
+   percentage maps consistently to axis position. */
+.ci-viz__inner {
+  position: absolute;
+  inset: 0 20px;
+}
+
+.ci-viz__track {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 23px;
+  height: 1px;
+  background: var(--color-border-strong);
+}
+
+.ci-viz__zero-label {
+  position: absolute;
+  top: 0;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  line-height: 1;
+  color: var(--color-text-tertiary);
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+.ci-viz__zero {
+  position: absolute;
+  top: 16px;
+  height: 14px;
+  width: 1px;
+  background: var(--color-text-tertiary);
+  transform: translateX(-50%);
+}
+
+.ci-viz__bar {
+  position: absolute;
+  top: 18px;
+  height: 10px;
+  border-radius: 3px;
+  border: 1px solid;
+  box-sizing: border-box;
+}
+
+.ci-viz--pos .ci-viz__bar {
+  background: var(--ee-pos-bar-fill);
+  border-color: var(--ee-pos-bar-border);
+}
+.ci-viz--neg .ci-viz__bar {
+  background: var(--ee-neg-bar-fill);
+  border-color: var(--ee-neg-bar-border);
+}
+.ci-viz--ns .ci-viz__bar {
+  background: var(--ee-ns-bar-fill);
+  border-color: var(--ee-ns-bar-border);
+}
+
+.ci-viz__dot {
+  position: absolute;
+  top: 15px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  /* Halo separates the dot from the bar where they overlap. */
+  border: 2px solid var(--color-bg-inset);
+  box-sizing: border-box;
+  transform: translateX(-50%);
+}
+
+.ci-viz--pos .ci-viz__dot {
+  background: var(--ee-pos-dot);
+}
+.ci-viz--neg .ci-viz__dot {
+  background: var(--ee-neg-dot);
+}
+.ci-viz--ns .ci-viz__dot {
+  background: var(--ee-ns-dot);
+}
+
+.ci-viz__scale {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 12px;
+}
+
+.ci-viz__tick {
+  position: absolute;
+  top: 0;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 1;
+  color: var(--color-text-tertiary);
+  transform: translateX(-50%);
+  white-space: nowrap;
+}

--- a/src/components/CIVisualization.css
+++ b/src/components/CIVisualization.css
@@ -1,12 +1,12 @@
 .ci-viz {
   --ee-pos-bar-fill: rgba(36, 57, 107, 0.08);
   --ee-pos-bar-border: rgba(36, 57, 107, 0.2);
-  --ee-neg-bar-fill: rgba(120, 40, 40, 0.06);
-  --ee-neg-bar-border: rgba(120, 40, 40, 0.18);
+  --ee-neg-bar-fill: rgba(185, 28, 28, 0.08);
+  --ee-neg-bar-border: rgba(185, 28, 28, 0.18);
   --ee-ns-bar-fill: rgba(154, 74, 18, 0.08);
   --ee-ns-bar-border: rgba(154, 74, 18, 0.18);
   --ee-pos-dot: #24396b;
-  --ee-neg-dot: #6b2020;
+  --ee-neg-dot: var(--color-estimate-neg);
   --ee-ns-dot: var(--color-text-tertiary);
 
   position: relative;

--- a/src/components/CIVisualization.tsx
+++ b/src/components/CIVisualization.tsx
@@ -1,0 +1,89 @@
+import "./CIVisualization.css";
+
+export type Significance = "pos" | "neg" | "ns";
+
+interface CIVisualizationProps {
+  pointEstimate?: number;
+  ciLower?: number;
+  ciUpper?: number;
+  significance: Significance;
+}
+
+/**
+ * Pick a symmetric axis [-axisMax, axisMax] that contains zero plus the data.
+ * Returns five evenly-spaced ticks: [-axisMax, -axisMax/2, 0, axisMax/2, axisMax].
+ */
+function pickAxis(values: number[]): { axisMax: number; ticks: number[] } {
+  const maxAbs = values.length === 0 ? 1 : Math.max(...values.map(Math.abs));
+  const axisMax = Math.max(0.5, Math.ceil(maxAbs * 2) / 2);
+  return {
+    axisMax,
+    ticks: [-axisMax, -axisMax / 2, 0, axisMax / 2, axisMax],
+  };
+}
+
+function pct(value: number, axisMax: number): number {
+  const clamped = Math.max(-axisMax, Math.min(axisMax, value));
+  return ((clamped + axisMax) / (2 * axisMax)) * 100;
+}
+
+function formatTick(t: number): string {
+  if (t === 0) return "0";
+  const abs = Math.abs(t).toFixed(1);
+  return t < 0 ? `−${abs}` : abs;
+}
+
+export function CIVisualization({
+  pointEstimate,
+  ciLower,
+  ciUpper,
+  significance,
+}: CIVisualizationProps) {
+  const present = [pointEstimate, ciLower, ciUpper].filter(
+    (n): n is number => typeof n === "number",
+  );
+  if (present.length === 0) return null;
+
+  const { axisMax, ticks } = pickAxis(present);
+  const lo = ciLower ?? pointEstimate;
+  const hi = ciUpper ?? pointEstimate;
+  const hasCi = typeof ciLower === "number" && typeof ciUpper === "number";
+
+  return (
+    <div class={`ci-viz ci-viz--${significance}`}>
+      <div class="ci-viz__inner">
+        <div class="ci-viz__zero-label" style={{ left: `${pct(0, axisMax)}%` }}>
+          0
+        </div>
+        <div class="ci-viz__track" />
+        <div class="ci-viz__zero" style={{ left: `${pct(0, axisMax)}%` }} />
+        {hasCi && lo !== undefined && hi !== undefined && (
+          <div
+            class="ci-viz__bar"
+            style={{
+              left: `${pct(lo, axisMax)}%`,
+              width: `${pct(hi, axisMax) - pct(lo, axisMax)}%`,
+            }}
+          />
+        )}
+        {typeof pointEstimate === "number" && (
+          <div
+            class="ci-viz__dot"
+            style={{ left: `${pct(pointEstimate, axisMax)}%` }}
+          />
+        )}
+        <div class="ci-viz__scale" aria-hidden="true">
+          {ticks.map((t) => (
+            <span
+              key={t}
+              class="ci-viz__tick"
+              style={{ left: `${pct(t, axisMax)}%` }}
+            >
+              {formatTick(t)}
+            </span>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/EffectEstimateCard.css
+++ b/src/components/EffectEstimateCard.css
@@ -1,0 +1,100 @@
+.ee-card {
+  background: var(--color-bg-inset);
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  padding: 22px 26px;
+  margin: 16px 0 12px;
+}
+
+.ee-card__label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-text-tertiary);
+  margin: 0 0 14px;
+}
+
+.ee-card__headline {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin-bottom: 6px;
+}
+
+.ee-card__estimate {
+  font-family: var(--font-mono);
+  font-size: 30px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
+
+.ee-card__estimate--pos {
+  color: var(--color-text-primary);
+}
+.ee-card__estimate--neg {
+  color: #6b2020;
+}
+.ee-card__estimate--ns {
+  color: var(--color-text-secondary);
+}
+
+.ee-card__metric {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+}
+
+.ee-card__se {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--color-text-tertiary);
+}
+
+.ee-card__ci {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  color: var(--color-text-secondary);
+  margin-bottom: 4px;
+}
+
+.ee-card__ci-bracket {
+  color: var(--color-text-tertiary);
+}
+
+.ee-card__source {
+  font-size: 12px;
+  color: var(--color-text-tertiary);
+  font-style: italic;
+  margin: var(--spacing-xs) 0 0;
+}
+
+.ee-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+  margin-top: var(--spacing-sm);
+}
+
+/* Ghost-outlined adjustment indicator (matches the prototype's .pill styling
+   in the klim-b override: transparent fill, strong border). */
+.ee-card__tag {
+  font-family: var(--font-body);
+  font-size: 12px;
+  font-weight: 500;
+  background: transparent;
+  border: 1px solid var(--color-border-strong);
+  border-radius: 3px;
+  padding: 3px 8px;
+  color: var(--color-text-secondary);
+}
+
+.ee-card__not-clustering {
+  font-size: 12px;
+  color: var(--color-text-tertiary);
+  margin: var(--spacing-xs) 0 0;
+}

--- a/src/components/EffectEstimateCard.css
+++ b/src/components/EffectEstimateCard.css
@@ -33,13 +33,13 @@
 }
 
 .ee-card__estimate--pos {
-  color: var(--color-text-primary);
+  color: var(--color-accent);
 }
 .ee-card__estimate--neg {
-  color: #6b2020;
+  color: var(--color-estimate-neg);
 }
 .ee-card__estimate--ns {
-  color: var(--color-text-secondary);
+  color: var(--color-text-tertiary);
 }
 
 .ee-card__metric {

--- a/src/components/EffectEstimateCard.tsx
+++ b/src/components/EffectEstimateCard.tsx
@@ -1,0 +1,114 @@
+import { CIVisualization, type Significance } from "./CIVisualization";
+import { ArmDataTable } from "./ArmDataTable";
+import type {
+  ArmData,
+  ControlConditionData,
+  EffectEstimateData,
+  InterventionData,
+} from "@/types/investigation";
+import "./EffectEstimateCard.css";
+
+interface EffectEstimateCardProps {
+  estimate: EffectEstimateData;
+  arms: ArmData[];
+  intervention: InterventionData | null;
+  control: ControlConditionData | null;
+}
+
+export function classifyEstimate(estimate: EffectEstimateData): Significance {
+  const { ciLower, ciUpper } = estimate;
+  if (typeof ciLower !== "number" || typeof ciUpper !== "number") return "ns";
+  if (ciLower > 0 && ciUpper > 0) return "pos";
+  if (ciLower < 0 && ciUpper < 0) return "neg";
+  return "ns";
+}
+
+function fmt2(n: number): string {
+  const fixed = Math.abs(n).toFixed(2);
+  return n < 0 ? `−${fixed}` : fixed;
+}
+
+function fmt3(n: number): string {
+  return n.toFixed(3);
+}
+
+function fmtCi(n: number): string {
+  // CI text uses ASCII minus for clean bracket reading
+  return n.toFixed(2);
+}
+
+export function EffectEstimateCard({
+  estimate,
+  arms,
+  intervention,
+  control,
+}: EffectEstimateCardProps) {
+  const significance = classifyEstimate(estimate);
+  const {
+    pointEstimate,
+    standardError,
+    ciLower,
+    ciUpper,
+    effectSizeMetric,
+    baselineAdjusted,
+    clusteringAdjusted,
+  } = estimate;
+
+  const metricLabel = effectSizeMetric?.label;
+  const sourceLabel = estimate.estimateSource?.label;
+  const showAdjustmentRow = baselineAdjusted === true;
+  const showNotClustering = clusteringAdjusted === "no";
+  const ciPrefix =
+    typeof estimate.confidenceLevel === "number"
+      ? `${Math.round(estimate.confidenceLevel * 100)}% CI`
+      : "CI";
+
+  return (
+    <div class="ee-card">
+      <h4 class="ee-card__label">Effect estimate</h4>
+
+      <div class="ee-card__headline">
+        {typeof pointEstimate === "number" ? (
+          <span class={`ee-card__estimate ee-card__estimate--${significance}`}>
+            {fmt2(pointEstimate)}
+          </span>
+        ) : (
+          <span class="ee-card__estimate ee-card__estimate--ns">—</span>
+        )}
+        {metricLabel && <span class="ee-card__metric">{metricLabel}</span>}
+        {typeof standardError === "number" && (
+          <span class="ee-card__se">SE = {fmt3(standardError)}</span>
+        )}
+      </div>
+
+      {typeof ciLower === "number" && typeof ciUpper === "number" && (
+        <div class="ee-card__ci">
+          {ciPrefix} <span class="ee-card__ci-bracket">[</span>
+          {fmtCi(ciLower)}, {fmtCi(ciUpper)}
+          <span class="ee-card__ci-bracket">]</span>
+        </div>
+      )}
+
+      {sourceLabel && <p class="ee-card__source">{sourceLabel}</p>}
+
+      <CIVisualization
+        pointEstimate={pointEstimate}
+        ciLower={ciLower}
+        ciUpper={ciUpper}
+        significance={significance}
+      />
+
+      {showAdjustmentRow && (
+        <div class="ee-card__tags">
+          <span class="ee-card__tag">Baseline adjusted</span>
+        </div>
+      )}
+
+      {showNotClustering && (
+        <p class="ee-card__not-clustering">Not clustering adjusted</p>
+      )}
+
+      <ArmDataTable arms={arms} intervention={intervention} control={control} />
+    </div>
+  );
+}

--- a/src/components/EffectEstimateCard.tsx
+++ b/src/components/EffectEstimateCard.tsx
@@ -105,7 +105,7 @@ export function EffectEstimateCard({
       )}
 
       {showNotClustering && (
-        <p class="ee-card__not-clustering">Not clustering adjusted</p>
+        <p class="ee-card__not-clustering">Not adjusted for clustering</p>
       )}
 
       <ArmDataTable arms={arms} intervention={intervention} control={control} />

--- a/src/components/FindingCard.tsx
+++ b/src/components/FindingCard.tsx
@@ -3,12 +3,29 @@ import { InterventionDetails } from "./InterventionDetails";
 import { ContextDetails } from "./ContextDetails";
 import { SampleDetails } from "./SampleDetails";
 import { OutcomeDetails } from "./OutcomeDetails";
-import type { FindingData } from "@/types/investigation";
+import { EffectEstimateCard } from "./EffectEstimateCard";
+import type {
+  ArmData,
+  EffectEstimateData,
+  FindingData,
+} from "@/types/investigation";
 import "./ComparisonRow.css";
 import "./InterventionDetails.css";
 import "./SampleDetails.css";
 import "./OutcomeDetails.css";
 import "./FindingCard.css";
+
+function armsForEstimate(
+  estimate: EffectEstimateData,
+  arms: ArmData[] | undefined,
+): ArmData[] {
+  if (!arms || arms.length === 0) return [];
+  if (!estimate.derivedFromIds || estimate.derivedFromIds.length === 0) {
+    return arms;
+  }
+  const ids = new Set(estimate.derivedFromIds);
+  return arms.filter((a) => ids.has(a.id));
+}
 
 interface FindingCardProps {
   finding: FindingData;
@@ -45,6 +62,8 @@ export function FindingCard({
 }: FindingCardProps) {
   const { intervention, control, context, outcome } = finding;
   const showSample = hasSampleData(finding);
+  const estimates = finding.effectEstimates ?? [];
+  const showOutcomeSection = Boolean(outcome) || estimates.length > 0;
 
   return (
     <article class="finding-card lg-card">
@@ -82,16 +101,27 @@ export function FindingCard({
         </>
       )}
 
-      {outcome && (
+      {showOutcomeSection && (
         <div class="finding-card__section">
           {!isShared && <hr class="finding-card__divider lg-divider" />}
           <h3 class="finding-card__section-label lg-section-label">Outcome</h3>
-          <OutcomeDetails
-            outcome={outcome}
-            labels={labels}
-            broader={broader}
-            definitions={definitions}
-          />
+          {outcome && (
+            <OutcomeDetails
+              outcome={outcome}
+              labels={labels}
+              broader={broader}
+              definitions={definitions}
+            />
+          )}
+          {estimates.map((estimate, i) => (
+            <EffectEstimateCard
+              key={`ee-${i}`}
+              estimate={estimate}
+              arms={armsForEstimate(estimate, finding.arms)}
+              intervention={intervention}
+              control={control}
+            />
+          ))}
         </div>
       )}
 

--- a/src/services/investigationParser.ts
+++ b/src/services/investigationParser.ts
@@ -10,6 +10,8 @@ import type {
   ContextData,
   OutcomeData,
   FindingData,
+  EffectEstimateData,
+  ArmData,
 } from "@/types/investigation";
 
 type Dict = Record<string, unknown>;
@@ -246,6 +248,65 @@ function parseContext(
   };
 }
 
+function getIdRef(v: unknown): string | undefined {
+  if (typeof v === "string") return v;
+  if (isDict(v) && typeof v["@id"] === "string") return v["@id"] as string;
+  return undefined;
+}
+
+function resolveConceptRef(
+  v: unknown,
+  prefixes: Map<string, string>,
+  labels: Map<string, string>,
+): ResolvedConcept | undefined {
+  const id = getIdRef(v);
+  if (!id) return undefined;
+  const uri = expandCompactUri(id, prefixes);
+  return { uri, label: labels.get(uri) };
+}
+
+function parseArm(node: Dict): ArmData {
+  const numField = (key: string) => resolveNumericValue(node[key]);
+  return {
+    id: getString(node["@id"]) ?? "",
+    conditionRef: getIdRef(node["forCondition"]),
+    n: numField("n"),
+    mean: numField("mean"),
+    sd: numField("sd"),
+    se: numField("se"),
+    preMean: numField("preMean"),
+    preSd: numField("preSd"),
+    clusterCount: numField("clusterCount"),
+    icc: numField("icc"),
+    events: numField("events"),
+  };
+}
+
+function parseEffectEstimate(
+  node: Dict,
+  prefixes: Map<string, string>,
+  labels: Map<string, string>,
+): EffectEstimateData {
+  const derivedFromIds = ensureArray(node["derivedFrom"])
+    .map(getIdRef)
+    .filter((s): s is string => s !== undefined);
+  return {
+    pointEstimate: resolveNumericValue(node["pointEstimate"]),
+    standardError: resolveNumericValue(node["standardError"]),
+    confidenceLevel: resolveNumericValue(node["confidenceLevel"]),
+    ciLower: resolveNumericValue(node["confidenceIntervalLower"]),
+    ciUpper: resolveNumericValue(node["confidenceIntervalUpper"]),
+    effectSizeMetric: resolveConceptRef(node["effectSizeMetric"], prefixes, labels),
+    estimateSource: resolveConceptRef(node["estimateSource"], prefixes, labels),
+    baselineAdjusted:
+      typeof node["baselineAdjusted"] === "boolean"
+        ? (node["baselineAdjusted"] as boolean)
+        : undefined,
+    clusteringAdjusted: resolveStringValue(node["clusteringAdjusted"]),
+    derivedFromIds: derivedFromIds.length > 0 ? derivedFromIds : undefined,
+  };
+}
+
 function parseOutcome(
   node: Dict,
   prefixes: Map<string, string>,
@@ -303,6 +364,11 @@ function parseSingleFinding(
     labels,
   );
 
+  const arms = ensureArray(raw["hasArmData"]).filter(isDict).map(parseArm);
+  const effectEstimates = ensureArray(raw["hasEffectEstimate"])
+    .filter(isDict)
+    .map((n) => parseEffectEstimate(n, prefixes, labels));
+
   return {
     intervention: interv.data,
     interventionRef: interv.ref,
@@ -320,6 +386,8 @@ function parseSingleFinding(
       resolveStringAnnotation(n, prefixes),
     ),
     sampleFeatures: sampleFeatures.length > 0 ? sampleFeatures : undefined,
+    arms: arms.length > 0 ? arms : undefined,
+    effectEstimates: effectEstimates.length > 0 ? effectEstimates : undefined,
   };
 }
 

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -67,6 +67,7 @@
   --color-success: #198754;
   --color-warning: #ffc107;
   --color-warning-light: #fef3c7;
+  --color-estimate-neg: #6b2020;
 
   /* ── Colors: retracted state ── (unchanged — landed in PR #18) */
   --color-retracted-bg: #fef2f2;

--- a/src/types/investigation.ts
+++ b/src/types/investigation.ts
@@ -51,6 +51,37 @@ export interface OutcomeData {
   description?: string;
 }
 
+export interface ArmData {
+  id: string;
+  conditionRef?: string;
+  n?: number;
+  mean?: number;
+  sd?: number;
+  se?: number;
+  preMean?: number;
+  preSd?: number;
+  clusterCount?: number;
+  icc?: number;
+  events?: number;
+}
+
+export interface EffectEstimateData {
+  pointEstimate?: number;
+  standardError?: number;
+  // Decimal in (0, 1], e.g. 0.95 → "95% CI". Don't assume 95% — the data
+  // may omit it, in which case the CI text renders without a percentage.
+  confidenceLevel?: number;
+  ciLower?: number;
+  ciUpper?: number;
+  effectSizeMetric?: ResolvedConcept;
+  // Provenance, e.g. "Computed from summary statistics".
+  estimateSource?: ResolvedConcept;
+  baselineAdjusted?: boolean;
+  // ESEA context types this as xsd:string with values "yes" / "no".
+  clusteringAdjusted?: string;
+  derivedFromIds?: string[];
+}
+
 export interface FindingData {
   intervention: InterventionData | null;
   interventionRef?: string;
@@ -64,6 +95,8 @@ export interface FindingData {
   cost?: StringAnnotation;
   groupDifferences?: StringAnnotation;
   sampleFeatures?: CodedAnnotation<ResolvedConcept>[];
+  effectEstimates?: EffectEstimateData[];
+  arms?: ArmData[];
 }
 
 export interface InvestigationData {

--- a/tests/components/ArmDataTable.test.tsx
+++ b/tests/components/ArmDataTable.test.tsx
@@ -1,0 +1,83 @@
+import { describe, test, expect } from "vitest";
+import { render, screen } from "@testing-library/preact";
+import { ArmDataTable } from "@/components/ArmDataTable";
+import { makeArm } from "../fixtures";
+
+const intervention = { id: "_:int", name: "Vanguard program" };
+const control = { id: "_:ctrl", description: "Business as usual" };
+
+describe("ArmDataTable", () => {
+  test("renders nothing when arms array is empty", () => {
+    const { container } = render(
+      <ArmDataTable arms={[]} intervention={intervention} control={control} />,
+    );
+    expect(container.querySelector(".arm-data")).toBeNull();
+  });
+
+  test("only renders columns that have at least one populated value", () => {
+    const { container } = render(
+      <ArmDataTable
+        arms={[
+          makeArm({ id: "_:armI", conditionRef: "_:int", n: 222 }),
+          makeArm({ id: "_:armC", conditionRef: "_:ctrl", n: 222 }),
+        ]}
+        intervention={intervention}
+        control={control}
+      />,
+    );
+    const headers = Array.from(
+      container.querySelectorAll(".arm-data__header"),
+    ).map((h) => h.textContent);
+    expect(headers).toContain("Arm");
+    expect(headers).toContain("n");
+    expect(headers).not.toContain("Mean");
+    expect(headers).not.toContain("SD");
+  });
+
+  test("resolves intervention/control labels via conditionRef", () => {
+    render(
+      <ArmDataTable
+        arms={[
+          makeArm({ id: "_:armI", conditionRef: "_:int", n: 100 }),
+          makeArm({ id: "_:armC", conditionRef: "_:ctrl", n: 100 }),
+        ]}
+        intervention={intervention}
+        control={control}
+      />,
+    );
+    expect(screen.getByText("Vanguard program")).toBeDefined();
+    expect(screen.getByText("Control")).toBeDefined();
+  });
+
+  test("falls back to 'Arm N' label when conditionRef does not match", () => {
+    render(
+      <ArmDataTable
+        arms={[makeArm({ id: "_:armX", conditionRef: "_:other", n: 50 })]}
+        intervention={intervention}
+        control={control}
+      />,
+    );
+    expect(screen.getByText("Arm 1")).toBeDefined();
+  });
+
+  test("renders mean/sd cells when those fields are populated", () => {
+    render(
+      <ArmDataTable
+        arms={[
+          makeArm({
+            id: "_:armI",
+            conditionRef: "_:int",
+            n: 30,
+            mean: 12.5,
+            sd: 2.1,
+          }),
+        ]}
+        intervention={intervention}
+        control={control}
+      />,
+    );
+    expect(screen.getByText("Mean")).toBeDefined();
+    expect(screen.getByText("12.5")).toBeDefined();
+    expect(screen.getByText("2.1")).toBeDefined();
+  });
+});

--- a/tests/components/CIVisualization.test.tsx
+++ b/tests/components/CIVisualization.test.tsx
@@ -1,0 +1,83 @@
+import { describe, test, expect } from "vitest";
+import { render } from "@testing-library/preact";
+import { CIVisualization } from "@/components/CIVisualization";
+
+describe("CIVisualization", () => {
+  test("renders nothing when no values provided", () => {
+    const { container } = render(<CIVisualization significance="ns" />);
+    expect(container.querySelector(".ci-viz")).toBeNull();
+  });
+
+  test("applies significance modifier class to root", () => {
+    const { container } = render(
+      <CIVisualization
+        pointEstimate={0.33}
+        ciLower={0.18}
+        ciUpper={0.48}
+        significance="pos"
+      />,
+    );
+    expect(container.querySelector(".ci-viz--pos")).not.toBeNull();
+  });
+
+  test("places point estimate dot at proportional offset", () => {
+    const { container } = render(
+      <CIVisualization
+        pointEstimate={0.5}
+        ciLower={0}
+        ciUpper={1}
+        significance="pos"
+      />,
+    );
+    // axisMax = 1; dot at 0.5 → 75% of axis [-1, 1]
+    const dot = container.querySelector(".ci-viz__dot") as HTMLElement;
+    expect(dot.style.left).toBe("75%");
+  });
+
+  test("CI bar spans from lower to upper as percentage offsets", () => {
+    const { container } = render(
+      <CIVisualization
+        pointEstimate={0}
+        ciLower={-0.5}
+        ciUpper={0.5}
+        significance="ns"
+      />,
+    );
+    const bar = container.querySelector(".ci-viz__bar") as HTMLElement;
+    // axisMax = 0.5; bar from 0% to 100%
+    expect(bar.style.left).toBe("0%");
+    expect(bar.style.width).toBe("100%");
+  });
+
+  test("renders five tick labels including 0", () => {
+    const { container } = render(
+      <CIVisualization
+        pointEstimate={0.3}
+        ciLower={0.1}
+        ciUpper={0.5}
+        significance="pos"
+      />,
+    );
+    const ticks = container.querySelectorAll(".ci-viz__tick");
+    expect(ticks).toHaveLength(5);
+    const labels = Array.from(ticks).map((t) => t.textContent);
+    expect(labels).toContain("0");
+  });
+
+  test("scale expands when CI exceeds [-1, 1]", () => {
+    const { container } = render(
+      <CIVisualization
+        pointEstimate={1.2}
+        ciLower={0.8}
+        ciUpper={1.6}
+        significance="pos"
+      />,
+    );
+    const ticks = Array.from(
+      container.querySelectorAll(".ci-viz__tick"),
+    ).map((t) => t.textContent);
+    // axisMax = 2.0 -> outer ticks "2.0" / "−2.0"
+    expect(ticks).toContain("2.0");
+    expect(ticks).toContain("−2.0");
+  });
+});

--- a/tests/components/EffectEstimateCard.test.tsx
+++ b/tests/components/EffectEstimateCard.test.tsx
@@ -94,11 +94,11 @@ describe("EffectEstimateCard", () => {
     expect(screen.queryByText("Baseline adjusted")).toBeNull();
   });
 
-  test("Not clustering adjusted text only when clusteringAdjusted === 'no'", () => {
+  test("Not adjusted for clustering text only when clusteringAdjusted === 'no'", () => {
     const { rerender } = renderCard(
       makeEffectEstimate({ clusteringAdjusted: "no" }),
     );
-    expect(screen.getByText("Not clustering adjusted")).toBeDefined();
+    expect(screen.getByText("Not adjusted for clustering")).toBeDefined();
 
     rerender(
       <EffectEstimateCard
@@ -108,7 +108,7 @@ describe("EffectEstimateCard", () => {
         control={control}
       />,
     );
-    expect(screen.queryByText("Not clustering adjusted")).toBeNull();
+    expect(screen.queryByText("Not adjusted for clustering")).toBeNull();
   });
 
   test("renders ArmDataTable when arms present", () => {

--- a/tests/components/EffectEstimateCard.test.tsx
+++ b/tests/components/EffectEstimateCard.test.tsx
@@ -1,0 +1,134 @@
+import { describe, test, expect } from "vitest";
+import { render, screen } from "@testing-library/preact";
+import {
+  EffectEstimateCard,
+  classifyEstimate,
+} from "@/components/EffectEstimateCard";
+import { makeArm, makeEffectEstimate } from "../fixtures";
+
+const intervention = { id: "_:int", name: "Vanguard program" };
+const control = { id: "_:ctrl", description: "Business as usual" };
+
+function renderCard(
+  estimate = makeEffectEstimate(),
+  arms = [] as ReturnType<typeof makeArm>[],
+) {
+  return render(
+    <EffectEstimateCard
+      estimate={estimate}
+      arms={arms}
+      intervention={intervention}
+      control={control}
+    />,
+  );
+}
+
+describe("classifyEstimate", () => {
+  test("positive significant when both CI bounds > 0", () => {
+    expect(classifyEstimate({ ciLower: 0.1, ciUpper: 0.5 })).toBe("pos");
+  });
+  test("negative significant when both CI bounds < 0", () => {
+    expect(classifyEstimate({ ciLower: -0.5, ciUpper: -0.1 })).toBe("neg");
+  });
+  test("non-significant when CI crosses zero", () => {
+    expect(classifyEstimate({ ciLower: -0.1, ciUpper: 0.3 })).toBe("ns");
+  });
+  test("non-significant when CI bound is exactly zero", () => {
+    expect(classifyEstimate({ ciLower: 0, ciUpper: 0.3 })).toBe("ns");
+  });
+  test("non-significant when CI bounds missing", () => {
+    expect(classifyEstimate({ pointEstimate: 0.3 })).toBe("ns");
+  });
+});
+
+describe("EffectEstimateCard", () => {
+  test("renders point estimate with metric and SE", () => {
+    renderCard();
+    expect(screen.getByText("0.33")).toBeDefined();
+    expect(screen.getByText("Hedges' g")).toBeDefined();
+    expect(screen.getByText("SE = 0.078")).toBeDefined();
+    expect(screen.getByText(/0.18, 0.48/)).toBeDefined();
+  });
+
+  test("renders negative point estimate with U+2212 minus and applies neg class", () => {
+    const { container } = renderCard(
+      makeEffectEstimate({
+        pointEstimate: -0.48,
+        ciLower: -0.67,
+        ciUpper: -0.29,
+        standardError: 0.096,
+      }),
+    );
+    expect(screen.getByText("−0.48")).toBeDefined();
+    const estimate = container.querySelector(".ee-card__estimate");
+    expect(estimate?.classList.contains("ee-card__estimate--neg")).toBe(true);
+  });
+
+  test("CI crossing zero renders ns classifier on point estimate", () => {
+    const { container } = renderCard(
+      makeEffectEstimate({
+        pointEstimate: 0.05,
+        ciLower: -0.1,
+        ciUpper: 0.2,
+        standardError: 0.05,
+      }),
+    );
+    const estimate = container.querySelector(".ee-card__estimate");
+    expect(estimate?.classList.contains("ee-card__estimate--ns")).toBe(true);
+  });
+
+  test("Baseline adjusted tag visible only when baselineAdjusted is true", () => {
+    const { rerender } = renderCard(
+      makeEffectEstimate({ baselineAdjusted: true }),
+    );
+    expect(screen.getByText("Baseline adjusted")).toBeDefined();
+
+    rerender(
+      <EffectEstimateCard
+        estimate={makeEffectEstimate({ baselineAdjusted: false })}
+        arms={[]}
+        intervention={intervention}
+        control={control}
+      />,
+    );
+    expect(screen.queryByText("Baseline adjusted")).toBeNull();
+  });
+
+  test("Not clustering adjusted text only when clusteringAdjusted === 'no'", () => {
+    const { rerender } = renderCard(
+      makeEffectEstimate({ clusteringAdjusted: "no" }),
+    );
+    expect(screen.getByText("Not clustering adjusted")).toBeDefined();
+
+    rerender(
+      <EffectEstimateCard
+        estimate={makeEffectEstimate({ clusteringAdjusted: "yes" })}
+        arms={[]}
+        intervention={intervention}
+        control={control}
+      />,
+    );
+    expect(screen.queryByText("Not clustering adjusted")).toBeNull();
+  });
+
+  test("renders ArmDataTable when arms present", () => {
+    renderCard(makeEffectEstimate(), [
+      makeArm({ id: "_:armI", conditionRef: "_:int", n: 222 }),
+      makeArm({ id: "_:armC", conditionRef: "_:ctrl", n: 222 }),
+    ]);
+    expect(screen.getByText("Vanguard program")).toBeDefined();
+    expect(screen.getByText("Control")).toBeDefined();
+  });
+
+  test("hides ArmDataTable when no arms", () => {
+    const { container } = renderCard(makeEffectEstimate(), []);
+    expect(container.querySelector(".arm-data")).toBeNull();
+  });
+
+  test("renders em-dash for missing point estimate", () => {
+    const { container } = renderCard(
+      makeEffectEstimate({ pointEstimate: undefined }),
+    );
+    expect(container.querySelector(".ee-card__estimate")?.textContent).toBe("—");
+  });
+});

--- a/tests/components/FindingCard.test.tsx
+++ b/tests/components/FindingCard.test.tsx
@@ -2,7 +2,7 @@ import { describe, test, expect } from "vitest";
 import { render, screen } from "@testing-library/preact";
 import { FindingCard } from "@/components/FindingCard";
 import type { FindingData } from "@/types/investigation";
-import { makeRichFinding } from "../fixtures";
+import { makeArm, makeEffectEstimate, makeRichFinding } from "../fixtures";
 
 function renderCard(opts: { finding?: Partial<FindingData>; isShared?: boolean } = {}) {
   return render(
@@ -43,5 +43,25 @@ describe("FindingCard", () => {
     expect(
       screen.getByText(/Same intervention, control, and context as above/),
     ).toBeDefined();
+  });
+
+  test("renders effect estimate inset and arm rows when provided", () => {
+    renderCard({
+      finding: {
+        effectEstimates: [
+          makeEffectEstimate({ derivedFromIds: ["_:armI", "_:armC"] }),
+        ],
+        arms: [
+          makeArm({ id: "_:armI", conditionRef: "_:int", n: 222 }),
+          makeArm({ id: "_:armC", conditionRef: "_:ctrl", n: 222 }),
+        ],
+      },
+    });
+    expect(screen.getByText("0.33")).toBeDefined();
+    expect(screen.getByText("Hedges' g")).toBeDefined();
+    // "Test Intervention" appears in both ComparisonRow and the arm table.
+    // "Control" appears as the ComparisonRow label and the arm row name.
+    expect(screen.getAllByText("Test Intervention").length).toBe(2);
+    expect(screen.getAllByText("Control").length).toBe(2);
   });
 });

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -1,6 +1,8 @@
 import type {
+  ArmData,
   ContextData,
   ControlConditionData,
+  EffectEstimateData,
   FindingData,
   InterventionData,
 } from "@/types/investigation";
@@ -59,6 +61,32 @@ export function makeRichFinding(overrides: Partial<FindingData> = {}): FindingDa
       outcomes: [{ value: { uri: "u:2", label: "Basic Skills" } }],
     },
     sampleSize: { value: 50 },
+    ...overrides,
+  };
+}
+
+/** Default effect estimate: positive significant Hedges' g. */
+export function makeEffectEstimate(
+  overrides: Partial<EffectEstimateData> = {},
+): EffectEstimateData {
+  return {
+    pointEstimate: 0.33,
+    standardError: 0.078,
+    ciLower: 0.18,
+    ciUpper: 0.48,
+    effectSizeMetric: { uri: "evrepo:HEDGES_G", label: "Hedges' g" },
+    baselineAdjusted: true,
+    clusteringAdjusted: "no",
+    ...overrides,
+  };
+}
+
+/** Default arm: bound to the matching makeFinding intervention by default. */
+export function makeArm(overrides: Partial<ArmData> = {}): ArmData {
+  return {
+    id: "_:armI",
+    conditionRef: "_:int",
+    n: 222,
     ...overrides,
   };
 }

--- a/tests/services/investigationParser.test.ts
+++ b/tests/services/investigationParser.test.ts
@@ -425,6 +425,128 @@ describe("parseInvestigation", () => {
     expect(result.findings[1].sampleSize?.value).toBe(47);
   });
 
+  test("parses effect estimates with CI bounds, metric, and adjustment flags", () => {
+    const labels = new Map([
+      ...LABELS,
+      ["https://vocab.evidence-repository.org/HEDGES_G", "Hedges' g"],
+      [
+        "https://vocab.evidence-repository.org/COMPUTED",
+        "Computed from summary statistics",
+      ],
+    ]);
+    const data = makeData({
+      hasFinding: [
+        {
+          "@type": "Finding",
+          hasArmData: [
+            {
+              "@id": "_:armI",
+              "@type": "ObservedResult",
+              forCondition: "_:int",
+              n: 222,
+            },
+            {
+              "@id": "_:armC",
+              "@type": "ObservedResult",
+              forCondition: "_:ctrl",
+              n: 222,
+            },
+          ],
+          hasEffectEstimate: [
+            {
+              "@type": "EffectEstimate",
+              pointEstimate: -0.48,
+              standardError: 0.096,
+              confidenceIntervalLower: -0.67,
+              confidenceIntervalUpper: -0.29,
+              effectSizeMetric: "evrepo:HEDGES_G",
+              estimateSource: "evrepo:COMPUTED",
+              baselineAdjusted: true,
+              clusteringAdjusted: "no",
+              derivedFrom: ["_:armI", "_:armC"],
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = parseInvestigation(data, PREFIXES, labels);
+    const finding = result.findings[0];
+
+    expect(finding.effectEstimates).toHaveLength(1);
+    const ee = finding.effectEstimates![0];
+    expect(ee.pointEstimate).toBe(-0.48);
+    expect(ee.standardError).toBe(0.096);
+    expect(ee.ciLower).toBe(-0.67);
+    expect(ee.ciUpper).toBe(-0.29);
+    expect(ee.effectSizeMetric?.label).toBe("Hedges' g");
+    expect(ee.estimateSource?.label).toBe("Computed from summary statistics");
+    expect(ee.baselineAdjusted).toBe(true);
+    expect(ee.clusteringAdjusted).toBe("no");
+    expect(ee.derivedFromIds).toEqual(["_:armI", "_:armC"]);
+
+    expect(finding.arms).toHaveLength(2);
+    expect(finding.arms![0]).toMatchObject({
+      id: "_:armI",
+      conditionRef: "_:int",
+      n: 222,
+    });
+  });
+
+  test("parses sparse arm data: only n populated, other fields undefined", () => {
+    const data = makeData({
+      hasFinding: [
+        {
+          "@type": "Finding",
+          hasArmData: [
+            {
+              "@id": "_:armI",
+              "@type": "ObservedResult",
+              forCondition: "_:int",
+              n: 50,
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = parseInvestigation(data, PREFIXES, LABELS);
+    const arm = result.findings[0].arms![0];
+    expect(arm.n).toBe(50);
+    expect(arm.mean).toBeUndefined();
+    expect(arm.sd).toBeUndefined();
+    expect(arm.se).toBeUndefined();
+  });
+
+  test("handles forCondition as object reference with @id", () => {
+    const data = makeData({
+      hasFinding: [
+        {
+          "@type": "Finding",
+          hasArmData: [
+            {
+              "@id": "_:armI",
+              "@type": "ObservedResult",
+              forCondition: { "@id": "_:int" },
+              n: 12,
+            },
+          ],
+        },
+      ],
+    });
+    const result = parseInvestigation(data, PREFIXES, LABELS);
+    expect(result.findings[0].arms![0].conditionRef).toBe("_:int");
+  });
+
+  test("findings without effect estimates or arms leave fields undefined", () => {
+    const data = makeData({
+      hasFinding: [{ "@type": "Finding" }],
+    });
+    const result = parseInvestigation(data, PREFIXES, LABELS);
+    expect(result.findings[0].effectEstimates).toBeUndefined();
+    expect(result.findings[0].arms).toBeUndefined();
+  });
+
   test("returns undefined label when concept not in vocabulary", () => {
     const data = makeData({
       documentType: {


### PR DESCRIPTION
Closes #10.

## Summary

Renders an EFFECT ESTIMATE inset inside each finding's outcome section, plus an ARM DATA table populated from `derivedFrom`. Layout and typography follow the [klim-b prototype](https://taxonomy-prototype.pages.dev/demo/investigation-klim-b) and the design-spec comment on #10.

<img width="865" height="941" alt="Screenshot 2026-05-01 at 6 24 23 PM" src="https://github.com/user-attachments/assets/f308395f-3808-4a6f-a279-c055e365086b" />

## Highlights

- `classifyEstimate` decides pos/neg/ns from CI bounds (sign, exclusive of zero); exported and unit-tested separately so other surfaces can reuse it.
- `CIVisualization` places track, zero line, bar, dot, and tick labels in one shared percentage coord system inside a 20px-inset inner box, so axis-aligned elements stay pixel-aligned.
- Parser tolerates both `"_:armI"` and `{"@id": "_:armI"}` for `forCondition` / `derivedFrom`; arm/condition resolution is deferred to the renderer where the finding's own intervention/control IDs are available.
- `ArmDataTable` hides columns no arm populates, and falls back to rendering all finding arms when `derivedFrom` is absent.
- Adjustment tag follows the klim-b `.pill` ghost style; non-significant CI tint is the prototype's warm `rgba(154, 74, 18, …)`, kept component-local rather than promoted to a global token.
- `EffectEstimateData` only carries fields with a current consumer. `variance` and `forOutcome` were intentionally left unsurfaced.

## Test plan

- [x] `npm run typecheck`, `npm test` (298 pass; 26 new)
- [x] Visual smoke against seeded `…0010` record covers pos / neg / ns classifiers, sparse vs. full arm columns, present / absent `confidenceLevel` and `estimateSource`