### PR TITLE
Purge Front Door cache for custom domain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,5 +97,6 @@ jobs:
               --resource-group ${{ vars.FRONTDOOR_RESOURCE_GROUP }} \
               --profile-name ${{ vars.FRONTDOOR_PROFILE_NAME }} \
               --endpoint-name ${{ vars.FRONTDOOR_ENDPOINT_NAME }} \
+              --domains ${{ vars.CUSTOM_DOMAIN }} \
               --content-paths "/*" \
               --no-wait

--- a/infra/app/github_actions.tf
+++ b/infra/app/github_actions.tf
@@ -136,3 +136,10 @@ resource "github_actions_environment_variable" "frontdoor_endpoint_name" {
   variable_name = "FRONTDOOR_ENDPOINT_NAME"
   value         = azurerm_cdn_frontdoor_endpoint.this.name
 }
+
+resource "github_actions_environment_variable" "custom_domain" {
+  repository    = github_repository_environment.environment.repository
+  environment   = github_repository_environment.environment.environment
+  variable_name = "CUSTOM_DOMAIN"
+  value         = local.custom_domain
+}


### PR DESCRIPTION
## Summary
- Pass `--domains \${{ vars.CUSTOM_DOMAIN }}` to `az afd endpoint purge` so the custom-domain cache is actually invalidated. Without it, the purge only hits the default `*.azurefd.net` hostname and users continue to see stale content (reproducible with a cache-busting query string).
- Add a `CUSTOM_DOMAIN` GitHub Actions environment variable (sourced from `local.custom_domain`) per environment via Terraform, mirroring the `FEEDBACK_CUSTOM_DOMAIN` pattern used in taxonomy-builder.

## Rollout
- Requires `terraform apply` for each environment (staging/production/development) before this workflow change will succeed — otherwise `--domains` is empty and the purge fails.

## Test plan
- [x] Apply terraform for staging; confirm `CUSTOM_DOMAIN` appears under the environment's variables on GitHub
- [x] Run the deploy workflow on staging
- [x] Hit the custom-domain URL without a query string and confirm the new build is served