### PR TITLE
UX fixes: sort dropdown, country names, field wrapping

### DIFF
--- a/src/components/ContextDetails.tsx
+++ b/src/components/ContextDetails.tsx
@@ -2,6 +2,7 @@ import { TagGroup } from "./TagGroup";
 import { SourceEvidenceToggle } from "./SourceEvidenceToggle";
 import { evidenceFrom } from "@/services/sourceEvidence";
 import { conceptsToTags } from "@/services/conceptLabels";
+import { countryName } from "@/utils/country";
 import type { ContextData } from "@/types/investigation";
 
 interface ContextDetailsProps {
@@ -52,7 +53,7 @@ export function ContextDetails({
         {context.countries && context.countries.length > 0 && (
           <div class="lg-field">
             <span class="lg-label">Country</span>
-            <span>{context.countries.map((c) => c.value).join(", ")}</span>
+            <span>{context.countries.map((c) => countryName(c.value)).join(", ")}</span>
           </div>
         )}
         {context.countryLevel1 && (

--- a/src/components/InterventionDetails.css
+++ b/src/components/InterventionDetails.css
@@ -8,4 +8,5 @@
   border-left: 2px solid var(--color-border);
   font-size: 14px;
   color: var(--color-text-secondary);
+  overflow-wrap: anywhere;
 }

--- a/src/components/LabeledField.css
+++ b/src/components/LabeledField.css
@@ -2,6 +2,7 @@
   margin: var(--spacing-sm) 0;
   font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
+  overflow-wrap: anywhere;
 }
 
 .labeled-field__label {

--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -1,36 +1,32 @@
-import { useState, useEffect } from "preact/hooks";
 import { MagnifierIcon } from "@/components/icons";
-import { parseYear } from "@/utils/year";
 import "./SearchBar.css";
 
 interface SearchBarProps {
-  q: string;
-  startYear: number | undefined;
-  endYear: number | undefined;
-  onSubmit: (q: string, startYear: number | undefined, endYear: number | undefined) => void;
+  draftQ: string;
+  draftStart: string;
+  draftEnd: string;
+  onDraftQChange: (q: string) => void;
+  onDraftStartChange: (s: string) => void;
+  onDraftEndChange: (e: string) => void;
+  validationError: string | null;
+  onSubmit: () => void;
   disabled?: boolean;
 }
 
-export function SearchBar({ q, startYear, endYear, onSubmit, disabled = false }: SearchBarProps) {
-  const [draftQ, setDraftQ] = useState(q);
-  const [draftStart, setDraftStart] = useState(startYear !== undefined ? String(startYear) : "");
-  const [draftEnd, setDraftEnd] = useState(endYear !== undefined ? String(endYear) : "");
-  const [validationError, setValidationError] = useState<string | null>(null);
-
-  useEffect(() => { setDraftQ(q); }, [q]);
-  useEffect(() => { setDraftStart(startYear !== undefined ? String(startYear) : ""); }, [startYear]);
-  useEffect(() => { setDraftEnd(endYear !== undefined ? String(endYear) : ""); }, [endYear]);
-
+export function SearchBar({
+  draftQ,
+  draftStart,
+  draftEnd,
+  onDraftQChange,
+  onDraftStartChange,
+  onDraftEndChange,
+  validationError,
+  onSubmit,
+  disabled = false,
+}: SearchBarProps) {
   function handleSubmit(e?: Event) {
     e?.preventDefault();
-    const s = parseYear(draftStart);
-    const en = parseYear(draftEnd);
-    if (s !== undefined && en !== undefined && s > en) {
-      setValidationError("Start year must not exceed end year.");
-      return;
-    }
-    setValidationError(null);
-    onSubmit(draftQ.trim(), s, en);
+    onSubmit();
   }
 
   return (
@@ -45,7 +41,7 @@ export function SearchBar({ q, startYear, endYear, onSubmit, disabled = false }:
             aria-label="Search query"
             placeholder="Search the evidence"
             value={draftQ}
-            onInput={(e) => setDraftQ((e.target as HTMLInputElement).value)}
+            onInput={(e) => onDraftQChange((e.target as HTMLInputElement).value)}
             disabled={disabled}
           />
           <button type="submit" class="search-btn" disabled={disabled}>
@@ -66,10 +62,7 @@ export function SearchBar({ q, startYear, endYear, onSubmit, disabled = false }:
           aria-label="Start year"
           class="search-filters__year"
           value={draftStart}
-          onInput={(e) => {
-            setDraftStart((e.target as HTMLInputElement).value);
-            setValidationError(null);
-          }}
+          onInput={(e) => onDraftStartChange((e.target as HTMLInputElement).value)}
           disabled={disabled}
         />
         <span class="search-filters__sep" aria-hidden="true">—</span>
@@ -83,10 +76,7 @@ export function SearchBar({ q, startYear, endYear, onSubmit, disabled = false }:
           aria-label="End year"
           class="search-filters__year"
           value={draftEnd}
-          onInput={(e) => {
-            setDraftEnd((e.target as HTMLInputElement).value);
-            setValidationError(null);
-          }}
+          onInput={(e) => onDraftEndChange((e.target as HTMLInputElement).value)}
           disabled={disabled}
         />
       </div>

--- a/src/hooks/useSearchDraft.ts
+++ b/src/hooks/useSearchDraft.ts
@@ -1,0 +1,69 @@
+import { useEffect, useState } from "preact/hooks";
+import type { SearchParams } from "@/services/searchParams";
+import { parseYear } from "@/utils/year";
+
+export interface CommittedDraft {
+  q: string;
+  startYear: number | undefined;
+  endYear: number | undefined;
+}
+
+export interface SearchDraft {
+  draftQ: string;
+  draftStart: string;
+  draftEnd: string;
+  setDraftQ: (q: string) => void;
+  setDraftStart: (s: string) => void;
+  setDraftEnd: (e: string) => void;
+  validationError: string | null;
+  commitDraft: () => CommittedDraft | null;
+}
+
+// Holds pending text/year edits separately from the URL-backed `params` so
+// sibling controls (e.g. SortDropdown) can commit them on navigation.
+export function useSearchDraft(params: SearchParams): SearchDraft {
+  const [draftQ, setDraftQ] = useState(params.q);
+  const [draftStart, setDraftStart] = useState(yearToInput(params.startYear));
+  const [draftEnd, setDraftEnd] = useState(yearToInput(params.endYear));
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  useEffect(() => { setDraftQ(params.q); }, [params.q]);
+  useEffect(() => { setDraftStart(yearToInput(params.startYear)); }, [params.startYear]);
+  useEffect(() => { setDraftEnd(yearToInput(params.endYear)); }, [params.endYear]);
+
+  function setDraftStartAndClearError(s: string) {
+    setDraftStart(s);
+    setValidationError(null);
+  }
+
+  function setDraftEndAndClearError(e: string) {
+    setDraftEnd(e);
+    setValidationError(null);
+  }
+
+  function commitDraft(): CommittedDraft | null {
+    const s = parseYear(draftStart);
+    const en = parseYear(draftEnd);
+    if (s !== undefined && en !== undefined && s > en) {
+      setValidationError("Start year must not exceed end year.");
+      return null;
+    }
+    setValidationError(null);
+    return { q: draftQ.trim(), startYear: s, endYear: en };
+  }
+
+  return {
+    draftQ,
+    draftStart,
+    draftEnd,
+    setDraftQ,
+    setDraftStart: setDraftStartAndClearError,
+    setDraftEnd: setDraftEndAndClearError,
+    validationError,
+    commitDraft,
+  };
+}
+
+function yearToInput(year: number | undefined): string {
+  return year !== undefined ? String(year) : "";
+}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,12 +1,12 @@
-import { useEffect, useState } from "preact/hooks";
+import { useEffect } from "preact/hooks";
 import { useCommunity } from "@/community/CommunityContext";
 import type { Community } from "@/types/models";
 import { parseSearchParams, toQueryString, buildSearchUrl, type SortOption } from "@/services/searchParams";
 import { navigate } from "@/services/navigation";
-import { parseYear } from "@/utils/year";
 import { useUrlParams } from "@/hooks/useUrlParams";
 import { useCorpusTotal } from "@/hooks/useCorpusTotal";
 import { useSearch } from "@/hooks/useSearch";
+import { useSearchDraft } from "@/hooks/useSearchDraft";
 import { SearchBar } from "@/components/search/SearchBar";
 import { SortDropdown } from "@/components/search/SortDropdown";
 import { ResultRow } from "@/components/search/ResultRow";
@@ -70,16 +70,7 @@ function SearchPageInner({ community }: { community: Community }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [canonicalQs, community.slug]);
 
-  // Draft state lives here (not in SearchBar) so sibling controls like
-  // SortDropdown can commit pending text/year edits when they navigate.
-  const [draftQ, setDraftQ] = useState(params.q);
-  const [draftStart, setDraftStart] = useState(params.startYear !== undefined ? String(params.startYear) : "");
-  const [draftEnd, setDraftEnd] = useState(params.endYear !== undefined ? String(params.endYear) : "");
-  const [validationError, setValidationError] = useState<string | null>(null);
-
-  useEffect(() => { setDraftQ(params.q); }, [params.q]);
-  useEffect(() => { setDraftStart(params.startYear !== undefined ? String(params.startYear) : ""); }, [params.startYear]);
-  useEffect(() => { setDraftEnd(params.endYear !== undefined ? String(params.endYear) : ""); }, [params.endYear]);
+  const draft = useSearchDraft(params);
 
   const corpus = useCorpusTotal();
   const results = useSearch(params);
@@ -100,22 +91,10 @@ function SearchPageInner({ community }: { community: Community }) {
     params.endYear !== undefined ||
     results.error !== null;
 
-  // Returns parsed draft values, or null if the year range is invalid.
-  function commitDraft(): { q: string; startYear: number | undefined; endYear: number | undefined } | null {
-    const s = parseYear(draftStart);
-    const en = parseYear(draftEnd);
-    if (s !== undefined && en !== undefined && s > en) {
-      setValidationError("Start year must not exceed end year.");
-      return null;
-    }
-    setValidationError(null);
-    return { q: draftQ.trim(), startYear: s, endYear: en };
-  }
-
   function handleSubmit() {
-    const draft = commitDraft();
-    if (!draft) return;
-    navigate(buildSearchUrl(community.slug, { ...params, ...draft, page: 1 }));
+    const committed = draft.commitDraft();
+    if (!committed) return;
+    navigate(buildSearchUrl(community.slug, { ...params, ...committed, page: 1 }));
   }
 
   function handlePageChange(page: number) {
@@ -123,19 +102,9 @@ function SearchPageInner({ community }: { community: Community }) {
   }
 
   function handleSortChange(sort: SortOption | undefined) {
-    const draft = commitDraft();
-    if (!draft) return;
-    navigate(buildSearchUrl(community.slug, { ...params, ...draft, sort, page: 1 }));
-  }
-
-  function handleDraftStartChange(s: string) {
-    setDraftStart(s);
-    setValidationError(null);
-  }
-
-  function handleDraftEndChange(e: string) {
-    setDraftEnd(e);
-    setValidationError(null);
+    const committed = draft.commitDraft();
+    if (!committed) return;
+    navigate(buildSearchUrl(community.slug, { ...params, ...committed, sort, page: 1 }));
   }
 
   // Page size comes from the API response (page.count) so the UI stays in
@@ -160,13 +129,13 @@ function SearchPageInner({ community }: { community: Community }) {
               : community.name}
         </p>
         <SearchBar
-          draftQ={draftQ}
-          draftStart={draftStart}
-          draftEnd={draftEnd}
-          onDraftQChange={setDraftQ}
-          onDraftStartChange={handleDraftStartChange}
-          onDraftEndChange={handleDraftEndChange}
-          validationError={validationError}
+          draftQ={draft.draftQ}
+          draftStart={draft.draftStart}
+          draftEnd={draft.draftEnd}
+          onDraftQChange={draft.setDraftQ}
+          onDraftStartChange={draft.setDraftStart}
+          onDraftEndChange={draft.setDraftEnd}
+          validationError={draft.validationError}
           onSubmit={handleSubmit}
           disabled={results.loading && results.results !== null}
         />

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,8 +1,9 @@
-import { useEffect } from "preact/hooks";
+import { useEffect, useState } from "preact/hooks";
 import { useCommunity } from "@/community/CommunityContext";
 import type { Community } from "@/types/models";
 import { parseSearchParams, toQueryString, buildSearchUrl, type SortOption } from "@/services/searchParams";
 import { navigate } from "@/services/navigation";
+import { parseYear } from "@/utils/year";
 import { useUrlParams } from "@/hooks/useUrlParams";
 import { useCorpusTotal } from "@/hooks/useCorpusTotal";
 import { useSearch } from "@/hooks/useSearch";
@@ -69,6 +70,17 @@ function SearchPageInner({ community }: { community: Community }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [canonicalQs, community.slug]);
 
+  // Draft state lives here (not in SearchBar) so sibling controls like
+  // SortDropdown can commit pending text/year edits when they navigate.
+  const [draftQ, setDraftQ] = useState(params.q);
+  const [draftStart, setDraftStart] = useState(params.startYear !== undefined ? String(params.startYear) : "");
+  const [draftEnd, setDraftEnd] = useState(params.endYear !== undefined ? String(params.endYear) : "");
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  useEffect(() => { setDraftQ(params.q); }, [params.q]);
+  useEffect(() => { setDraftStart(params.startYear !== undefined ? String(params.startYear) : ""); }, [params.startYear]);
+  useEffect(() => { setDraftEnd(params.endYear !== undefined ? String(params.endYear) : ""); }, [params.endYear]);
+
   const corpus = useCorpusTotal();
   const results = useSearch(params);
 
@@ -88,8 +100,22 @@ function SearchPageInner({ community }: { community: Community }) {
     params.endYear !== undefined ||
     results.error !== null;
 
-  function handleSubmit(q: string, startYear: number | undefined, endYear: number | undefined) {
-    navigate(buildSearchUrl(community.slug, { ...params, q, page: 1, startYear, endYear }));
+  // Returns parsed draft values, or null if the year range is invalid.
+  function commitDraft(): { q: string; startYear: number | undefined; endYear: number | undefined } | null {
+    const s = parseYear(draftStart);
+    const en = parseYear(draftEnd);
+    if (s !== undefined && en !== undefined && s > en) {
+      setValidationError("Start year must not exceed end year.");
+      return null;
+    }
+    setValidationError(null);
+    return { q: draftQ.trim(), startYear: s, endYear: en };
+  }
+
+  function handleSubmit() {
+    const draft = commitDraft();
+    if (!draft) return;
+    navigate(buildSearchUrl(community.slug, { ...params, ...draft, page: 1 }));
   }
 
   function handlePageChange(page: number) {
@@ -97,7 +123,19 @@ function SearchPageInner({ community }: { community: Community }) {
   }
 
   function handleSortChange(sort: SortOption | undefined) {
-    navigate(buildSearchUrl(community.slug, { ...params, sort, page: 1 }));
+    const draft = commitDraft();
+    if (!draft) return;
+    navigate(buildSearchUrl(community.slug, { ...params, ...draft, sort, page: 1 }));
+  }
+
+  function handleDraftStartChange(s: string) {
+    setDraftStart(s);
+    setValidationError(null);
+  }
+
+  function handleDraftEndChange(e: string) {
+    setDraftEnd(e);
+    setValidationError(null);
   }
 
   // Page size comes from the API response (page.count) so the UI stays in
@@ -122,9 +160,13 @@ function SearchPageInner({ community }: { community: Community }) {
               : community.name}
         </p>
         <SearchBar
-          q={params.q}
-          startYear={params.startYear}
-          endYear={params.endYear}
+          draftQ={draftQ}
+          draftStart={draftStart}
+          draftEnd={draftEnd}
+          onDraftQChange={setDraftQ}
+          onDraftStartChange={handleDraftStartChange}
+          onDraftEndChange={handleDraftEndChange}
+          validationError={validationError}
           onSubmit={handleSubmit}
           disabled={results.loading && results.results !== null}
         />

--- a/src/utils/country.ts
+++ b/src/utils/country.ts
@@ -1,0 +1,5 @@
+const regionNames = new Intl.DisplayNames(["en"], { type: "region" });
+
+export function countryName(code: string): string {
+  return regionNames.of(code) ?? code;
+}

--- a/src/utils/country.ts
+++ b/src/utils/country.ts
@@ -1,5 +1,12 @@
 const regionNames = new Intl.DisplayNames(["en"], { type: "region" });
 
+// Intl.DisplayNames throws RangeError on inputs that aren't structurally
+// valid region codes (e.g. legacy data containing a full country name); fall
+// back to the raw value so a bad row can't crash the surrounding view.
 export function countryName(code: string): string {
-  return regionNames.of(code) ?? code;
+  try {
+    return regionNames.of(code) ?? code;
+  } catch {
+    return code;
+  }
 }

--- a/tests/components/search/SearchBar.test.tsx
+++ b/tests/components/search/SearchBar.test.tsx
@@ -2,106 +2,67 @@ import { describe, test, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/preact";
 import { SearchBar } from "@/components/search/SearchBar";
 
+function renderBar(overrides: Partial<Parameters<typeof SearchBar>[0]> = {}) {
+  const props = {
+    draftQ: "",
+    draftStart: "",
+    draftEnd: "",
+    onDraftQChange: vi.fn(),
+    onDraftStartChange: vi.fn(),
+    onDraftEndChange: vi.fn(),
+    validationError: null,
+    onSubmit: vi.fn(),
+    ...overrides,
+  };
+  render(<SearchBar {...props} />);
+  return props;
+}
+
 describe("SearchBar", () => {
-  test("renders initial values from props", () => {
-    render(
-      <SearchBar
-        q="phonics"
-        startYear={2010}
-        endYear={2024}
-        onSubmit={() => {}}
-      />,
-    );
+  test("renders draft values from props", () => {
+    renderBar({ draftQ: "phonics", draftStart: "2010", draftEnd: "2024" });
     expect(screen.getByRole("searchbox")).toHaveValue("phonics");
     expect(screen.getByLabelText(/start year/i)).toHaveValue("2010");
     expect(screen.getByLabelText(/end year/i)).toHaveValue("2024");
   });
 
-  test("submit via button calls onSubmit with draft values", () => {
-    const onSubmit = vi.fn();
-    render(<SearchBar q="" startYear={undefined} endYear={undefined} onSubmit={onSubmit} />);
+  test("typing in the query field calls onDraftQChange", () => {
+    const props = renderBar();
     fireEvent.input(screen.getByRole("searchbox"), { target: { value: "phonics" } });
+    expect(props.onDraftQChange).toHaveBeenCalledWith("phonics");
+  });
+
+  test("typing in the year fields calls the matching draft callback", () => {
+    const props = renderBar();
     fireEvent.input(screen.getByLabelText(/start year/i), { target: { value: "2010" } });
-    fireEvent.click(screen.getByRole("button", { name: /search/i }));
-    expect(onSubmit).toHaveBeenCalledWith("phonics", 2010, undefined);
+    expect(props.onDraftStartChange).toHaveBeenCalledWith("2010");
+    fireEvent.input(screen.getByLabelText(/end year/i), { target: { value: "2024" } });
+    expect(props.onDraftEndChange).toHaveBeenCalledWith("2024");
   });
 
-  test("Enter inside the input submits the form exactly once", () => {
+  test("submit button calls onSubmit", () => {
+    const props = renderBar({ draftQ: "phonics" });
+    fireEvent.click(screen.getByRole("button", { name: /search/i }));
+    expect(props.onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  test("submitting the form (Enter) calls onSubmit exactly once", () => {
     const onSubmit = vi.fn();
-    const { container } = render(
-      <SearchBar q="" startYear={undefined} endYear={undefined} onSubmit={onSubmit} />,
-    );
-    const input = screen.getByRole("searchbox");
-    fireEvent.input(input, { target: { value: "phonics" } });
-    fireEvent.submit(container.querySelector("form")!);
+    renderBar({ onSubmit });
+    fireEvent.submit(document.querySelector("form")!);
     expect(onSubmit).toHaveBeenCalledTimes(1);
-    expect(onSubmit).toHaveBeenCalledWith("phonics", undefined, undefined);
   });
 
-  test("empty year inputs pass undefined, not NaN", () => {
-    const onSubmit = vi.fn();
-    render(<SearchBar q="x" startYear={undefined} endYear={undefined} onSubmit={onSubmit} />);
-    fireEvent.click(screen.getByRole("button", { name: /search/i }));
-    expect(onSubmit).toHaveBeenCalledWith("x", undefined, undefined);
-  });
-
-  test("startYear > endYear blocks submit and shows validation", () => {
-    const onSubmit = vi.fn();
-    render(<SearchBar q="x" startYear={undefined} endYear={undefined} onSubmit={onSubmit} />);
-    fireEvent.input(screen.getByLabelText(/start year/i), { target: { value: "2024" } });
-    fireEvent.input(screen.getByLabelText(/end year/i), { target: { value: "2010" } });
-    fireEvent.click(screen.getByRole("button", { name: /search/i }));
-    expect(onSubmit).not.toHaveBeenCalled();
+  test("renders the validationError prop as an alert", () => {
+    renderBar({ validationError: "Start year must not exceed end year." });
     expect(screen.getByRole("alert")).toHaveTextContent(/start year must not exceed end year/i);
   });
 
-  test("resyncs when props change externally (back/forward)", () => {
-    const { rerender } = render(
-      <SearchBar q="a" startYear={undefined} endYear={undefined} onSubmit={() => {}} />,
-    );
-    expect(screen.getByRole("searchbox")).toHaveValue("a");
-    rerender(<SearchBar q="b" startYear={2020} endYear={undefined} onSubmit={() => {}} />);
-    expect(screen.getByRole("searchbox")).toHaveValue("b");
-    expect(screen.getByLabelText(/start year/i)).toHaveValue("2020");
-  });
-
-  test("typing does not trigger onSubmit (draft-local)", () => {
-    const onSubmit = vi.fn();
-    render(<SearchBar q="" startYear={undefined} endYear={undefined} onSubmit={onSubmit} />);
-    fireEvent.input(screen.getByRole("searchbox"), { target: { value: "phonics" } });
-    expect(onSubmit).not.toHaveBeenCalled();
-  });
-
-  test("validation error clears when user edits either year field", () => {
-    const onSubmit = vi.fn();
-    render(<SearchBar q="x" startYear={undefined} endYear={undefined} onSubmit={onSubmit} />);
-    fireEvent.input(screen.getByLabelText(/start year/i), { target: { value: "2024" } });
-    fireEvent.input(screen.getByLabelText(/end year/i), { target: { value: "2010" } });
-    fireEvent.click(screen.getByRole("button", { name: /search/i }));
-    expect(screen.getByRole("alert")).toBeInTheDocument();
-
-    fireEvent.input(screen.getByLabelText(/start year/i), { target: { value: "2000" } });
-    expect(screen.queryByRole("alert")).toBeNull();
-  });
-
-  test.each([
-    { label: "scientific notation", raw: "2e3" },
-    { label: "hex notation",        raw: "0x10" },
-    { label: "fractional",          raw: "2.5" },
-    { label: "alpha",               raw: "abc" },
-  ])("year input '$raw' ($label) is rejected and submits as undefined", ({ raw }) => {
-    const onSubmit = vi.fn();
-    render(<SearchBar q="x" startYear={undefined} endYear={undefined} onSubmit={onSubmit} />);
-    fireEvent.input(screen.getByLabelText(/start year/i), { target: { value: raw } });
-    fireEvent.click(screen.getByRole("button", { name: /search/i }));
-    expect(onSubmit).toHaveBeenCalledWith("x", undefined, undefined);
-  });
-
-  test("year input with surrounding whitespace is trimmed and accepted", () => {
-    const onSubmit = vi.fn();
-    render(<SearchBar q="x" startYear={undefined} endYear={undefined} onSubmit={onSubmit} />);
-    fireEvent.input(screen.getByLabelText(/start year/i), { target: { value: "  2010  " } });
-    fireEvent.click(screen.getByRole("button", { name: /search/i }));
-    expect(onSubmit).toHaveBeenCalledWith("x", 2010, undefined);
+  test("disabled prop disables inputs and submit", () => {
+    renderBar({ disabled: true });
+    expect(screen.getByRole("searchbox")).toBeDisabled();
+    expect(screen.getByLabelText(/start year/i)).toBeDisabled();
+    expect(screen.getByLabelText(/end year/i)).toBeDisabled();
+    expect(screen.getByRole("button", { name: /search/i })).toBeDisabled();
   });
 });

--- a/tests/pages/SearchPage.test.tsx
+++ b/tests/pages/SearchPage.test.tsx
@@ -245,6 +245,65 @@ describe("SearchPage", () => {
     expect(screen.getByText(/results for/i)).toHaveTextContent(/10,000\+ results for “education”/i);
   });
 
+  test("changing sort commits unsubmitted draft query and year filters", async () => {
+    // Regression: previously the sort dropdown navigated using URL params
+    // only, dropping any text/year edits the user hadn't yet submitted.
+    mockBoth({ results: makeResult(5721, ["r1"]) });
+    renderSearchPage();
+    await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
+
+    fireEvent.input(screen.getByRole("searchbox"), { target: { value: "literacy" } });
+    fireEvent.input(screen.getByLabelText(/start year/i), { target: { value: "2001" } });
+    fireEvent.input(screen.getByLabelText(/end year/i), { target: { value: "2010" } });
+
+    fireEvent.change(screen.getByLabelText(/sort results/i), { target: { value: "oldest" } });
+
+    await waitFor(() => expect(window.location.search).toContain("sort=oldest"));
+    expect(window.location.search).toContain("q=literacy");
+    expect(window.location.search).toContain("start_year=2001");
+    expect(window.location.search).toContain("end_year=2010");
+  });
+
+  test("invalid year range blocks submit and shows validation message", async () => {
+    mockBoth({ results: makeResult(5721, ["r1"]) });
+    renderSearchPage();
+    await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
+
+    fireEvent.input(screen.getByLabelText(/start year/i), { target: { value: "2024" } });
+    fireEvent.input(screen.getByLabelText(/end year/i), { target: { value: "2010" } });
+    fireEvent.click(screen.getByRole("button", { name: /search/i }));
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/start year must not exceed end year/i);
+    expect(window.location.search).toBe("");
+  });
+
+  test("validation error clears when user edits a year field", async () => {
+    mockBoth({ results: makeResult(5721, ["r1"]) });
+    renderSearchPage();
+    await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
+
+    fireEvent.input(screen.getByLabelText(/start year/i), { target: { value: "2024" } });
+    fireEvent.input(screen.getByLabelText(/end year/i), { target: { value: "2010" } });
+    fireEvent.click(screen.getByRole("button", { name: /search/i }));
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+
+    fireEvent.input(screen.getByLabelText(/start year/i), { target: { value: "2000" } });
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  test("drafts resync when the URL changes externally (back/forward)", async () => {
+    history.replaceState(null, "", "/esea?q=alpha");
+    mockBoth({ results: makeResult(5721, ["r1"]) });
+    renderSearchPage();
+    await waitFor(() => expect(screen.getByRole("searchbox")).toHaveValue("alpha"));
+
+    history.pushState(null, "", "/esea?q=beta&start_year=2020");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+
+    await waitFor(() => expect(screen.getByRole("searchbox")).toHaveValue("beta"));
+    expect(screen.getByLabelText(/start year/i)).toHaveValue("2020");
+  });
+
   test("search failure: renders retry, retry refetches without URL change", async () => {
     history.replaceState(null, "", "/esea?q=phonics");
     const pushSpy = vi.spyOn(history, "pushState");

--- a/tests/utils/country.test.ts
+++ b/tests/utils/country.test.ts
@@ -1,0 +1,15 @@
+import { describe, test, expect } from "vitest";
+import { countryName } from "@/utils/country";
+
+describe("countryName", () => {
+  test("translates ISO 3166-1 alpha-2 codes to English names", () => {
+    expect(countryName("AU")).toBe("Australia");
+    expect(countryName("NL")).toBe("Netherlands");
+  });
+
+  test("returns the input unchanged when the code is not a valid region", () => {
+    expect(countryName("Netherlands")).toBe("Netherlands");
+    expect(countryName("Not reported")).toBe("Not reported");
+    expect(countryName("")).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
- Sort dropdown now commits the search box and year-range drafts before navigating, so changing sort no longer drops unsubmitted query/filter input.
- Country values render as full names (via `Intl.DisplayNames`) instead of ISO codes.
- Long values in `LabeledField` and `InterventionDetails` wrap with `overflow-wrap: anywhere` so URL-like strings stop overflowing the column.

## Test plan
- [x] `npm run typecheck` (only pre-existing `keycloak-js` error remains)
- [x] `npx vitest run tests/components/search/SearchBar.test.tsx tests/pages/SearchPage.test.tsx` — 25/25 pass, including new regression for sort-commits-draft
- [x] Manually verify in browser: type a query + year range, change sort without clicking Search → URL reflects all three
- [x] Manually verify a record with country codes renders names; a record with a long URL field wraps inside its column