### PR TITLE
Issue #30: concept pills and real findings/estimates counts on search rows

### DIFF
--- a/src/components/search/ResultRow.css
+++ b/src/components/search/ResultRow.css
@@ -5,7 +5,9 @@
   position: relative;
   display: grid;
   grid-template-columns: 1fr auto;
-  gap: 20px;
+  /* Row-gap is 0 so .row-pills can sit directly under the abstract; the
+     column-gap stays 20px between the row-link and the right column. */
+  gap: 0 20px;
   padding: 18px 24px;
   background: var(--color-bg-surface);
   border-bottom: 1px solid var(--color-border);
@@ -22,6 +24,8 @@
 
 .result-row:last-of-type {
   border-bottom: none;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
 }
 
 /* Stretched-link anchor: the ::before extends across the whole row so
@@ -75,7 +79,7 @@
   font-size: 13px;
   font-style: italic;
   color: var(--color-text-tertiary);
-  margin-bottom: 8px;
+  margin-bottom: 10px;
 }
 
 .row-abstract {
@@ -88,6 +92,7 @@
   font-size: 13px;
   line-height: 1.55;
   color: var(--color-text-secondary);
+  margin-bottom: 10px;
 }
 
 .row-coder {
@@ -128,9 +133,8 @@
   text-decoration: underline;
 }
 
-/* Stat badges are placeholders for findings/estimates counts (deferred per
-   re-spec; see plan section "Deferred to follow-ups"). klim-b override:
-   transparent bg + bordered, sharper 3px corners. */
+/* Stat badges show findings/estimates counts pulled from the reference's
+   linked-data enhancement (or `—` when none). */
 .stat-badge {
   display: inline-flex;
   align-items: center;
@@ -149,4 +153,22 @@
   font-weight: 600;
   font-size: var(--font-size-mono-sm);
   color: var(--color-text-primary);
+}
+
+/* `pointer-events: none` lets clicks in the gaps between pills fall through
+   to the stretched-link overlay, so the row stays clickable. Individual
+   pills re-enable pointer-events so their tooltip (`:hover`) still fires. */
+.row-pills {
+  position: relative;
+  z-index: 1;
+  grid-column: 1;
+  pointer-events: none;
+}
+
+.row-pills .tag-group__tag {
+  pointer-events: auto;
+}
+
+.tag-group__tag--more {
+  color: var(--color-text-tertiary);
 }

--- a/src/components/search/ResultRow.css
+++ b/src/components/search/ResultRow.css
@@ -157,12 +157,22 @@
 
 /* `pointer-events: none` lets clicks in the gaps between pills fall through
    to the stretched-link overlay, so the row stays clickable. Individual
-   pills re-enable pointer-events so their tooltip (`:hover`) still fires. */
+   pills re-enable pointer-events so their tooltip (`:hover`) still fires.
+   `display: contents` on the inner TagGroup lets the `+N more` pill share
+   the same wrap flow as the other tags. */
 .row-pills {
   position: relative;
   z-index: 1;
   grid-column: 1;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--spacing-sm);
   pointer-events: none;
