### PR TITLE
Add Matomo analytics to evidence-repo-ui

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ VITE_VOCAB_PROXY_TARGET=https://vocab.staging.evidence-repository.org
 VITE_KEYCLOAK_URL=https://auth.evidence-repository.org
 VITE_KEYCLOAK_REALM=destiny
 VITE_KEYCLOAK_CLIENT_ID=evidence-repo-ui-client-development
+# VITE_MATOMO_CONTAINER_URL=https://cdn.matomo.cloud/futureevidence.matomo.cloud/container_<id>_dev_<hash>.js

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,7 @@ jobs:
           VITE_KEYCLOAK_URL: ${{ vars.VITE_KEYCLOAK_URL }}
           VITE_KEYCLOAK_REALM: ${{ vars.VITE_KEYCLOAK_REALM }}
           VITE_KEYCLOAK_CLIENT_ID: ${{ vars.VITE_KEYCLOAK_CLIENT_ID }}
+          VITE_MATOMO_CONTAINER_URL: ${{ vars.VITE_MATOMO_CONTAINER_URL }}
         run: npm run build
 
       - name: Upload build artifacts

--- a/infra/app/github_actions.tf
+++ b/infra/app/github_actions.tf
@@ -108,6 +108,14 @@ resource "github_actions_environment_variable" "vite_keycloak_client_id" {
   value         = var.keycloak_client_id
 }
 
+resource "github_actions_environment_variable" "vite_matomo_container_url" {
+  count         = var.matomo_container_url != "" ? 1 : 0
+  repository    = github_repository_environment.environment.repository
+  environment   = github_repository_environment.environment.environment
+  variable_name = "VITE_MATOMO_CONTAINER_URL"
+  value         = var.matomo_container_url
+}
+
 resource "github_actions_environment_variable" "frontdoor_resource_group" {
   repository    = github_repository_environment.environment.repository
   environment   = github_repository_environment.environment.environment

--- a/infra/app/variables.tf
+++ b/infra/app/variables.tf
@@ -94,3 +94,9 @@ variable "keycloak_client_id" {
   type        = string
 }
 
+variable "matomo_container_url" {
+  description = "Matomo Tag Manager container URL for this environment; empty disables analytics"
+  type        = string
+  default     = ""
+}
+

--- a/src/analytics/matomo.ts
+++ b/src/analytics/matomo.ts
@@ -1,0 +1,18 @@
+declare global {
+  interface Window {
+    _mtm?: Array<Record<string, unknown>>;
+  }
+}
+
+export function initMatomo(containerUrl: string | undefined): void {
+  if (!containerUrl) return;
+
+  const _mtm = (window._mtm = window._mtm || []);
+  _mtm.push({ "mtm.startTime": new Date().getTime(), event: "mtm.Start" });
+
+  const g = document.createElement("script");
+  const s = document.getElementsByTagName("script")[0];
+  g.async = true;
+  g.src = containerUrl;
+  s.parentNode!.insertBefore(g, s);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,8 @@ export const KEYCLOAK_URL = import.meta.env.VITE_KEYCLOAK_URL;
 export const KEYCLOAK_REALM = import.meta.env.VITE_KEYCLOAK_REALM;
 export const KEYCLOAK_CLIENT_ID = import.meta.env.VITE_KEYCLOAK_CLIENT_ID;
 
+export const MATOMO_CONTAINER_URL = import.meta.env.VITE_MATOMO_CONTAINER_URL;
+
 const VOCAB_PROXY_TARGET = import.meta.env.VITE_VOCAB_PROXY_TARGET;
 
 /**

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,9 @@
 import { render } from "preact";
 import { App } from "./App";
+import { initMatomo } from "./analytics/matomo";
 import { AuthError, Loading } from "./auth/AuthGate";
 import { initKeycloak } from "./auth/keycloak";
+import { MATOMO_CONTAINER_URL } from "./config";
 import "./styles/reset.css";
 import "./styles/fonts.css";
 import "./styles/variables.css";
@@ -10,6 +12,8 @@ import "./styles/auth-gate.css";
 const root = document.getElementById("app")!;
 
 render(<Loading />, root);
+
+initMatomo(MATOMO_CONTAINER_URL);
 
 initKeycloak()
   .then(() => render(<App />, root))

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE: string;
+  readonly VITE_MATOMO_CONTAINER_URL?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
Closes #28.

## Summary

- Adds `src/analytics/matomo.ts` mirroring Matomo's official Tag Manager snippet. No-ops when `VITE_MATOMO_CONTAINER_URL` is empty/unset.
- Wires `initMatomo(MATOMO_CONTAINER_URL)` into `src/main.tsx` before `initKeycloak()`.
- Plumbs the per-env container URL through Terraform (`matomo_container_url`) and `.github/workflows/deploy.yml` (new `VITE_MATOMO_CONTAINER_URL` build env). The Terraform `github_actions_environment_variable` resource is `count`-guarded to skip envs where the URL is empty (GitHub's API rejects empty values).

## Privacy posture (Path A — anonymous, no consent banner)

Same shape as the taxonomy-builder integration: cookieless tracking + IP anonymisation + DoNotTrack + no `setUserId` are all configured on the Matomo Tracker tag inside MTM, not in app code. SPA route changes are picked up by MTM's History Change trigger (preact-router's existing `pushState` calls trigger it without app-side wiring).

## Operational notes

- evidence-repo-ui gets its own Matomo site **and** its own MTM container (separate from the two taxonomy-builder containers), with three published versions per environment (`dev`, `staging`, `production`). Container URL pattern: `https://cdn.matomo.cloud/futureevidence.matomo.cloud/container_<id>{,_dev_<hash>,_staging_<hash>}.js`.
- After `terraform apply` per environment, set `matomo_container_url` to the env-appropriate container URL. Default is `""` so envs without containers configured remain unaffected.
- Companion PR for taxonomy-builder is destiny-evidence/taxonomy-builder#213.

## Test plan

- [X] With `VITE_MATOMO_CONTAINER_URL` set to the dev container URL: container script loads, Matomo dev environment shows visits.
- [X] With `VITE_MATOMO_CONTAINER_URL` unset: no script request, no console errors, `window._mtm` undefined.
- [X] MTM Preview/Debug confirms Page View + History Change triggers fire correctly through preact-router navigation.