+}
+
+.row-pills > .tag-group {
+  display: contents;
 }
 
 .row-pills .tag-group__tag {

--- a/src/components/search/ResultRow.tsx
+++ b/src/components/search/ResultRow.tsx
@@ -93,8 +93,8 @@ export function ResultRow({ communitySlug, reference }: ResultRowProps) {
       labels,
     );
     const concepts = aggregatePillConcepts(investigation);
-    // Search rows render flat pills (no parent breadcrumb) per the prototype,
-    // so we pass an empty `broader` map. Definitions still drive the tooltip.
+    // Flat pills (no parent breadcrumb) — pass an empty `broader` map.
+    // Definitions still drive the hover tooltip.
     return conceptsToTags(
       concepts,
       labels,
@@ -115,7 +115,14 @@ export function ResultRow({ communitySlug, reference }: ResultRowProps) {
   const findingsLabel = counts ? String(counts.findings) : "—";
   const estimatesLabel = counts ? String(counts.estimates) : "—";
 
-  const visibleTags = pillTags ? pillTags.slice(0, PILL_CAP) : [];
+  // If a single extra pill would be hidden behind "+1 more", just show it —
+  // the real estate is the same.
+  const showAllPills = pillTags !== null && pillTags.length <= PILL_CAP + 1;
+  const visibleTags = !pillTags
+    ? []
+    : showAllPills
+      ? pillTags
+      : pillTags.slice(0, PILL_CAP);
   const overflow = pillTags ? pillTags.length - visibleTags.length : 0;
 
   // Stretched-link pattern: the .row-link <a> wraps left-column content, and

--- a/src/components/search/ResultRow.tsx
+++ b/src/components/search/ResultRow.tsx
@@ -1,6 +1,23 @@
+import { useMemo } from "preact/hooks";
 import type { Reference } from "@/types/models";
-import { extractBibliographic, extractDoi, formatPagination } from "@/services/referenceUtils";
+import type {
+  CodedAnnotation,
+  InvestigationData,
+  ResolvedConcept,
+} from "@/types/investigation";
+import {
+  extractBibliographic,
+  extractDoi,
+  extractFindingsAndEstimatesCount,
+  extractLinkedData,
+  formatPagination,
+} from "@/services/referenceUtils";
 import { extractReferenceCodingInstitution } from "@/services/codingInstitution";
+import { parseInvestigation } from "@/services/investigationParser";
+import { conceptsToTags } from "@/services/conceptLabels";
+import { useVocabulary } from "@/hooks/useVocabulary";
+import { useContextPrefixes } from "@/hooks/useContextPrefixes";
+import { TagGroup } from "@/components/TagGroup";
 import "./ResultRow.css";
 
 interface ResultRowProps {
@@ -9,6 +26,7 @@ interface ResultRowProps {
 }
 
 const MAX_AUTHORS_SHOWN = 3;
+const PILL_CAP = 8;
 
 function formatAuthors(authors: { display_name: string }[]): string {
   if (authors.length === 0) return "";
@@ -26,10 +44,64 @@ function findAbstract(reference: Reference): string | null {
   return abs && abs.content.enhancement_type === "abstract" ? abs.content.abstract : null;
 }
 
+// Document type first, then per-finding context/intervention/outcome concepts
+// and sample features. De-duped by URI; insertion order preserved so the
+// document type pill leads.
+function aggregatePillConcepts(
+  inv: InvestigationData,
+): CodedAnnotation<ResolvedConcept>[] {
+  const seen = new Set<string>();
+  const out: CodedAnnotation<ResolvedConcept>[] = [];
+  const add = (a: CodedAnnotation<ResolvedConcept>) => {
+    const uri = a.value.uri;
+    if (uri && !seen.has(uri)) {
+      seen.add(uri);
+      out.push(a);
+    }
+  };
+  const addAll = (xs?: CodedAnnotation<ResolvedConcept>[]) => xs?.forEach(add);
+
+  if (inv.documentType) add(inv.documentType);
+  for (const f of inv.findings) {
+    addAll(f.context?.educationLevels);
+    addAll(f.context?.settings);
+    addAll(f.intervention?.educationThemes);
+    addAll(f.outcome?.outcomes);
+    addAll(f.sampleFeatures);
+  }
+  return out;
+}
+
 export function ResultRow({ communitySlug, reference }: ResultRowProps) {
   const bib = extractBibliographic(reference);
   const doi = extractDoi(reference.identifiers);
   const abstract = findAbstract(reference);
+  const counts = extractFindingsAndEstimatesCount(reference);
+
+  const linkedData = extractLinkedData(reference);
+  const rawContext = linkedData?.data?.["@context"];
+  const contextUrl = typeof rawContext === "string" ? rawContext : undefined;
+
+  const { labels, definitions } = useVocabulary(linkedData?.vocabulary_uri);
+  const { context } = useContextPrefixes(contextUrl);
+
+  const pillTags = useMemo(() => {
+    if (!linkedData?.data || !labels || !context) return null;
+    const investigation = parseInvestigation(
+      linkedData.data,
+      context.prefixes,
+      labels,
+    );
+    const concepts = aggregatePillConcepts(investigation);
+    // Search rows render flat pills (no parent breadcrumb) per the prototype,
+    // so we pass an empty `broader` map. Definitions still drive the tooltip.
+    return conceptsToTags(
+      concepts,
+      labels,
+      new Map(),
+      definitions ?? new Map(),
+    );
+  }, [linkedData, labels, definitions, context]);
 
   const title = bib?.title ?? reference.id;
   const authors = bib?.authorship ? formatAuthors(bib.authorship) : "";
@@ -39,6 +111,12 @@ export function ResultRow({ communitySlug, reference }: ResultRowProps) {
     ? String(bib.publication_year)
     : "";
   const codingInstitution = extractReferenceCodingInstitution(reference);
+
+  const findingsLabel = counts ? String(counts.findings) : "—";
+  const estimatesLabel = counts ? String(counts.estimates) : "—";
+
+  const visibleTags = pillTags ? pillTags.slice(0, PILL_CAP) : [];
+  const overflow = pillTags ? pillTags.length - visibleTags.length : 0;
 
   // Stretched-link pattern: the .row-link <a> wraps left-column content, and
   // its ::before extends a transparent overlay across the whole .result-row
@@ -79,10 +157,10 @@ export function ResultRow({ communitySlug, reference }: ResultRowProps) {
           </a>
         )}
         <span class="stat-badge">
-          <span class="stat-num">—</span> findings
+          <span class="stat-num">{findingsLabel}</span> findings
         </span>
         <span class="stat-badge">
-          <span class="stat-num">—</span> estimates
+          <span class="stat-num">{estimatesLabel}</span> estimates
         </span>
         {codingInstitution && (
           <span class="row-coder" data-testid="coder-text">
@@ -90,6 +168,16 @@ export function ResultRow({ communitySlug, reference }: ResultRowProps) {
           </span>
         )}
       </div>
+      {pillTags && pillTags.length > 0 && (
+        <div class="row-pills">
+          <TagGroup tags={visibleTags} />
+          {overflow > 0 && (
+            <span class="tag-group__tag tag-group__tag--more">
+              +{overflow} more
+            </span>
+          )}
+        </div>
+      )}
     </article>
   );
 }

--- a/src/components/search/ResultRow.tsx
+++ b/src/components/search/ResultRow.tsx
@@ -26,7 +26,7 @@ interface ResultRowProps {
 }
 
 const MAX_AUTHORS_SHOWN = 3;
-const PILL_CAP = 8;
+export const PILL_CAP = 8;
 
 function formatAuthors(authors: { display_name: string }[]): string {
   if (authors.length === 0) return "";

--- a/src/pages/SearchPage.css
+++ b/src/pages/SearchPage.css
@@ -37,7 +37,11 @@
   background: var(--color-bg-surface);
   border: 1px solid var(--color-border);
   border-radius: 4px;
-  overflow: hidden;
+  /* Intentionally NOT overflow: hidden — descendant overlays such as
+     TagGroup's tooltip ::after on result-row pills must escape this card.
+     Children with backgrounds round their own outer corners (see
+     `.search-results__meta`, `.result-row:last-of-type`, etc.) so the
+     rounded border still appears clean. */
 }
 
 .search-results__meta {
@@ -50,6 +54,8 @@
   color: var(--color-text-secondary);
   border-bottom: 1px solid var(--color-border);
   background: var(--color-bg-inset);
+  border-top-left-radius: inherit;
+  border-top-right-radius: inherit;
 }
 
 .search-results__meta-left {
@@ -89,6 +95,11 @@
 .search-results__skeleton {
   display: flex;
   flex-direction: column;
+}
+
+.search-results__skeleton-row:last-child {
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
 }
 
 .search-results__skeleton-row {

--- a/src/services/investigationParser.ts
+++ b/src/services/investigationParser.ts
@@ -1,4 +1,5 @@
 import { expandCompactUri } from "./vocabulary/contextService";
+import { isDict } from "./referenceUtils";
 import type {
   InvestigationData,
   CodedAnnotation,
@@ -15,10 +16,6 @@ import type {
 type Dict = Record<string, unknown>;
 
 const SKIP_STATUSES = ["notReported", "notApplicable"];
-
-function isDict(v: unknown): v is Dict {
-  return typeof v === "object" && v !== null && !Array.isArray(v);
-}
 
 function ensureArray(v: unknown): unknown[] {
   if (v === undefined || v === null) return [];

--- a/src/services/referenceUtils.ts
+++ b/src/services/referenceUtils.ts
@@ -7,6 +7,9 @@ import type {
   ExternalIdentifier,
   Pagination,
 } from "@/types/models";
+export function isDict(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
 
 export function extractLatestEnhancement<T extends EnhancementContent>(
   reference: Reference,
@@ -49,6 +52,30 @@ export function extractLinkedData(
   reference: Reference,
 ): LinkedDataEnhancement | null {
   return extractLinkedDataEnhancement(reference)?.content ?? null;
+}
+
+// Counts are read straight from raw JSON-LD so badges render on first paint
+// without waiting on vocabulary resolution. Returns null when the reference
+// has no linked-data enhancement, preserving the `—` fallback path.
+export function extractFindingsAndEstimatesCount(
+  reference: Reference,
+): { findings: number; estimates: number } | null {
+  const ld = extractLinkedData(reference);
+  if (!ld) return null;
+  const root = isDict(ld.data) ? ld.data : null;
+  const investigation =
+    root && isDict(root["hasInvestigation"]) ? root["hasInvestigation"] : root;
+  const rawFindings =
+    investigation && Array.isArray(investigation["hasFinding"])
+      ? investigation["hasFinding"]
+      : [];
+  let estimates = 0;
+  for (const f of rawFindings) {
+    if (isDict(f) && Array.isArray(f["hasEffectEstimate"])) {
+      estimates += f["hasEffectEstimate"].length;
+    }
+  }
+  return { findings: rawFindings.length, estimates };
 }
 
 export function extractDoi(

--- a/tests/components/search/ResultRow.test.tsx
+++ b/tests/components/search/ResultRow.test.tsx
@@ -219,6 +219,33 @@ describe("ResultRow", () => {
     );
   });
 
+  test("renders the 9th pill instead of '+1 more' when only one would be hidden", () => {
+    const labels = new Map<string, string>();
+    const findings: unknown[] = [];
+    for (let i = 0; i < 9; i++) {
+      const uri = `http://ex/concept-${i}`;
+      labels.set(uri, `Concept ${i}`);
+      findings.push({
+        hasOutcome: { outcome: [{ codedValue: { "@id": uri } }] },
+      });
+    }
+    vocabState.labels = labels;
+    vocabState.broader = new Map();
+    vocabState.definitions = new Map();
+    contextState.context = { prefixes: new Map() };
+
+    const ref = makeRef({ investigation: { hasFinding: findings } });
+    const { container } = render(
+      <ResultRow communitySlug="esea" reference={ref} />,
+    );
+    const pills = container.querySelector(".row-pills");
+    const tagEls = pills!.querySelectorAll(
+      ".tag-group__tag:not(.tag-group__tag--more)",
+    );
+    expect(tagEls).toHaveLength(9);
+    expect(pills!.querySelector(".tag-group__tag--more")).toBeNull();
+  });
+
   test("does not render coding institution when no raw enhancement is present", () => {
     render(<ResultRow communitySlug="esea" reference={makeRef()} />);
     expect(screen.queryByTestId("coder-text")).toBeNull();

--- a/tests/components/search/ResultRow.test.tsx
+++ b/tests/components/search/ResultRow.test.tsx
@@ -1,6 +1,6 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/preact";
-import { ResultRow } from "@/components/search/ResultRow";
+import { PILL_CAP, ResultRow } from "@/components/search/ResultRow";
 import { makeReference } from "../../fixtures";
 
 const vocabState = {
@@ -190,9 +190,10 @@ describe("ResultRow", () => {
   });
 
   test("caps pill list at PILL_CAP and renders +N more", () => {
+    const overflow = 4;
     const labels = new Map<string, string>();
     const findings: unknown[] = [];
-    for (let i = 0; i < 12; i++) {
+    for (let i = 0; i < PILL_CAP + overflow; i++) {
       const uri = `http://ex/concept-${i}`;
       labels.set(uri, `Concept ${i}`);
       findings.push({
@@ -213,16 +214,16 @@ describe("ResultRow", () => {
     const tagEls = pills!.querySelectorAll(
       ".tag-group__tag:not(.tag-group__tag--more)",
     );
-    expect(tagEls).toHaveLength(8);
+    expect(tagEls).toHaveLength(PILL_CAP);
     expect(pills!.querySelector(".tag-group__tag--more")).toHaveTextContent(
-      "+4 more",
+      `+${overflow} more`,
     );
   });
 
-  test("renders the 9th pill instead of '+1 more' when only one would be hidden", () => {
+  test("renders the extra pill instead of '+1 more' when only one would be hidden", () => {
     const labels = new Map<string, string>();
     const findings: unknown[] = [];
-    for (let i = 0; i < 9; i++) {
+    for (let i = 0; i < PILL_CAP + 1; i++) {
       const uri = `http://ex/concept-${i}`;
       labels.set(uri, `Concept ${i}`);
       findings.push({
@@ -242,7 +243,7 @@ describe("ResultRow", () => {
     const tagEls = pills!.querySelectorAll(
       ".tag-group__tag:not(.tag-group__tag--more)",
     );
-    expect(tagEls).toHaveLength(9);
+    expect(tagEls).toHaveLength(PILL_CAP + 1);
     expect(pills!.querySelector(".tag-group__tag--more")).toBeNull();
   });
 

--- a/tests/components/search/ResultRow.test.tsx
+++ b/tests/components/search/ResultRow.test.tsx
@@ -1,56 +1,57 @@
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/preact";
 import { ResultRow } from "@/components/search/ResultRow";
-import type { Reference } from "@/types/models";
+import { makeReference } from "../../fixtures";
 
-function makeRef(overrides: Partial<Reference> = {}): Reference {
-  return {
-    id: "ref-1",
-    visibility: "public",
-    identifiers: [{ identifier: "10.1000/abc", identifier_type: "doi" }],
-    enhancements: [
-      {
-        id: "e1",
-        reference_id: "ref-1",
-        source: "openalex",
-        visibility: "public",
-        robot_version: null,
-        derived_from: null,
-        created_at: "2024-01-01",
-        content: {
-          enhancement_type: "bibliographic",
-          authorship: [
-            { display_name: "Smith, J.", orcid: null, position: "first" },
-            { display_name: "Jones, K.", orcid: null, position: "last" },
-          ],
-          cited_by_count: 42,
-          created_date: null,
-          updated_date: null,
-          publication_date: "2020-06-01",
-          publication_year: 2020,
-          publisher: null,
-          title: "On phonics instruction",
-          pagination: null,
-          publication_venue: { display_name: "Journal of Education", venue_type: "journal" },
-        },
-      },
-      {
-        id: "e2",
-        reference_id: "ref-1",
-        source: "openalex",
-        visibility: "public",
-        robot_version: null,
-        derived_from: null,
-        created_at: "2024-01-02",
-        content: {
-          enhancement_type: "abstract",
-          process: "openalex",
-          abstract: "This is the abstract body text used for the snippet preview.",
-        },
-      },
-    ],
-    ...overrides,
-  };
+const vocabState = {
+  labels: null as Map<string, string> | null,
+  broader: null as Map<string, string> | null,
+  definitions: null as Map<string, string> | null,
+};
+const contextState = {
+  context: null as { prefixes: Map<string, string> } | null,
+};
+
+vi.mock("@/hooks/useVocabulary", () => ({
+  useVocabulary: () => ({
+    labels: vocabState.labels,
+    broader: vocabState.broader,
+    definitions: vocabState.definitions,
+    loading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("@/hooks/useContextPrefixes", () => ({
+  useContextPrefixes: () => ({
+    context: contextState.context,
+    loading: false,
+    error: null,
+  }),
+}));
+
+beforeEach(() => {
+  vocabState.labels = null;
+  vocabState.broader = null;
+  vocabState.definitions = null;
+  contextState.context = null;
+});
+
+const REF_ID = "ref-1";
+
+function makeRef(opts: Parameters<typeof makeReference>[0] = {}) {
+  return makeReference({
+    id: REF_ID,
+    doi: "10.1000/abc",
+    bibliographic: {
+      title: "On phonics instruction",
+      authors: ["Smith, J.", "Jones, K."],
+      year: 2020,
+      venue: "Journal of Education",
+    },
+    abstract: "This is the abstract body text used for the snippet preview.",
+    ...opts,
+  });
 }
 
 describe("ResultRow", () => {
@@ -69,9 +70,13 @@ describe("ResultRow", () => {
 
   test("primary content (title, authors, venue, abstract) is all wrapped in the row anchor", () => {
     render(<ResultRow communitySlug="esea" reference={makeRef()} />);
-    const rowLink = screen.getByRole("link", { name: /on phonics instruction/i });
-    expect(rowLink).toHaveAttribute("href", "/esea/references/ref-1");
-    expect(rowLink).toContainElement(screen.getByText("On phonics instruction"));
+    const rowLink = screen.getByRole("link", {
+      name: /on phonics instruction/i,
+    });
+    expect(rowLink).toHaveAttribute("href", `/esea/references/${REF_ID}`);
+    expect(rowLink).toContainElement(
+      screen.getByText("On phonics instruction"),
+    );
     expect(rowLink).toContainElement(screen.getByText(/Smith, J\./));
     expect(rowLink).toContainElement(screen.getByText(/Journal of Education/));
     expect(rowLink).toContainElement(screen.getByText(/2020/));
@@ -81,7 +86,9 @@ describe("ResultRow", () => {
   });
 
   test("row anchor carries the stretched-link class so CSS can extend its hit area", () => {
-    const { container } = render(<ResultRow communitySlug="esea" reference={makeRef()} />);
+    const { container } = render(
+      <ResultRow communitySlug="esea" reference={makeRef()} />,
+    );
     const link = container.querySelector(".row-link");
     expect(link).not.toBeNull();
     expect(link?.tagName).toBe("A");
@@ -95,19 +102,121 @@ describe("ResultRow", () => {
   });
 
   test("DOI link is not rendered when no DOI identifier present", () => {
-    const ref = makeRef({ identifiers: [] });
-    render(<ResultRow communitySlug="esea" reference={ref} />);
+    render(
+      <ResultRow
+        communitySlug="esea"
+        reference={makeRef({ doi: undefined })}
+      />,
+    );
     expect(screen.queryByRole("link", { name: /^doi/i })).toBeNull();
   });
 
-  test("renders findings/estimates placeholder badges in right column", () => {
-    const { container } = render(<ResultRow communitySlug="esea" reference={makeRef()} />);
+  test("falls back to — for findings/estimates badges when reference has no linked-data", () => {
+    const { container } = render(
+      <ResultRow communitySlug="esea" reference={makeRef()} />,
+    );
     const nums = container.querySelectorAll(".stat-num");
     expect(nums).toHaveLength(2);
     expect(nums[0]).toHaveTextContent("—");
     expect(nums[1]).toHaveTextContent("—");
     expect(container.querySelector(".row-right")).toHaveTextContent(/findings/);
-    expect(container.querySelector(".row-right")).toHaveTextContent(/estimates/);
+    expect(container.querySelector(".row-right")).toHaveTextContent(
+      /estimates/,
+    );
+    expect(container.querySelector(".row-pills")).toBeNull();
+  });
+
+  test("renders real findings/estimates counts from linked-data", () => {
+    const ref = makeRef({
+      investigation: {
+        hasFinding: [
+          { hasEffectEstimate: [{}, {}] },
+          { hasEffectEstimate: [{}] },
+        ],
+      },
+    });
+    const { container } = render(
+      <ResultRow communitySlug="esea" reference={ref} />,
+    );
+    const nums = container.querySelectorAll(".stat-num");
+    expect(nums[0]).toHaveTextContent("2"); // 2 findings
+    expect(nums[1]).toHaveTextContent("3"); // 3 estimates
+  });
+
+  test("counts render even when vocabulary is unresolved (pills wait)", () => {
+    // labels/context left null — pills cannot resolve, but counts are
+    // derived synchronously from raw JSON-LD.
+    const ref = makeRef({
+      investigation: { hasFinding: [{ hasEffectEstimate: [{}] }] },
+    });
+    const { container } = render(
+      <ResultRow communitySlug="esea" reference={ref} />,
+    );
+    const nums = container.querySelectorAll(".stat-num");
+    expect(nums[0]).toHaveTextContent("1");
+    expect(nums[1]).toHaveTextContent("1");
+    expect(container.querySelector(".row-pills")).toBeNull();
+  });
+
+  test("renders concept pills under the abstract once vocabulary resolves", () => {
+    vocabState.labels = new Map([
+      ["http://ex/Trial", "Randomised trial"],
+      ["http://ex/Maths", "Mathematics"],
+    ]);
+    vocabState.broader = new Map();
+    vocabState.definitions = new Map();
+    contextState.context = { prefixes: new Map() };
+
+    const ref = makeRef({
+      investigation: {
+        documentType: { codedValue: { "@id": "http://ex/Trial" } },
+        hasFinding: [
+          {
+            evaluates: {
+              educationTheme: [{ codedValue: { "@id": "http://ex/Maths" } }],
+            },
+          },
+        ],
+      },
+    });
+    const { container } = render(
+      <ResultRow communitySlug="esea" reference={ref} />,
+    );
+    const pills = container.querySelector(".row-pills");
+    expect(pills).not.toBeNull();
+    expect(pills).toHaveTextContent("Randomised trial");
+    expect(pills).toHaveTextContent("Mathematics");
+    expect(pills?.querySelector(".tag-group__tag--more")).toBeNull();
+  });
+
+  test("caps pill list at PILL_CAP and renders +N more", () => {
+    const labels = new Map<string, string>();
+    const findings: unknown[] = [];
+    for (let i = 0; i < 12; i++) {
+      const uri = `http://ex/concept-${i}`;
+      labels.set(uri, `Concept ${i}`);
+      findings.push({
+        hasOutcome: { outcome: [{ codedValue: { "@id": uri } }] },
+      });
+    }
+    vocabState.labels = labels;
+    vocabState.broader = new Map();
+    vocabState.definitions = new Map();
+    contextState.context = { prefixes: new Map() };
+
+    const ref = makeRef({ investigation: { hasFinding: findings } });
+    const { container } = render(
+      <ResultRow communitySlug="esea" reference={ref} />,
+    );
+    const pills = container.querySelector(".row-pills");
+    expect(pills).not.toBeNull();
+    const tagEls = pills!.querySelectorAll(
+      ".tag-group__tag:not(.tag-group__tag--more)",
+    );
+    expect(tagEls).toHaveLength(8);
+    expect(pills!.querySelector(".tag-group__tag--more")).toHaveTextContent(
+      "+4 more",
+    );
   });
 
   test("does not render coding institution when no raw enhancement is present", () => {
@@ -142,7 +251,7 @@ describe("ResultRow", () => {
   test("renders without throwing when bibliographic missing; row-anchor falls back to id", () => {
     const ref = makeRef({ enhancements: [] });
     render(<ResultRow communitySlug="esea" reference={ref} />);
-    const rowLink = screen.getByRole("link", { name: /ref-1/i });
-    expect(rowLink).toHaveAttribute("href", "/esea/references/ref-1");
+    const rowLink = screen.getByRole("link", { name: new RegExp(REF_ID, "i") });
+    expect(rowLink).toHaveAttribute("href", `/esea/references/${REF_ID}`);
   });
 });

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -133,6 +133,24 @@ export function bibliographicEnh(
   };
 }
 
+/** Build an abstract Enhancement. */
+export function abstractEnh(refId: string, abstract: string): Enhancement {
+  return {
+    id: `${refId}-abs`,
+    reference_id: refId,
+    source: "openalex",
+    visibility: "public",
+    robot_version: null,
+    derived_from: null,
+    created_at: null,
+    content: {
+      enhancement_type: "abstract",
+      process: "openalex",
+      abstract,
+    },
+  };
+}
+
 interface LinkedDataEnhOpts {
   id?: string;
   derivedFrom?: string[] | null;
@@ -192,20 +210,24 @@ interface ReferenceOpts {
   id?: string;
   doi?: string;
   bibliographic?: BibOpts;
+  abstract?: string;
   /** Investigation dict to wrap in a linked_data enhancement, if any. */
   investigation?: Record<string, unknown>;
-  /** Override enhancements entirely (skips bibliographic/investigation). */
+  /** Override enhancements entirely (skips bibliographic/abstract/investigation). */
   enhancements?: Enhancement[];
 }
 
-/** Build a Reference with optional bibliographic and linked-data enhancements. */
+/** Build a Reference with optional bibliographic, abstract, and linked-data enhancements. */
 export function makeReference(opts: ReferenceOpts = {}): Reference {
   const id = opts.id ?? "abc-123";
   const enhancements =
     opts.enhancements ??
     [
       bibliographicEnh(id, opts.bibliographic),
-      opts.investigation ? linkedDataEnh(id, { investigation: opts.investigation }) : null,
+      opts.abstract ? abstractEnh(id, opts.abstract) : null,
+      opts.investigation
+        ? linkedDataEnh(id, { investigation: opts.investigation })
+        : null,
     ].filter((e): e is Enhancement => e !== null);
 
   return {


### PR DESCRIPTION
## Summary

Closes https://github.com/destiny-evidence/evidence-repo-ui/issues/30. Replaces the `—` placeholders in result-row stat badges with real findings/estimates counts and renders a flat row of concept-tag pills under each abstract.

- Counts are read straight from raw JSON-LD (`hasInvestigation.hasFinding[].hasEffectEstimate[]`) so badges flip on first paint without waiting on vocabulary resolution. Rows with no linked data keep `—` and render no pills.
- Pills aggregate `documentType` plus per-finding context/intervention/outcome concepts and sample features, de-duped by URI, capped at 8 with `+N more`. Flat (no `parent ›` breadcrumb) per the klim-b prototype; SKOS-definition tooltip preserved.
- `.search-results` no longer uses `overflow: hidden` (it was clipping pill tooltips); the meta bar and the last result row self-clip the rounded outer corners.
- `.row-pills` uses `pointer-events: none` with `auto` on individual tags so clicks in the gaps fall through to the stretched row link while pill hover-tooltips still fire.
- `isDict` is exported from `referenceUtils` and reused by `investigationParser` to drop the duplicate.
- Test fixtures gain an `abstract` option; `ResultRow.test.tsx` migrated to use them.

## Out of scope (per issue)

- Pill click-through to taxonomy definitions — tracked in https://github.com/destiny-evidence/evidence-repo-ui/issues/21.
- Pill grouping by concept type / property.
- Filter-by-pill ("show me all RCTs").
- Popover for the `+N more` overflow pill.

## Test plan

- [x] `npm run test` — 273/273 pass.
- [x] `tsc --noEmit` clean.
- [ ] Manual: search returning a mix of references with and without linked data; confirm badges flip from `—` to real counts on first paint, pills appear under the abstract once vocab resolves, tooltip text is readable (not clipped), clicking gaps in the pill row navigates to the detail page, clicking a pill shows the tooltip without navigating.