### PR TITLE
Search export button and download flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@ VITE_KEYCLOAK_URL=https://auth.evidence-repository.org
 VITE_KEYCLOAK_REALM=destiny
 VITE_KEYCLOAK_CLIENT_ID=evidence-repo-ui-client-development
 # VITE_MATOMO_CONTAINER_URL=https://cdn.matomo.cloud/futureevidence.matomo.cloud/container_<id>_dev_<hash>.js
+VITE_EXPORT_VOCABULARY_URL=https://vocab.staging.evidence-repository.org/published/019d40cf-2a63-77af-9828-c6a70647792c/1.1/vocabulary.jsonld
+VITE_EXPORT_CONTEXT_URL=https://vocab.staging.evidence-repository.org/published/019d40cf-2a63-77af-9828-c6a70647792c/1.1/context.jsonld

--- a/src/components/TagGroup.css
+++ b/src/components/TagGroup.css
@@ -28,36 +28,11 @@
   font-weight: 500;
 }
 
-/* Tooltip: shown on hover/focus for tags carrying a skos:definition. */
-.tag-group__tag[data-def] {
-  position: relative;
+.tag-group__tag--has-tooltip {
   cursor: help;
 }
 
-.tag-group__tag[data-def]:hover::after,
-.tag-group__tag[data-def]:focus-visible::after {
-  content: attr(data-def);
-  position: absolute;
-  bottom: calc(100% + 8px);
-  left: 50%;
-  transform: translateX(-50%);
-  background: #161b22;
-  color: #fff;
-  padding: 12px 14px;
-  border-radius: var(--radius-lg);
-  font-size: 14px;
-  font-weight: 400;
-  line-height: 1.4;
-  width: max-content;
-  max-width: 280px;
-  white-space: normal;
-  text-align: left;
-  z-index: 10;
-  pointer-events: none;
-  box-shadow: var(--shadow-md);
-}
-
-.tag-group__tag[data-def]:focus-visible {
+.tag-group__tag--has-tooltip:focus-visible {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
 }

--- a/src/components/TagGroup.tsx
+++ b/src/components/TagGroup.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from "./Tooltip";
 import "./TagGroup.css";
 
 export interface HierarchicalTag {
@@ -29,21 +30,26 @@ export function TagGroup({ label, tags }: TagGroupProps) {
       {label && <span class="tag-group__label lg-label">{label}</span>}
       {validTags.map((tag, i) => {
         if (isHierarchical(tag)) {
+          const hasDefinition = !!tag.definition;
           return (
-            <span
-              key={`${tag.label}-${i}`}
-              class="tag-group__tag"
-              data-def={tag.definition || undefined}
-              tabIndex={tag.definition ? 0 : undefined}
-            >
-              {tag.parent && (
-                <>
-                  <span class="tag-group__tag-parent">{tag.parent}</span>
-                  <span class="tag-group__tag-sep"> › </span>
-                </>
-              )}
-              <span class="tag-group__tag-child">{tag.label}</span>
-            </span>
+            <Tooltip key={`${tag.label}-${i}`} text={tag.definition}>
+              <span
+                class={
+                  hasDefinition
+                    ? "tag-group__tag tag-group__tag--has-tooltip"
+                    : "tag-group__tag"
+                }
+                tabIndex={hasDefinition ? 0 : undefined}
+              >
+                {tag.parent && (
+                  <>
+                    <span class="tag-group__tag-parent">{tag.parent}</span>
+                    <span class="tag-group__tag-sep"> › </span>
+                  </>
+                )}
+                <span class="tag-group__tag-child">{tag.label}</span>
+              </span>
+            </Tooltip>
           );
         }
         return (

--- a/src/components/Tooltip.css
+++ b/src/components/Tooltip.css
@@ -1,0 +1,39 @@
+/**
+ * CSS-only tooltip: the trigger renders the `text` prop in a pill above
+ * itself on hover or keyboard focus, via a positioned pseudo-element.
+ *
+ * Known limitations:
+ * - No viewport-edge clamping; tooltips near the right edge of narrow
+ *   viewports may clip.
+ * - No portaling; an ancestor with `overflow: hidden` will clip the
+ *   bubble.
+ */
+
+.tooltip {
+  position: relative;
+  display: inline-flex;
+}
+
+.tooltip:hover::after,
+.tooltip:focus-within::after,
+.tooltip:focus-visible::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: #161b22;
+  color: #fff;
+  padding: 12px 14px;
+  border-radius: var(--radius-lg);
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.4;
+  width: max-content;
+  max-width: 280px;
+  white-space: normal;
+  text-align: left;
+  z-index: 10;
+  pointer-events: none;
+  box-shadow: var(--shadow-md);
+}

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,0 +1,22 @@
+import type { ComponentChildren } from "preact";
+import "./Tooltip.css";
+
+interface TooltipProps {
+  /** When undefined or empty, the trigger renders without tooltip behavior. */
+  text: string | undefined;
+  children: ComponentChildren;
+}
+
+/**
+ * Wrap a trigger element to show a hover/focus tooltip with the given text.
+ * The trigger inside is responsible for its own cursor, tabIndex, and focus
+ * outline; this component only provides the bubble.
+ */
+export function Tooltip({ text, children }: TooltipProps) {
+  if (!text) return <>{children}</>;
+  return (
+    <span class="tooltip" data-tooltip={text}>
+      {children}
+    </span>
+  );
+}

--- a/src/components/search/ExportButton.css
+++ b/src/components/search/ExportButton.css
@@ -1,0 +1,26 @@
+.export-button {
+  background: var(--color-bg-inset);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font-family: var(--font-body);
+  font-size: var(--font-size-xs);
+  line-height: 1.2;
+  padding: 5px 12px;
+}
+
+.export-button:hover:not(:disabled) {
+  background: var(--color-bg-elevated, var(--color-bg-inset));
+  color: var(--color-text-primary);
+}
+
+.export-button:focus {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -1px;
+}
+
+.export-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/src/components/search/ExportButton.css
+++ b/src/components/search/ExportButton.css
@@ -10,7 +10,7 @@
   padding: 5px 12px;
 }
 
-.export-button:hover:not(:disabled) {
+.export-button:hover:not([aria-disabled="true"]) {
   background: var(--color-bg-elevated, var(--color-bg-inset));
   color: var(--color-text-primary);
 }
@@ -20,7 +20,7 @@
   outline-offset: -1px;
 }
 
-.export-button:disabled {
+.export-button[aria-disabled="true"] {
   opacity: 0.5;
   cursor: not-allowed;
 }

--- a/src/components/search/ExportButton.tsx
+++ b/src/components/search/ExportButton.tsx
@@ -40,7 +40,6 @@ export function ExportButton({
         class="export-button"
         onClick={disabled ? undefined : onClick}
         aria-disabled={disabled ? "true" : undefined}
-        aria-label={label}
         aria-describedby={tooltip ? tooltipId : undefined}
       >
         {label}

--- a/src/components/search/ExportButton.tsx
+++ b/src/components/search/ExportButton.tsx
@@ -1,0 +1,45 @@
+import { Tooltip } from "@/components/Tooltip";
+import type { ExportStatus } from "@/hooks/useSearchExport";
+import "./ExportButton.css";
+
+interface ExportButtonProps {
+  disabled: boolean;
+  status: ExportStatus;
+  onClick: () => void;
+  tooltip?: string;
+}
+
+function labelFor(status: ExportStatus): string {
+  switch (status) {
+    case "requesting":
+    case "polling":
+      return "Preparing…";
+    case "downloading":
+      return "Downloading…";
+    default:
+      return "Export to Excel";
+  }
+}
+
+export function ExportButton({
+  disabled,
+  status,
+  onClick,
+  tooltip,
+}: ExportButtonProps) {
+  // Tooltip wraps the button so :hover fires on the wrapper rather than the
+  // disabled <button>, which Firefox doesn't route hover events to.
+  return (
+    <Tooltip text={tooltip}>
+      <button
+        type="button"
+        class="export-button"
+        onClick={onClick}
+        disabled={disabled}
+        aria-label={labelFor(status)}
+      >
+        {labelFor(status)}
+      </button>
+    </Tooltip>
+  );
+}

--- a/src/components/search/ExportButton.tsx
+++ b/src/components/search/ExportButton.tsx
@@ -1,3 +1,4 @@
+import { useId } from "preact/hooks";
 import { Tooltip } from "@/components/Tooltip";
 import type { ExportStatus } from "@/hooks/useSearchExport";
 import "./ExportButton.css";
@@ -27,19 +28,28 @@ export function ExportButton({
   onClick,
   tooltip,
 }: ExportButtonProps) {
-  // Tooltip wraps the button so :hover fires on the wrapper rather than the
-  // disabled <button>, which Firefox doesn't route hover events to.
+  const tooltipId = useId();
+  const label = labelFor(status);
+  // aria-disabled (rather than native disabled) keeps the button in the tab
+  // order so keyboard / screen-reader users can focus it, hear the reason
+  // it's unavailable via aria-describedby, and move on. Click is guarded.
   return (
     <Tooltip text={tooltip}>
       <button
         type="button"
         class="export-button"
-        onClick={onClick}
-        disabled={disabled}
-        aria-label={labelFor(status)}
+        onClick={disabled ? undefined : onClick}
+        aria-disabled={disabled ? "true" : undefined}
+        aria-label={label}
+        aria-describedby={tooltip ? tooltipId : undefined}
       >
-        {labelFor(status)}
+        {label}
       </button>
+      {tooltip && (
+        <span id={tooltipId} class="visually-hidden">
+          {tooltip}
+        </span>
+      )}
     </Tooltip>
   );
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,9 @@ export const KEYCLOAK_CLIENT_ID = import.meta.env.VITE_KEYCLOAK_CLIENT_ID;
 
 export const MATOMO_CONTAINER_URL = import.meta.env.VITE_MATOMO_CONTAINER_URL;
 
+export const EXPORT_VOCABULARY_URL = import.meta.env.VITE_EXPORT_VOCABULARY_URL;
+export const EXPORT_CONTEXT_URL = import.meta.env.VITE_EXPORT_CONTEXT_URL;
+
 const VOCAB_PROXY_TARGET = import.meta.env.VITE_VOCAB_PROXY_TARGET;
 
 /**

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "preact/hooks";
-import { searchReferences, SORT_BACKEND, type SearchFilters } from "@/services/apiClient";
+import { searchReferences, type SearchFilters } from "@/services/apiClient";
+import { SORT_BACKEND } from "@/services/searchParams";
 import { useCommunity } from "@/community/CommunityContext";
 import type { SearchResult } from "@/types/models";
 import type { SearchParams } from "@/services/searchParams";

--- a/src/hooks/useSearchExport.ts
+++ b/src/hooks/useSearchExport.ts
@@ -30,17 +30,27 @@ export interface UseSearchExportResult {
 
 const POLL_INTERVAL_MS = 2000;
 
+/**
+ * Drives the export request → polling → download pipeline.
+ *
+ * **Cancellation.** Each call to `start` increments `runIdRef` and captures the
+ * new id in a closure. Every async callback compares its captured id against
+ * the live ref via `isCurrentRun()` and bails if they differ — meaning the
+ * user called `start` again, `reset`, or unmounted. State writes on stale
+ * callbacks would either warn (post-unmount) or corrupt the current run's
+ * state machine. AbortController would be the canonical alternative but
+ * would mean threading `signal` through the API client, the export module
+ * and `streamJsonlFromUrl`; revisit if any of those grow other reasons to
+ * abort.
+ */
 export function useSearchExport(): UseSearchExportResult {
   const [status, setStatus] = useState<ExportStatus>("idle");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  // Generation counter — bumped on reset/unmount. Callbacks that started under
-  // generation N bail if cancelRef.current !== N, so a late poll response from
-  // a cancelled run never writes state.
-  const cancelRef = useRef(0);
+  const runIdRef = useRef(0);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const clearTimeoutRef = useCallback(() => {
+  const clearScheduledPoll = useCallback(() => {
     if (timeoutRef.current !== null) {
       clearTimeout(timeoutRef.current);
       timeoutRef.current = null;
@@ -48,18 +58,18 @@ export function useSearchExport(): UseSearchExportResult {
   }, []);
 
   const reset = useCallback(() => {
-    cancelRef.current += 1;
-    clearTimeoutRef();
+    runIdRef.current += 1;
+    clearScheduledPoll();
     setStatus("idle");
     setErrorMessage(null);
-  }, [clearTimeoutRef]);
+  }, [clearScheduledPoll]);
 
   useEffect(() => {
     return () => {
-      cancelRef.current += 1;
-      clearTimeoutRef();
+      runIdRef.current += 1;
+      clearScheduledPoll();
     };
-  }, [clearTimeoutRef]);
+  }, [clearScheduledPoll]);
 
   const start = useCallback(
     (
@@ -67,9 +77,9 @@ export function useSearchExport(): UseSearchExportResult {
       filters: Omit<SearchFilters, "page">,
       filename: string,
     ) => {
-      cancelRef.current += 1;
-      const generation = cancelRef.current;
-      clearTimeoutRef();
+      runIdRef.current += 1;
+      const runId = runIdRef.current;
+      clearScheduledPoll();
       setErrorMessage(null);
 
       // Vocab/context URLs are optional — the workbook falls back to raw
@@ -84,13 +94,20 @@ export function useSearchExport(): UseSearchExportResult {
 
       setStatus("requesting");
 
-      const isActive = () => cancelRef.current === generation;
+      const isCurrentRun = () => runIdRef.current === runId;
+
+      // Drop the run into the error state, but only if it's still the
+      // current one — cancelled runs must not overwrite a fresh run's state.
+      const fail = (message: string) => {
+        if (!isCurrentRun()) return;
+        setErrorMessage(message);
+        setStatus("error");
+      };
 
       const handleCompleted = async (job: SearchExportRead) => {
-        if (!isActive()) return;
+        if (!isCurrentRun()) return;
         if (!job.result_url) {
-          setErrorMessage("Export finished but no download URL was returned.");
-          setStatus("error");
+          fail("Export finished but no download URL was returned.");
           return;
         }
         setStatus("downloading");
@@ -102,55 +119,47 @@ export function useSearchExport(): UseSearchExportResult {
             filename,
           );
         } catch (err) {
-          if (!isActive()) return;
-          setErrorMessage(
-            err instanceof Error ? err.message : "Failed to build the Excel file.",
-          );
-          setStatus("error");
+          fail(err instanceof Error ? err.message : "Failed to build the Excel file.");
           return;
         }
-        if (!isActive()) return;
+        if (!isCurrentRun()) return;
         setStatus("done");
       };
 
       const poll = (jobId: string) => {
-        if (!isActive()) return;
+        if (!isCurrentRun()) return;
         getSearchExport(jobId)
           .then((job) => {
-            if (!isActive()) return;
+            if (!isCurrentRun()) return;
             if (job.status === "completed") {
               void handleCompleted(job);
               return;
             }
             if (job.status === "failed") {
-              setErrorMessage(job.error || "The export job failed.");
-              setStatus("error");
+              fail(job.error || "The export job failed.");
               return;
             }
             // pending or running — keep polling.
             timeoutRef.current = setTimeout(() => poll(jobId), POLL_INTERVAL_MS);
           })
           .catch((err) => {
-            if (!isActive()) return;
-            setErrorMessage(
+            fail(
               err instanceof Error
                 ? err.message
                 : "Lost contact with the export job. Please try again.",
             );
-            setStatus("error");
           });
       };
 
       requestSearchExport(query, filters)
         .then((job) => {
-          if (!isActive()) return;
+          if (!isCurrentRun()) return;
           if (job.status === "completed") {
             void handleCompleted(job);
             return;
           }
           if (job.status === "failed") {
-            setErrorMessage(job.error || "The export job failed.");
-            setStatus("error");
+            fail(job.error || "The export job failed.");
             return;
           }
           setStatus("polling");
@@ -160,14 +169,10 @@ export function useSearchExport(): UseSearchExportResult {
           );
         })
         .catch((err) => {
-          if (!isActive()) return;
-          setErrorMessage(
-            err instanceof Error ? err.message : "Failed to start the export.",
-          );
-          setStatus("error");
+          fail(err instanceof Error ? err.message : "Failed to start the export.");
         });
     },
-    [clearTimeoutRef],
+    [clearScheduledPoll],
   );
 
   return { status, errorMessage, start, reset };

--- a/src/hooks/useSearchExport.ts
+++ b/src/hooks/useSearchExport.ts
@@ -1,0 +1,163 @@
+import { useCallback, useEffect, useRef, useState } from "preact/hooks";
+
+import { EXPORT_CONTEXT_URL, EXPORT_VOCABULARY_URL } from "@/config";
+import {
+  getSearchExport,
+  requestSearchExport,
+  type SearchFilters,
+} from "@/services/apiClient";
+import { exportReferencesToExcel } from "@/services/export/export";
+import type { SearchExportRead } from "@/types/models";
+
+export type ExportStatus =
+  | "idle"
+  | "requesting"
+  | "polling"
+  | "downloading"
+  | "done"
+  | "error";
+
+export interface UseSearchExportResult {
+  status: ExportStatus;
+  errorMessage: string | null;
+  start: (
+    query: string,
+    filters: Omit<SearchFilters, "page">,
+    filename: string,
+  ) => void;
+  reset: () => void;
+}
+
+const POLL_INTERVAL_MS = 2000;
+
+export function useSearchExport(): UseSearchExportResult {
+  const [status, setStatus] = useState<ExportStatus>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  // Generation counter — bumped on reset/unmount. Callbacks that started under
+  // generation N bail if cancelRef.current !== N, so a late poll response from
+  // a cancelled run never writes state.
+  const cancelRef = useRef(0);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimeoutRef = useCallback(() => {
+    if (timeoutRef.current !== null) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    cancelRef.current += 1;
+    clearTimeoutRef();
+    setStatus("idle");
+    setErrorMessage(null);
+  }, [clearTimeoutRef]);
+
+  useEffect(() => {
+    return () => {
+      cancelRef.current += 1;
+      clearTimeoutRef();
+    };
+  }, [clearTimeoutRef]);
+
+  const start = useCallback(
+    (
+      query: string,
+      filters: Omit<SearchFilters, "page">,
+      filename: string,
+    ) => {
+      cancelRef.current += 1;
+      const generation = cancelRef.current;
+      clearTimeoutRef();
+      setErrorMessage(null);
+      setStatus("requesting");
+
+      const isActive = () => cancelRef.current === generation;
+
+      const handleCompleted = async (job: SearchExportRead) => {
+        if (!isActive()) return;
+        if (!job.result_url) {
+          setErrorMessage("Export finished but no download URL was returned.");
+          setStatus("error");
+          return;
+        }
+        setStatus("downloading");
+        try {
+          await exportReferencesToExcel(
+            job.result_url,
+            EXPORT_VOCABULARY_URL,
+            EXPORT_CONTEXT_URL,
+            filename,
+          );
+        } catch (err) {
+          if (!isActive()) return;
+          setErrorMessage(
+            err instanceof Error ? err.message : "Failed to build the Excel file.",
+          );
+          setStatus("error");
+          return;
+        }
+        if (!isActive()) return;
+        setStatus("done");
+      };
+
+      const poll = (jobId: string) => {
+        if (!isActive()) return;
+        getSearchExport(jobId)
+          .then((job) => {
+            if (!isActive()) return;
+            if (job.status === "completed") {
+              void handleCompleted(job);
+              return;
+            }
+            if (job.status === "failed") {
+              setErrorMessage(job.error || "The export job failed.");
+              setStatus("error");
+              return;
+            }
+            // pending or running — keep polling.
+            timeoutRef.current = setTimeout(() => poll(jobId), POLL_INTERVAL_MS);
+          })
+          .catch((err) => {
+            if (!isActive()) return;
+            setErrorMessage(
+              err instanceof Error
+                ? err.message
+                : "Lost contact with the export job. Please try again.",
+            );
+            setStatus("error");
+          });
+      };
+
+      requestSearchExport(query, filters)
+        .then((job) => {
+          if (!isActive()) return;
+          if (job.status === "completed") {
+            void handleCompleted(job);
+            return;
+          }
+          if (job.status === "failed") {
+            setErrorMessage(job.error || "The export job failed.");
+            setStatus("error");
+            return;
+          }
+          setStatus("polling");
+          timeoutRef.current = setTimeout(
+            () => poll(job.id),
+            POLL_INTERVAL_MS,
+          );
+        })
+        .catch((err) => {
+          if (!isActive()) return;
+          setErrorMessage(
+            err instanceof Error ? err.message : "Failed to start the export.",
+          );
+          setStatus("error");
+        });
+    },
+    [clearTimeoutRef],
+  );
+
+  return { status, errorMessage, start, reset };
+}

--- a/src/hooks/useSearchExport.ts
+++ b/src/hooks/useSearchExport.ts
@@ -72,14 +72,14 @@ export function useSearchExport(): UseSearchExportResult {
       clearTimeoutRef();
       setErrorMessage(null);
 
-      // Fail loud-but-friendly when the deploy is missing vocab/context URLs
-      // rather than letting fetch("undefined") produce a confusing 404.
+      // Vocab/context URLs are optional — the workbook falls back to raw
+      // CURIEs when they're missing. Warn so misconfiguration is visible
+      // in devtools without surfacing a user-facing error.
       if (!EXPORT_VOCABULARY_URL || !EXPORT_CONTEXT_URL) {
-        setErrorMessage(
-          "Export is not configured for this deployment. Contact an administrator.",
+        console.warn(
+          "Export vocab/context URLs not configured; concept cells will contain raw CURIEs.",
+          { EXPORT_VOCABULARY_URL, EXPORT_CONTEXT_URL },
         );
-        setStatus("error");
-        return;
       }
 
       setStatus("requesting");

--- a/src/hooks/useSearchExport.ts
+++ b/src/hooks/useSearchExport.ts
@@ -71,6 +71,17 @@ export function useSearchExport(): UseSearchExportResult {
       const generation = cancelRef.current;
       clearTimeoutRef();
       setErrorMessage(null);
+
+      // Fail loud-but-friendly when the deploy is missing vocab/context URLs
+      // rather than letting fetch("undefined") produce a confusing 404.
+      if (!EXPORT_VOCABULARY_URL || !EXPORT_CONTEXT_URL) {
+        setErrorMessage(
+          "Export is not configured for this deployment. Contact an administrator.",
+        );
+        setStatus("error");
+        return;
+      }
+
       setStatus("requesting");
 
       const isActive = () => cancelRef.current === generation;

--- a/src/hooks/useSearchExport.ts
+++ b/src/hooks/useSearchExport.ts
@@ -33,15 +33,12 @@ const POLL_INTERVAL_MS = 2000;
 /**
  * Drives the export request → polling → download pipeline.
  *
- * **Cancellation.** Each call to `start` increments `runIdRef` and captures the
- * new id in a closure. Every async callback compares its captured id against
- * the live ref via `isCurrentRun()` and bails if they differ — meaning the
- * user called `start` again, `reset`, or unmounted. State writes on stale
- * callbacks would either warn (post-unmount) or corrupt the current run's
- * state machine. AbortController would be the canonical alternative but
- * would mean threading `signal` through the API client, the export module
- * and `streamJsonlFromUrl`; revisit if any of those grow other reasons to
- * abort.
+ * **Cancellation.** Each call to `start` increments `runIdRef` and captures
+ * the new id in a closure. Every async callback compares its captured id
+ * against the live ref via `isCurrentRun()` and bails if they differ —
+ * meaning the user called `start` again, `reset`, or unmounted. Without the
+ * guard, a stale callback from a cancelled run could clobber the current
+ * run's state machine.
  */
 export function useSearchExport(): UseSearchExportResult {
   const [status, setStatus] = useState<ExportStatus>("idle");
@@ -64,27 +61,19 @@ export function useSearchExport(): UseSearchExportResult {
     setErrorMessage(null);
   }, [clearScheduledPoll]);
 
-  useEffect(() => {
-    return () => {
-      runIdRef.current += 1;
-      clearScheduledPoll();
-    };
-  }, [clearScheduledPoll]);
+  // Cancel any in-flight run on unmount. The setStatus/setErrorMessage
+  // inside reset() are no-ops on the unmounted component.
+  useEffect(() => reset, [reset]);
 
   const start = useCallback(
-    (
-      query: string,
-      filters: Omit<SearchFilters, "page">,
-      filename: string,
-    ) => {
+    (query: string, filters: Omit<SearchFilters, "page">, filename: string) => {
       runIdRef.current += 1;
       const runId = runIdRef.current;
       clearScheduledPoll();
       setErrorMessage(null);
 
-      // Vocab/context URLs are optional — the workbook falls back to raw
-      // CURIEs when they're missing. Warn so misconfiguration is visible
-      // in devtools without surfacing a user-facing error.
+      // The workbook falls back to raw CURIEs when Vocab/context URLs are missing.
+      // Warn so misconfiguration is visible in devtools without surfacing a user-facing error.
       if (!EXPORT_VOCABULARY_URL || !EXPORT_CONTEXT_URL) {
         console.warn(
           "Export vocab/context URLs not configured; concept cells will contain raw CURIEs.",
@@ -119,11 +108,34 @@ export function useSearchExport(): UseSearchExportResult {
             filename,
           );
         } catch (err) {
-          fail(err instanceof Error ? err.message : "Failed to build the Excel file.");
+          fail(
+            err instanceof Error
+              ? err.message
+              : "Failed to build the Excel file.",
+          );
           return;
         }
         if (!isCurrentRun()) return;
         setStatus("done");
+      };
+
+      const schedulePoll = (jobId: string) => {
+        timeoutRef.current = setTimeout(() => poll(jobId), POLL_INTERVAL_MS);
+      };
+
+      const handleStatus = (job: SearchExportRead) => {
+        if (job.status === "completed") {
+          handleCompleted(job);
+          return;
+        }
+        if (job.status === "failed") {
+          fail(job.error || "The export job failed.");
+          return;
+        }
+        // pending or running — keep polling. setStatus is idempotent on the
+        // second-and-later passes; Preact bails on same-value state writes.
+        setStatus("polling");
+        schedulePoll(job.id);
       };
 
       const poll = (jobId: string) => {
@@ -131,16 +143,7 @@ export function useSearchExport(): UseSearchExportResult {
         getSearchExport(jobId)
           .then((job) => {
             if (!isCurrentRun()) return;
-            if (job.status === "completed") {
-              void handleCompleted(job);
-              return;
-            }
-            if (job.status === "failed") {
-              fail(job.error || "The export job failed.");
-              return;
-            }
-            // pending or running — keep polling.
-            timeoutRef.current = setTimeout(() => poll(jobId), POLL_INTERVAL_MS);
+            handleStatus(job);
           })
           .catch((err) => {
             fail(
@@ -154,22 +157,12 @@ export function useSearchExport(): UseSearchExportResult {
       requestSearchExport(query, filters)
         .then((job) => {
           if (!isCurrentRun()) return;
-          if (job.status === "completed") {
-            void handleCompleted(job);
-            return;
-          }
-          if (job.status === "failed") {
-            fail(job.error || "The export job failed.");
-            return;
-          }
-          setStatus("polling");
-          timeoutRef.current = setTimeout(
-            () => poll(job.id),
-            POLL_INTERVAL_MS,
-          );
+          handleStatus(job);
         })
         .catch((err) => {
-          fail(err instanceof Error ? err.message : "Failed to start the export.");
+          fail(
+            err instanceof Error ? err.message : "Failed to start the export.",
+          );
         });
     },
     [clearScheduledPoll],

--- a/src/pages/SearchPage.css
+++ b/src/pages/SearchPage.css
@@ -72,7 +72,7 @@
 
 .search-results__export-status {
   font-size: var(--font-size-small);
-  color: var(--color-text-secondary);
+  color: var(--color-danger);
 }
 
 .search-results__meta-count {

--- a/src/pages/SearchPage.css
+++ b/src/pages/SearchPage.css
@@ -64,6 +64,17 @@
   gap: var(--spacing-sm);
 }
 
+.search-results__meta-right {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.search-results__export-status {
+  font-size: var(--font-size-small);
+  color: var(--color-text-secondary);
+}
+
 .search-results__meta-count {
   font-family: var(--font-mono);
   font-size: 15px;

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -7,8 +7,11 @@ import { useUrlParams } from "@/hooks/useUrlParams";
 import { useCorpusTotal } from "@/hooks/useCorpusTotal";
 import { useSearch } from "@/hooks/useSearch";
 import { useSearchDraft } from "@/hooks/useSearchDraft";
+import { useSearchExport } from "@/hooks/useSearchExport";
+import { SORT_BACKEND, type SearchFilters } from "@/services/apiClient";
 import { SearchBar } from "@/components/search/SearchBar";
 import { SortDropdown } from "@/components/search/SortDropdown";
+import { ExportButton } from "@/components/search/ExportButton";
 import { ResultRow } from "@/components/search/ResultRow";
 import { Pagination } from "@/components/Pagination";
 import { NotFoundPage } from "./NotFoundPage";
@@ -30,6 +33,17 @@ function formatYearClause(start: number | undefined, end: number | undefined): s
   if (start !== undefined) return ` from ${start}`;
   if (end !== undefined) return ` to ${end}`;
   return "";
+}
+
+// 10k is destiny-repository's max_result_window; deep pagination + exports
+// past that are explicitly out of scope. Mirrors the search backend cap.
+const EXPORT_MAX_RESULTS = 10000;
+
+function formatExportFilename(slug: string, now: Date = new Date()): string {
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, "0");
+  const d = String(now.getDate()).padStart(2, "0");
+  return `destiny-evidence-${slug}-${y}${m}${d}.xlsx`;
 }
 
 function formatResultsSummary(
@@ -74,6 +88,7 @@ function SearchPageInner({ community }: { community: Community }) {
 
   const corpus = useCorpusTotal();
   const results = useSearch(params);
+  const exportJob = useSearchExport();
 
   // Hide the bar on the initial browse-mode load so the skeleton owns the
   // full vertical space; show it as soon as there's anything to put in it.
@@ -105,6 +120,33 @@ function SearchPageInner({ community }: { community: Community }) {
     const committed = draft.commitDraft();
     if (!committed) return;
     navigate(buildSearchUrl(community.slug, { ...params, ...committed, sort, page: 1 }));
+  }
+
+  const queryEmpty = params.q.trim() === "";
+  const hasResults = results.results !== null && results.results.references.length > 0;
+  const overCap =
+    results.results !== null
+    && results.results.total.is_lower_bound
+    && results.results.total.count >= EXPORT_MAX_RESULTS;
+  const exportBusy =
+    exportJob.status === "requesting"
+    || exportJob.status === "polling"
+    || exportJob.status === "downloading";
+  const exportDisabled = queryEmpty || !hasResults || overCap || exportBusy;
+  const exportTooltip = queryEmpty
+    ? "Enter a search query to export."
+    : overCap
+      ? `Refine your search — exports are limited to ${EXPORT_MAX_RESULTS.toLocaleString()} results.`
+      : undefined;
+
+  function handleExport() {
+    const filters: Omit<SearchFilters, "page"> = {
+      startYear: params.startYear,
+      endYear: params.endYear,
+      annotation: community.defaultAnnotations,
+    };
+    if (params.sort !== undefined) filters.sort = [SORT_BACKEND[params.sort]];
+    exportJob.start(params.q, filters, formatExportFilename(community.slug));
   }
 
   // Page size comes from the API response (page.count) so the UI stays in
@@ -169,11 +211,27 @@ function SearchPageInner({ community }: { community: Community }) {
                 : null}
             </span>
             {results.results && (
-              <SortDropdown
-                value={params.sort}
-                onChange={handleSortChange}
-                disabled={results.loading}
-              />
+              <span class="search-results__meta-right">
+                {exportJob.status === "error" && (
+                  <span
+                    class="search-results__export-status"
+                    role="alert"
+                  >
+                    {exportJob.errorMessage ?? "Export failed."}
+                  </span>
+                )}
+                <ExportButton
+                  disabled={exportDisabled}
+                  status={exportJob.status}
+                  onClick={handleExport}
+                  tooltip={exportTooltip}
+                />
+                <SortDropdown
+                  value={params.sort}
+                  onChange={handleSortChange}
+                  disabled={results.loading}
+                />
+              </span>
             )}
           </div>
         )}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -123,6 +123,8 @@ function SearchPageInner({ community }: { community: Community }) {
   }
 
   const queryEmpty = params.q.trim() === "";
+  const hasYearFilter = params.startYear !== undefined || params.endYear !== undefined;
+  const noFilters = queryEmpty && !hasYearFilter;
   const hasResults = results.results !== null && results.results.references.length > 0;
   const overCap =
     results.results !== null
@@ -132,9 +134,9 @@ function SearchPageInner({ community }: { community: Community }) {
     exportJob.status === "requesting"
     || exportJob.status === "polling"
     || exportJob.status === "downloading";
-  const exportDisabled = queryEmpty || !hasResults || overCap || exportBusy;
-  const exportTooltip = queryEmpty
-    ? "Enter a search query to export."
+  const exportDisabled = noFilters || !hasResults || overCap || exportBusy;
+  const exportTooltip = noFilters
+    ? "Submit a search query to export."
     : overCap
       ? `Refine your search — exports are limited to ${EXPORT_MAX_RESULTS.toLocaleString()} results.`
       : undefined;
@@ -146,7 +148,10 @@ function SearchPageInner({ community }: { community: Community }) {
       annotation: community.defaultAnnotations,
     };
     if (params.sort !== undefined) filters.sort = [SORT_BACKEND[params.sort]];
-    exportJob.start(params.q, filters, formatExportFilename(community.slug));
+    // Backend requires q with min_length=1; substitute "*" for year-only
+    // searches so the year filter is the user-supplied intent.
+    const exportQuery = queryEmpty ? "*" : params.q;
+    exportJob.start(exportQuery, filters, formatExportFilename(community.slug));
   }
 
   // Page size comes from the API response (page.count) so the UI stays in

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -143,9 +143,6 @@ function SearchPageInner({ community }: { community: Community }) {
     navigate(buildSearchUrl(community.slug, { ...params, ...committed, sort, page: 1 }));
   }
 
-  const queryEmpty = params.q.trim() === "";
-  const hasYearFilter = params.startYear !== undefined || params.endYear !== undefined;
-  const noFilters = queryEmpty && !hasYearFilter;
   const hasResults = results.results !== null && results.results.references.length > 0;
   const overCap =
     results.results !== null
@@ -159,13 +156,8 @@ function SearchPageInner({ community }: { community: Community }) {
   // a new fetch is in flight, so `hasResults` / `overCap` would otherwise
   // reflect the previous search and let an export through against stale state.
   const exportDisabled =
-    noFilters
-    || !hasResults
-    || overCap
-    || exportBusy
-    || results.loading;
+    !hasResults || overCap || exportBusy || results.loading;
   const exportTooltip = ((): string | undefined => {
-    if (noFilters) return "Submit a search query to export.";
     // Suppress while refetching: would otherwise assert a stale count.
     if (results.loading) return undefined;
     if (overCap) {

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -139,7 +139,17 @@ function SearchPageInner({ community }: { community: Community }) {
     ? "Submit a search query to export."
     : overCap
       ? `Refine your search — exports are limited to ${EXPORT_MAX_RESULTS.toLocaleString()} results.`
-      : undefined;
+      : results.results !== null && !hasResults
+        ? "No results to export."
+        : undefined;
+  const exportLiveAnnouncement =
+    exportJob.status === "requesting" || exportJob.status === "polling"
+      ? "Preparing export…"
+      : exportJob.status === "downloading"
+        ? "Downloading export…"
+        : exportJob.status === "done"
+          ? "Export downloaded."
+          : "";
 
   function handleExport() {
     const filters: Omit<SearchFilters, "page"> = {
@@ -225,6 +235,13 @@ function SearchPageInner({ community }: { community: Community }) {
                     {exportJob.errorMessage ?? "Export failed."}
                   </span>
                 )}
+                <span
+                  class="visually-hidden"
+                  role="status"
+                  aria-live="polite"
+                >
+                  {exportLiveAnnouncement}
+                </span>
                 <ExportButton
                   disabled={exportDisabled}
                   status={exportJob.status}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -40,9 +40,11 @@ function formatYearClause(start: number | undefined, end: number | undefined): s
 const EXPORT_MAX_RESULTS = 10000;
 
 function formatExportFilename(slug: string, now: Date = new Date()): string {
-  const y = now.getFullYear();
-  const m = String(now.getMonth() + 1).padStart(2, "0");
-  const d = String(now.getDate()).padStart(2, "0");
+  // UTC so the same wall-clock click in different timezones produces the
+  // same filename — easier to diff/dedupe across users.
+  const y = now.getUTCFullYear();
+  const m = String(now.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(now.getUTCDate()).padStart(2, "0");
   return `destiny-evidence-${slug}-${y}${m}${d}.xlsx`;
 }
 

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -136,14 +136,24 @@ function SearchPageInner({ community }: { community: Community }) {
     exportJob.status === "requesting"
     || exportJob.status === "polling"
     || exportJob.status === "downloading";
-  const exportDisabled = noFilters || !hasResults || overCap || exportBusy;
+  // Gate on results.loading too: useSearch keeps prior results visible while
+  // a new fetch is in flight, so `hasResults` / `overCap` would otherwise
+  // reflect the previous search and let an export through against stale state.
+  const exportDisabled =
+    noFilters
+    || !hasResults
+    || overCap
+    || exportBusy
+    || results.loading;
   const exportTooltip = noFilters
     ? "Submit a search query to export."
-    : overCap
-      ? `Refine your search — exports are limited to ${EXPORT_MAX_RESULTS.toLocaleString()} results.`
-      : results.results !== null && !hasResults
-        ? "No results to export."
-        : undefined;
+    : results.loading
+      ? undefined
+      : overCap
+        ? `Refine your search — exports are limited to ${EXPORT_MAX_RESULTS.toLocaleString()} results.`
+        : !hasResults
+          ? "No results to export."
+          : undefined;
   const exportLiveAnnouncement =
     exportJob.status === "requesting" || exportJob.status === "polling"
       ? "Preparing export…"

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -7,7 +7,7 @@ import { useUrlParams } from "@/hooks/useUrlParams";
 import { useCorpusTotal } from "@/hooks/useCorpusTotal";
 import { useSearch } from "@/hooks/useSearch";
 import { useSearchDraft } from "@/hooks/useSearchDraft";
-import { useSearchExport } from "@/hooks/useSearchExport";
+import { useSearchExport, type ExportStatus } from "@/hooks/useSearchExport";
 import { SORT_BACKEND, type SearchFilters } from "@/services/apiClient";
 import { SearchBar } from "@/components/search/SearchBar";
 import { SortDropdown } from "@/components/search/SortDropdown";
@@ -46,6 +46,20 @@ function formatExportFilename(slug: string, now: Date = new Date()): string {
   const m = String(now.getUTCMonth() + 1).padStart(2, "0");
   const d = String(now.getUTCDate()).padStart(2, "0");
   return `destiny-evidence-${slug}-${y}${m}${d}.xlsx`;
+}
+
+function exportAnnouncementFor(status: ExportStatus): string {
+  switch (status) {
+    case "requesting":
+    case "polling":
+      return "Preparing export…";
+    case "downloading":
+      return "Downloading export…";
+    case "done":
+      return "Export downloaded.";
+    default:
+      return "";
+  }
 }
 
 function formatResultsSummary(
@@ -155,14 +169,7 @@ function SearchPageInner({ community }: { community: Community }) {
     if (!hasResults) return "No results to export.";
     return undefined;
   })();
-  const exportLiveAnnouncement =
-    exportJob.status === "requesting" || exportJob.status === "polling"
-      ? "Preparing export…"
-      : exportJob.status === "downloading"
-        ? "Downloading export…"
-        : exportJob.status === "done"
-          ? "Export downloaded."
-          : "";
+  const exportAnnouncement = exportAnnouncementFor(exportJob.status);
 
   function handleExport() {
     const filters: Omit<SearchFilters, "page"> = {
@@ -253,7 +260,7 @@ function SearchPageInner({ community }: { community: Community }) {
                   role="status"
                   aria-live="polite"
                 >
-                  {exportLiveAnnouncement}
+                  {exportAnnouncement}
                 </span>
                 <ExportButton
                   disabled={exportDisabled}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,14 +1,19 @@
 import { useEffect } from "preact/hooks";
 import { useCommunity } from "@/community/CommunityContext";
 import type { Community } from "@/types/models";
-import { parseSearchParams, toQueryString, buildSearchUrl, type SortOption } from "@/services/searchParams";
+import {
+  parseSearchParams,
+  toQueryString,
+  buildSearchUrl,
+  toExportSearchQuery,
+  type SortOption,
+} from "@/services/searchParams";
 import { navigate } from "@/services/navigation";
 import { useUrlParams } from "@/hooks/useUrlParams";
 import { useCorpusTotal } from "@/hooks/useCorpusTotal";
 import { useSearch } from "@/hooks/useSearch";
 import { useSearchDraft } from "@/hooks/useSearchDraft";
 import { useSearchExport, type ExportStatus } from "@/hooks/useSearchExport";
-import { SORT_BACKEND, type SearchFilters } from "@/services/apiClient";
 import { SearchBar } from "@/components/search/SearchBar";
 import { SortDropdown } from "@/components/search/SortDropdown";
 import { ExportButton } from "@/components/search/ExportButton";
@@ -172,16 +177,8 @@ function SearchPageInner({ community }: { community: Community }) {
   const exportAnnouncement = exportAnnouncementFor(exportJob.status);
 
   function handleExport() {
-    const filters: Omit<SearchFilters, "page"> = {
-      startYear: params.startYear,
-      endYear: params.endYear,
-      annotation: community.defaultAnnotations,
-    };
-    if (params.sort !== undefined) filters.sort = [SORT_BACKEND[params.sort]];
-    // Backend requires q with min_length=1; substitute "*" for year-only
-    // searches so the year filter is the user-supplied intent.
-    const exportQuery = queryEmpty ? "*" : params.q;
-    exportJob.start(exportQuery, filters, formatExportFilename(community.slug));
+    const { query, filters } = toExportSearchQuery(params, community.defaultAnnotations);
+    exportJob.start(query, filters, formatExportFilename(community.slug));
   }
 
   // Page size comes from the API response (page.count) so the UI stays in

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -145,15 +145,16 @@ function SearchPageInner({ community }: { community: Community }) {
     || overCap
     || exportBusy
     || results.loading;
-  const exportTooltip = noFilters
-    ? "Submit a search query to export."
-    : results.loading
-      ? undefined
-      : overCap
-        ? `Refine your search — exports are limited to ${EXPORT_MAX_RESULTS.toLocaleString()} results.`
-        : !hasResults
-          ? "No results to export."
-          : undefined;
+  const exportTooltip = ((): string | undefined => {
+    if (noFilters) return "Submit a search query to export.";
+    // Suppress while refetching: would otherwise assert a stale count.
+    if (results.loading) return undefined;
+    if (overCap) {
+      return `Refine your search — exports are limited to ${EXPORT_MAX_RESULTS.toLocaleString()} results.`;
+    }
+    if (!hasResults) return "No results to export.";
+    return undefined;
+  })();
   const exportLiveAnnouncement =
     exportJob.status === "requesting" || exportJob.status === "polling"
       ? "Preparing export…"

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -1,5 +1,5 @@
 import { api } from "@/api/client";
-import type { Reference, SearchResult } from "@/types/models";
+import type { Reference, SearchExportRead, SearchResult } from "@/types/models";
 import type { SortOption } from "@/services/searchParams";
 
 export interface SearchFilters {
@@ -40,6 +40,31 @@ export async function searchReferences(
   for (const a of filters.annotation ?? []) params.append("annotation", a);
   for (const s of filters.sort ?? []) params.append("sort", s);
   return api.get<SearchResult>(`/v1/references/search/?${params.toString()}`);
+}
+
+// Unlike searchReferences, no empty-q → "*" shim: the export endpoint is
+// gated at the search page (button disabled when q is empty), and an
+// explicit "*" from the user is forwarded as-is.
+export async function requestSearchExport(
+  query: string,
+  filters: Omit<SearchFilters, "page"> = {},
+): Promise<SearchExportRead> {
+  const params = new URLSearchParams();
+  params.set("q", query.trim());
+  if (isPositiveSafeInt(filters.startYear)) params.set("start_year", String(filters.startYear));
+  if (isPositiveSafeInt(filters.endYear)) params.set("end_year", String(filters.endYear));
+  for (const a of filters.annotation ?? []) params.append("annotation", a);
+  for (const s of filters.sort ?? []) params.append("sort", s);
+  return api.post<SearchExportRead>(
+    `/v1/references/search/exports/?${params.toString()}`,
+    undefined,
+  );
+}
+
+export async function getSearchExport(id: string): Promise<SearchExportRead> {
+  return api.get<SearchExportRead>(
+    `/v1/references/search/exports/${encodeURIComponent(id)}/`,
+  );
 }
 
 export async function getReference(id: string): Promise<Reference | null> {

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -1,6 +1,5 @@
 import { api } from "@/api/client";
 import type { Reference, SearchExportRead, SearchResult } from "@/types/models";
-import type { SortOption } from "@/services/searchParams";
 
 export interface SearchFilters {
   page?: number;
@@ -9,12 +8,6 @@ export interface SearchFilters {
   annotation?: string[];
   sort?: string[];
 }
-
-// URL alias → backend ES-style `[-]field_name` wire format.
-export const SORT_BACKEND: Record<SortOption, string> = {
-  newest: "-publication_year",
-  oldest: "publication_year",
-};
 
 // Mirrors parseSearchParams: page must be >= 1, years > 0, all safe integers.
 // Defends the API boundary against NaN/Infinity/floats from programmatic callers.

--- a/src/services/export/export.ts
+++ b/src/services/export/export.ts
@@ -40,18 +40,29 @@ function triggerDownload(data: ArrayBuffer, filename: string): void {
  * vocabulary at `vocabularyUrl` (URI-keyed prefLabels) and the JSON-LD
  * @context at `contextUrl` (prefix → namespace map), build the
  * three-tab workbook, and prompt the user to download it as `filename`.
+ *
+ * When `vocabularyUrl` or `contextUrl` is omitted, concept cells fall back
+ * to raw CURIEs — same degradation as a reference with no
+ * `linkedData.vocabulary_uri` in the UI.
  */
 export async function exportReferencesToExcel(
   jsonlUrl: string,
-  vocabularyUrl: string,
-  contextUrl: string,
+  vocabularyUrl: string | undefined,
+  contextUrl: string | undefined,
   filename: string,
 ): Promise<void> {
   const references = streamJsonlFromUrl(jsonlUrl);
-  const [{ labels }, { prefixes }] = await Promise.all([
-    getCachedVocabulary(vocabularyUrl),
-    getCachedContext(contextUrl),
+  const [vocab, context] = await Promise.all([
+    vocabularyUrl
+      ? getCachedVocabulary(vocabularyUrl)
+      : Promise.resolve({ labels: new Map<string, string>() }),
+    contextUrl
+      ? getCachedContext(contextUrl)
+      : Promise.resolve({ prefixes: new Map<string, string>() }),
   ]);
-  const wb = await generateWorkbook(references, { prefixes, labels });
+  const wb = await generateWorkbook(references, {
+    prefixes: context.prefixes,
+    labels: vocab.labels,
+  });
   triggerDownload(workbookToArrayBuffer(wb), filename);
 }

--- a/src/services/searchParams.ts
+++ b/src/services/searchParams.ts
@@ -69,8 +69,8 @@ export function buildSearchUrl(communitySlug: string, params: SearchParams): str
 
 // Maps a SearchParams + community annotations to the query/filters shape the
 // export endpoint expects. Substitutes "*" for an empty `q` so the backend's
-// `min_length=1` constraint is satisfied for year-only searches; the SearchPage
-// gate ensures we never reach here without either a query or a year filter.
+// `min_length=1` constraint is satisfied for browse-mode and year-only
+// exports.
 export function toExportSearchQuery(
   params: SearchParams,
   annotations: string[] | undefined,

--- a/src/services/searchParams.ts
+++ b/src/services/searchParams.ts
@@ -1,6 +1,13 @@
 import { parseYear } from "@/utils/year";
+import type { SearchFilters } from "@/services/apiClient";
 
 export type SortOption = "newest" | "oldest";
+
+// URL alias → backend ES-style `[-]field_name` wire format.
+export const SORT_BACKEND: Record<SortOption, string> = {
+  newest: "-publication_year",
+  oldest: "publication_year",
+};
 
 export interface SearchParams {
   q: string;
@@ -58,4 +65,22 @@ export function toQueryString(params: SearchParams): string {
 export function buildSearchUrl(communitySlug: string, params: SearchParams): string {
   const qs = toQueryString(params);
   return qs ? `/${communitySlug}?${qs}` : `/${communitySlug}`;
+}
+
+// Maps a SearchParams + community annotations to the query/filters shape the
+// export endpoint expects. Substitutes "*" for an empty `q` so the backend's
+// `min_length=1` constraint is satisfied for year-only searches; the SearchPage
+// gate ensures we never reach here without either a query or a year filter.
+export function toExportSearchQuery(
+  params: SearchParams,
+  annotations: string[] | undefined,
+): { query: string; filters: Omit<SearchFilters, "page"> } {
+  const filters: Omit<SearchFilters, "page"> = {
+    startYear: params.startYear,
+    endYear: params.endYear,
+    annotation: annotations,
+  };
+  if (params.sort !== undefined) filters.sort = [SORT_BACKEND[params.sort]];
+  const query = params.q.trim() === "" ? "*" : params.q;
+  return { query, filters };
 }

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -46,3 +46,16 @@ h6 {
   isolation: isolate;
   min-height: 100vh;
 }
+
+/* Visually hide content while keeping it readable by assistive tech. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -123,3 +123,14 @@ export interface Reference {
   identifiers: ExternalIdentifier[] | null;
   enhancements: Enhancement[] | null;
 }
+
+export type SearchExportStatus = "pending" | "running" | "completed" | "failed";
+
+export interface SearchExportRead {
+  id: string;
+  status: SearchExportStatus;
+  result_url?: string | null;
+  n_references?: number | null;
+  truncated: boolean;
+  error?: string | null;
+}

--- a/tests/components/TagGroup.test.tsx
+++ b/tests/components/TagGroup.test.tsx
@@ -50,7 +50,7 @@ describe("TagGroup", () => {
     expect(container.querySelector(".tag-group__tag-parent")).toBeNull();
   });
 
-  test("attaches data-def and tabIndex when a definition is present", () => {
+  test("wraps tag in a Tooltip and marks it focusable when a definition is present", () => {
     const { container } = render(
       <TagGroup
         tags={[
@@ -62,19 +62,23 @@ describe("TagGroup", () => {
         ]}
       />,
     );
-    const tag = container.querySelector(".tag-group__tag");
-    expect(tag?.getAttribute("data-def")).toBe(
+    const wrap = container.querySelector(".tooltip");
+    expect(wrap?.getAttribute("data-tooltip")).toBe(
       "Peer-reviewed publication presenting original research or reviews.",
     );
+    const tag = wrap?.querySelector(".tag-group__tag");
+    expect(tag).not.toBeNull();
+    expect(tag?.classList.contains("tag-group__tag--has-tooltip")).toBe(true);
     expect(tag?.getAttribute("tabindex")).toBe("0");
   });
 
-  test("does not add data-def or tabIndex when definition is absent", () => {
+  test("does not wrap tag in a Tooltip when definition is absent", () => {
     const { container } = render(
       <TagGroup tags={[{ label: "Plain tag" }]} />,
     );
+    expect(container.querySelector(".tooltip")).toBeNull();
     const tag = container.querySelector(".tag-group__tag");
-    expect(tag?.hasAttribute("data-def")).toBe(false);
+    expect(tag?.classList.contains("tag-group__tag--has-tooltip")).toBe(false);
     expect(tag?.hasAttribute("tabindex")).toBe(false);
   });
 });

--- a/tests/components/Tooltip.test.tsx
+++ b/tests/components/Tooltip.test.tsx
@@ -1,0 +1,36 @@
+import { describe, test, expect } from "vitest";
+import { render } from "@testing-library/preact";
+import { Tooltip } from "@/components/Tooltip";
+
+describe("Tooltip", () => {
+  test("wraps children in a span with data-tooltip when text is set", () => {
+    const { container } = render(
+      <Tooltip text="hello">
+        <button type="button">click</button>
+      </Tooltip>,
+    );
+    const wrap = container.querySelector(".tooltip");
+    expect(wrap).not.toBeNull();
+    expect(wrap?.getAttribute("data-tooltip")).toBe("hello");
+    expect(wrap?.querySelector("button")?.textContent).toBe("click");
+  });
+
+  test("renders children unwrapped when text is undefined", () => {
+    const { container } = render(
+      <Tooltip text={undefined}>
+        <button type="button">click</button>
+      </Tooltip>,
+    );
+    expect(container.querySelector(".tooltip")).toBeNull();
+    expect(container.querySelector("button")?.textContent).toBe("click");
+  });
+
+  test("renders children unwrapped when text is an empty string", () => {
+    const { container } = render(
+      <Tooltip text="">
+        <span>x</span>
+      </Tooltip>,
+    );
+    expect(container.querySelector(".tooltip")).toBeNull();
+  });
+});

--- a/tests/hooks/useSearchExport.test.tsx
+++ b/tests/hooks/useSearchExport.test.tsx
@@ -1,0 +1,177 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/preact";
+import { useSearchExport } from "@/hooks/useSearchExport";
+import type { SearchExportRead } from "@/types/models";
+
+vi.mock("@/services/apiClient", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/services/apiClient")>();
+  return {
+    ...actual,
+    requestSearchExport: vi.fn(),
+    getSearchExport: vi.fn(),
+  };
+});
+
+vi.mock("@/services/export/export", () => ({
+  exportReferencesToExcel: vi.fn().mockResolvedValue(undefined),
+}));
+
+import {
+  requestSearchExport,
+  getSearchExport,
+} from "@/services/apiClient";
+import { exportReferencesToExcel } from "@/services/export/export";
+
+const mockRequest = vi.mocked(requestSearchExport);
+const mockGet = vi.mocked(getSearchExport);
+const mockExport = vi.mocked(exportReferencesToExcel);
+
+function pending(id = "job-1"): SearchExportRead {
+  return { id, status: "pending", truncated: false };
+}
+function running(id = "job-1"): SearchExportRead {
+  return { id, status: "running", truncated: false };
+}
+function completed(id = "job-1", url = "https://blob/result.jsonl"): SearchExportRead {
+  return {
+    id,
+    status: "completed",
+    result_url: url,
+    n_references: 42,
+    truncated: false,
+  };
+}
+function failed(id = "job-1", error = "boom"): SearchExportRead {
+  return { id, status: "failed", truncated: false, error };
+}
+
+beforeEach(() => {
+  mockRequest.mockReset();
+  mockGet.mockReset();
+  mockExport.mockReset().mockResolvedValue(undefined);
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useSearchExport", () => {
+  test("pending → running → completed drives the download", async () => {
+    mockRequest.mockResolvedValue(pending());
+    mockGet
+      .mockResolvedValueOnce(pending())
+      .mockResolvedValueOnce(running())
+      .mockResolvedValueOnce(completed());
+
+    const { result } = renderHook(() => useSearchExport());
+
+    act(() => {
+      result.current.start("phonics", { annotation: ["x"] }, "file.xlsx");
+    });
+    expect(result.current.status).toBe("requesting");
+    await vi.waitFor(() => expect(result.current.status).toBe("polling"));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    await vi.waitFor(() => expect(result.current.status).toBe("done"));
+    expect(mockExport).toHaveBeenCalledWith(
+      "https://blob/result.jsonl",
+      expect.any(String),
+      expect.any(String),
+      "file.xlsx",
+    );
+    expect(mockRequest).toHaveBeenCalledWith("phonics", { annotation: ["x"] });
+  });
+
+  test("failed surfaces the backend error message", async () => {
+    mockRequest.mockResolvedValue(pending());
+    mockGet.mockResolvedValueOnce(failed("job-1", "search broke"));
+
+    const { result } = renderHook(() => useSearchExport());
+    act(() => {
+      result.current.start("phonics", {}, "f.xlsx");
+    });
+    await vi.waitFor(() => expect(result.current.status).toBe("polling"));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    await vi.waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.errorMessage).toBe("search broke");
+    expect(mockExport).not.toHaveBeenCalled();
+  });
+
+  test("POST failure surfaces an error without polling", async () => {
+    mockRequest.mockRejectedValue(new Error("network down"));
+    const { result } = renderHook(() => useSearchExport());
+    act(() => {
+      result.current.start("phonics", {}, "f.xlsx");
+    });
+    await vi.waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.errorMessage).toBe("network down");
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  test("reset cancels a pending poll", async () => {
+    mockRequest.mockResolvedValue(pending());
+    mockGet.mockResolvedValue(pending());
+
+    const { result } = renderHook(() => useSearchExport());
+    act(() => {
+      result.current.start("phonics", {}, "f.xlsx");
+    });
+    await vi.waitFor(() => expect(result.current.status).toBe("polling"));
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.status).toBe("idle");
+
+    // Drain any scheduled timeouts and resolved promises; status must stay idle.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    expect(result.current.status).toBe("idle");
+  });
+
+  test("unmount during polling does not throw or update state", async () => {
+    mockRequest.mockResolvedValue(pending());
+    mockGet.mockResolvedValue(pending());
+
+    const { result, unmount } = renderHook(() => useSearchExport());
+    act(() => {
+      result.current.start("phonics", {}, "f.xlsx");
+    });
+    await vi.waitFor(() => expect(result.current.status).toBe("polling"));
+    unmount();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    // No error means cancellation worked — state writes on stale callbacks would
+    // surface as React warnings; tooling-level assertion captured by the act helper.
+  });
+
+  test("missing result_url on completed surfaces an error", async () => {
+    mockRequest.mockResolvedValue({
+      id: "job-1",
+      status: "completed",
+      truncated: false,
+    });
+
+    const { result } = renderHook(() => useSearchExport());
+    act(() => {
+      result.current.start("phonics", {}, "f.xlsx");
+    });
+    await vi.waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.errorMessage).toMatch(/no download URL/i);
+  });
+});

--- a/tests/hooks/useSearchExport.test.tsx
+++ b/tests/hooks/useSearchExport.test.tsx
@@ -16,6 +16,15 @@ vi.mock("@/services/export/export", () => ({
   exportReferencesToExcel: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("@/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/config")>();
+  return {
+    ...actual,
+    EXPORT_VOCABULARY_URL: "https://test.example/vocab",
+    EXPORT_CONTEXT_URL: "https://test.example/context",
+  };
+});
+
 import {
   requestSearchExport,
   getSearchExport,
@@ -85,8 +94,8 @@ describe("useSearchExport", () => {
     await vi.waitFor(() => expect(result.current.status).toBe("done"));
     expect(mockExport).toHaveBeenCalledWith(
       "https://blob/result.jsonl",
-      expect.any(String),
-      expect.any(String),
+      "https://test.example/vocab",
+      "https://test.example/context",
       "file.xlsx",
     );
     expect(mockRequest).toHaveBeenCalledWith("phonics", { annotation: ["x"] });

--- a/tests/hooks/useSearchExport.test.tsx
+++ b/tests/hooks/useSearchExport.test.tsx
@@ -82,13 +82,7 @@ describe("useSearchExport", () => {
     await vi.waitFor(() => expect(result.current.status).toBe("polling"));
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(2000);
-    });
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(2000);
-    });
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(2000);
+      await vi.advanceTimersByTimeAsync(6000);
     });
 
     await vi.waitFor(() => expect(result.current.status).toBe("done"));
@@ -165,8 +159,9 @@ describe("useSearchExport", () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(10_000);
     });
-    // No error means cancellation worked — state writes on stale callbacks would
-    // surface as React warnings; tooling-level assertion captured by the act helper.
+    // No throw means the cancellation guard stopped the poll chain. Preact
+    // silently no-ops setState on an unmounted component, so the absence of
+    // an error is the assertion.
   });
 
   test("missing result_url on completed surfaces an error", async () => {

--- a/tests/pages/SearchPage.test.tsx
+++ b/tests/pages/SearchPage.test.tsx
@@ -346,11 +346,17 @@ describe("SearchPage", () => {
       await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
 
       const btn = screen.getByRole("button", { name: /export to excel/i });
-      expect(btn).toBeDisabled();
+      expect(btn).toHaveAttribute("aria-disabled", "true");
       expect(btn.parentElement).toHaveAttribute(
         "data-tooltip",
         expect.stringMatching(/submit a search query/i),
       );
+      // Tooltip text is also exposed to AT via aria-describedby + a hidden node,
+      // since data-tooltip is purely a CSS hook.
+      const describedById = btn.getAttribute("aria-describedby");
+      expect(describedById).toBeTruthy();
+      const describedBy = document.getElementById(describedById!);
+      expect(describedBy?.textContent).toMatch(/submit a search query/i);
     });
 
     test("enabled in year-only URL; click POSTs with q=* and the year filter", async () => {
@@ -370,7 +376,7 @@ describe("SearchPage", () => {
       await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
 
       const btn = screen.getByRole("button", { name: /export to excel/i });
-      expect(btn).not.toBeDisabled();
+      expect(btn).not.toHaveAttribute("aria-disabled", "true");
       fireEvent.click(btn);
       await waitFor(() => expect(mockRequestExport).toHaveBeenCalledTimes(1));
       expect(mockRequestExport).toHaveBeenCalledWith("*", {
@@ -390,7 +396,7 @@ describe("SearchPage", () => {
       expect(btn).not.toBeDisabled();
     });
 
-    test("disabled when result set is empty", async () => {
+    test("disabled when result set is empty with explanatory tooltip", async () => {
       history.replaceState(null, "", "/esea?q=phonics");
       mockBoth({ results: makeResult(0, []) });
       renderSearchPage();
@@ -399,7 +405,11 @@ describe("SearchPage", () => {
       );
 
       const btn = screen.getByRole("button", { name: /export to excel/i });
-      expect(btn).toBeDisabled();
+      expect(btn).toHaveAttribute("aria-disabled", "true");
+      expect(btn.parentElement).toHaveAttribute(
+        "data-tooltip",
+        expect.stringMatching(/no results to export/i),
+      );
     });
 
     test("disabled past the 10k cap with tooltip", async () => {
@@ -409,7 +419,7 @@ describe("SearchPage", () => {
       await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
 
       const btn = screen.getByRole("button", { name: /export to excel/i });
-      expect(btn).toBeDisabled();
+      expect(btn).toHaveAttribute("aria-disabled", "true");
       expect(btn.parentElement).toHaveAttribute(
         "data-tooltip",
         expect.stringMatching(/limited to 10,000 results/i),

--- a/tests/pages/SearchPage.test.tsx
+++ b/tests/pages/SearchPage.test.tsx
@@ -421,6 +421,41 @@ describe("SearchPage", () => {
       );
     });
 
+    test("disabled while a follow-up search is in flight (stale results, gate before fresh data)", async () => {
+      history.replaceState(null, "", "/esea?q=phonics");
+      // Resolve the first fetch (47 results), then leave the second fetch
+      // pending so loading=true while the prior results still render.
+      let resolveSecond: ((value: SearchResult) => void) | undefined;
+      mockSearch.mockImplementationOnce(() => Promise.resolve(makeResult(5721, ["c1"])))
+        .mockImplementationOnce(() => Promise.resolve(makeResult(47, ["r1"])))
+        .mockImplementationOnce(
+          () => new Promise<SearchResult>((r) => { resolveSecond = r; }),
+        );
+      renderSearchPage();
+      await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
+      // First settled state: 47 results → button enabled.
+      const btn = screen.getByRole("button", { name: /export to excel/i });
+      expect(btn).not.toHaveAttribute("aria-disabled", "true");
+
+      // Submit a new query — keeps showing r1 (dim) while the second fetch hangs.
+      fireEvent.input(screen.getByRole("searchbox"), { target: { value: "literacy" } });
+      fireEvent.click(screen.getByRole("button", { name: /search/i }));
+
+      // Button is disabled while loading even though stale `results.results`
+      // would have said `hasResults && !overCap`.
+      await waitFor(() =>
+        expect(btn).toHaveAttribute("aria-disabled", "true"),
+      );
+      // Tooltip is suppressed during loading to avoid asserting a stale count.
+      expect(btn.parentElement).not.toHaveAttribute("data-tooltip");
+
+      // Resolve the second fetch; button re-enables.
+      resolveSecond?.(makeResult(12, ["r2"]));
+      await waitFor(() =>
+        expect(btn).not.toHaveAttribute("aria-disabled", "true"),
+      );
+    });
+
     test("disabled past the 10k cap with tooltip", async () => {
       history.replaceState(null, "", "/esea?q=education");
       mockBoth({ results: makeResult(10000, ["r1"], true) });

--- a/tests/pages/SearchPage.test.tsx
+++ b/tests/pages/SearchPage.test.tsx
@@ -349,23 +349,30 @@ describe("SearchPage", () => {
   });
 
   describe("export button", () => {
-    test("disabled in browse mode (no q, no years) with explanatory tooltip", async () => {
+    test("enabled in browse mode; click POSTs with q=* and the community annotation", async () => {
       mockBoth({ results: makeResult(5721, ["r1"]) });
+      mockRequestExport.mockResolvedValue({
+        id: "job-browse",
+        status: "pending",
+        truncated: false,
+      });
+      mockGetExport.mockResolvedValue({
+        id: "job-browse",
+        status: "pending",
+        truncated: false,
+      });
       renderSearchPage();
       await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
 
       const btn = screen.getByRole("button", { name: /export to excel/i });
-      expect(btn).toHaveAttribute("aria-disabled", "true");
-      expect(btn.parentElement).toHaveAttribute(
-        "data-tooltip",
-        expect.stringMatching(/submit a search query/i),
-      );
-      // Tooltip text is also exposed to AT via aria-describedby + a hidden node,
-      // since data-tooltip is purely a CSS hook.
-      const describedById = btn.getAttribute("aria-describedby");
-      expect(describedById).toBeTruthy();
-      const describedBy = document.getElementById(describedById!);
-      expect(describedBy?.textContent).toMatch(/submit a search query/i);
+      expect(btn).not.toHaveAttribute("aria-disabled", "true");
+      fireEvent.click(btn);
+      await waitFor(() => expect(mockRequestExport).toHaveBeenCalledTimes(1));
+      expect(mockRequestExport).toHaveBeenCalledWith("*", {
+        startYear: undefined,
+        endYear: undefined,
+        annotation: ["domain-inclusion/jacobs-education"],
+      });
     });
 
     test("enabled in year-only URL; click POSTs with q=* and the year filter", async () => {
@@ -393,16 +400,6 @@ describe("SearchPage", () => {
         endYear: undefined,
         annotation: ["domain-inclusion/jacobs-education"],
       });
-    });
-
-    test("explicit q=* is allowed (passes the empty-q gate)", async () => {
-      history.replaceState(null, "", "/esea?q=*");
-      mockBoth({ results: makeResult(50, ["r1"]) });
-      renderSearchPage();
-      await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
-
-      const btn = screen.getByRole("button", { name: /export to excel/i });
-      expect(btn).not.toHaveAttribute("aria-disabled", "true");
     });
 
     test("disabled when result set is empty with explanatory tooltip", async () => {

--- a/tests/pages/SearchPage.test.tsx
+++ b/tests/pages/SearchPage.test.tsx
@@ -340,7 +340,7 @@ describe("SearchPage", () => {
   });
 
   describe("export button", () => {
-    test("disabled in browse mode (empty query) with explanatory tooltip", async () => {
+    test("disabled in browse mode (no q, no years) with explanatory tooltip", async () => {
       mockBoth({ results: makeResult(5721, ["r1"]) });
       renderSearchPage();
       await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
@@ -349,18 +349,35 @@ describe("SearchPage", () => {
       expect(btn).toBeDisabled();
       expect(btn.parentElement).toHaveAttribute(
         "data-tooltip",
-        expect.stringMatching(/enter a search query/i),
+        expect.stringMatching(/submit a search query/i),
       );
     });
 
-    test("disabled in year-only URL (still empty q)", async () => {
+    test("enabled in year-only URL; click POSTs with q=* and the year filter", async () => {
       history.replaceState(null, "", "/esea?start_year=2020");
       mockBoth({ results: makeResult(120, ["r1"]) });
+      mockRequestExport.mockResolvedValue({
+        id: "job-yr",
+        status: "pending",
+        truncated: false,
+      });
+      mockGetExport.mockResolvedValue({
+        id: "job-yr",
+        status: "pending",
+        truncated: false,
+      });
       renderSearchPage();
       await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
 
       const btn = screen.getByRole("button", { name: /export to excel/i });
-      expect(btn).toBeDisabled();
+      expect(btn).not.toBeDisabled();
+      fireEvent.click(btn);
+      await waitFor(() => expect(mockRequestExport).toHaveBeenCalledTimes(1));
+      expect(mockRequestExport).toHaveBeenCalledWith("*", {
+        startYear: 2020,
+        endYear: undefined,
+        annotation: ["domain-inclusion/jacobs-education"],
+      });
     });
 
     test("explicit q=* is allowed (passes the empty-q gate)", async () => {

--- a/tests/pages/SearchPage.test.tsx
+++ b/tests/pages/SearchPage.test.tsx
@@ -402,7 +402,7 @@ describe("SearchPage", () => {
       await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
 
       const btn = screen.getByRole("button", { name: /export to excel/i });
-      expect(btn).not.toBeDisabled();
+      expect(btn).not.toHaveAttribute("aria-disabled", "true");
     });
 
     test("disabled when result set is empty with explanatory tooltip", async () => {
@@ -423,34 +423,46 @@ describe("SearchPage", () => {
 
     test("disabled while a follow-up search is in flight (stale results, gate before fresh data)", async () => {
       history.replaceState(null, "", "/esea?q=phonics");
-      // Resolve the first fetch (47 results), then leave the second fetch
-      // pending so loading=true while the prior results still render.
-      let resolveSecond: ((value: SearchResult) => void) | undefined;
-      mockSearch.mockImplementationOnce(() => Promise.resolve(makeResult(5721, ["c1"])))
-        .mockImplementationOnce(() => Promise.resolve(makeResult(47, ["r1"])))
-        .mockImplementationOnce(
-          () => new Promise<SearchResult>((r) => { resolveSecond = r; }),
-        );
+      // Route by query so the test isn't sensitive to mock call order:
+      // corpus query → 5,721; phonics → 47 results immediately; literacy
+      // hangs until we explicitly resolve it, so loading=true while the
+      // phonics rows still render.
+      let resolveLiteracy: ((value: SearchResult) => void) | undefined;
+      mockSearch.mockImplementation((q) => {
+        if (q === undefined)
+          return Promise.resolve(makeResult(5721, ["corpus-ref"]));
+        if (q === "phonics")
+          return Promise.resolve(makeResult(47, ["phonics-ref"]));
+        if (q === "literacy") {
+          return new Promise<SearchResult>((r) => {
+            resolveLiteracy = r;
+          });
+        }
+        return Promise.reject(new Error(`unexpected query: ${q}`));
+      });
       renderSearchPage();
-      await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
+      await waitFor(() =>
+        expect(screen.getByText("Title phonics-ref")).toBeInTheDocument(),
+      );
       // First settled state: 47 results → button enabled.
       const btn = screen.getByRole("button", { name: /export to excel/i });
       expect(btn).not.toHaveAttribute("aria-disabled", "true");
 
-      // Submit a new query — keeps showing r1 (dim) while the second fetch hangs.
-      fireEvent.input(screen.getByRole("searchbox"), { target: { value: "literacy" } });
+      // Submit a new query — keeps phonics-ref visible (dim) while the
+      // literacy fetch hangs.
+      fireEvent.input(screen.getByRole("searchbox"), {
+        target: { value: "literacy" },
+      });
       fireEvent.click(screen.getByRole("button", { name: /search/i }));
 
       // Button is disabled while loading even though stale `results.results`
       // would have said `hasResults && !overCap`.
-      await waitFor(() =>
-        expect(btn).toHaveAttribute("aria-disabled", "true"),
-      );
+      await waitFor(() => expect(btn).toHaveAttribute("aria-disabled", "true"));
       // Tooltip is suppressed during loading to avoid asserting a stale count.
       expect(btn.parentElement).not.toHaveAttribute("data-tooltip");
 
-      // Resolve the second fetch; button re-enables.
-      resolveSecond?.(makeResult(12, ["r2"]));
+      // Resolve the literacy fetch; button re-enables.
+      resolveLiteracy?.(makeResult(12, ["literacy-ref"]));
       await waitFor(() =>
         expect(btn).not.toHaveAttribute("aria-disabled", "true"),
       );

--- a/tests/pages/SearchPage.test.tsx
+++ b/tests/pages/SearchPage.test.tsx
@@ -14,11 +14,26 @@ function renderSearchPage() {
 
 vi.mock("@/services/apiClient", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/services/apiClient")>();
-  return { ...actual, searchReferences: vi.fn() };
+  return {
+    ...actual,
+    searchReferences: vi.fn(),
+    requestSearchExport: vi.fn(),
+    getSearchExport: vi.fn(),
+  };
 });
 
-import { searchReferences } from "@/services/apiClient";
+vi.mock("@/services/export/export", () => ({
+  exportReferencesToExcel: vi.fn().mockResolvedValue(undefined),
+}));
+
+import {
+  searchReferences,
+  requestSearchExport,
+  getSearchExport,
+} from "@/services/apiClient";
 const mockSearch = vi.mocked(searchReferences);
+const mockRequestExport = vi.mocked(requestSearchExport);
+const mockGetExport = vi.mocked(getSearchExport);
 
 function makeResult(count: number, ids: string[] = [], isLowerBound = false): SearchResult {
   return {
@@ -65,6 +80,8 @@ function mockBoth(opts: {
 
 beforeEach(() => {
   mockSearch.mockReset();
+  mockRequestExport.mockReset();
+  mockGetExport.mockReset();
   history.replaceState(null, "", "/esea");
 });
 
@@ -320,5 +337,100 @@ describe("SearchPage", () => {
     await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
     expect(pushSpy).not.toHaveBeenCalled();
     pushSpy.mockRestore();
+  });
+
+  describe("export button", () => {
+    test("disabled in browse mode (empty query) with explanatory tooltip", async () => {
+      mockBoth({ results: makeResult(5721, ["r1"]) });
+      renderSearchPage();
+      await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
+
+      const btn = screen.getByRole("button", { name: /export to excel/i });
+      expect(btn).toBeDisabled();
+      expect(btn.parentElement).toHaveAttribute(
+        "data-tooltip",
+        expect.stringMatching(/enter a search query/i),
+      );
+    });
+
+    test("disabled in year-only URL (still empty q)", async () => {
+      history.replaceState(null, "", "/esea?start_year=2020");
+      mockBoth({ results: makeResult(120, ["r1"]) });
+      renderSearchPage();
+      await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
+
+      const btn = screen.getByRole("button", { name: /export to excel/i });
+      expect(btn).toBeDisabled();
+    });
+
+    test("explicit q=* is allowed (passes the empty-q gate)", async () => {
+      history.replaceState(null, "", "/esea?q=*");
+      mockBoth({ results: makeResult(50, ["r1"]) });
+      renderSearchPage();
+      await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
+
+      const btn = screen.getByRole("button", { name: /export to excel/i });
+      expect(btn).not.toBeDisabled();
+    });
+
+    test("disabled when result set is empty", async () => {
+      history.replaceState(null, "", "/esea?q=phonics");
+      mockBoth({ results: makeResult(0, []) });
+      renderSearchPage();
+      await waitFor(() =>
+        expect(screen.getByText(/no matches/i)).toBeInTheDocument(),
+      );
+
+      const btn = screen.getByRole("button", { name: /export to excel/i });
+      expect(btn).toBeDisabled();
+    });
+
+    test("disabled past the 10k cap with tooltip", async () => {
+      history.replaceState(null, "", "/esea?q=education");
+      mockBoth({ results: makeResult(10000, ["r1"], true) });
+      renderSearchPage();
+      await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
+
+      const btn = screen.getByRole("button", { name: /export to excel/i });
+      expect(btn).toBeDisabled();
+      expect(btn.parentElement).toHaveAttribute(
+        "data-tooltip",
+        expect.stringMatching(/limited to 10,000 results/i),
+      );
+    });
+
+    test("click POSTs with current filters and shows preparing status", async () => {
+      history.replaceState(null, "", "/esea?q=phonics&start_year=2015");
+      mockBoth({ results: makeResult(47, ["r1"]) });
+      mockRequestExport.mockResolvedValue({
+        id: "job-1",
+        status: "pending",
+        truncated: false,
+      });
+      // Keep polling pending forever so the test settles on "Preparing…".
+      mockGetExport.mockResolvedValue({
+        id: "job-1",
+        status: "pending",
+        truncated: false,
+      });
+
+      renderSearchPage();
+      await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
+
+      const btn = screen.getByRole("button", { name: /export to excel/i });
+      fireEvent.click(btn);
+
+      await waitFor(() => expect(mockRequestExport).toHaveBeenCalledTimes(1));
+      expect(mockRequestExport).toHaveBeenCalledWith("phonics", {
+        startYear: 2015,
+        endYear: undefined,
+        annotation: ["domain-inclusion/jacobs-education"],
+      });
+      await waitFor(() =>
+        expect(
+          screen.getByRole("button", { name: /preparing/i }),
+        ).toBeInTheDocument(),
+      );
+    });
   });
 });

--- a/tests/pages/SearchPage.test.tsx
+++ b/tests/pages/SearchPage.test.tsx
@@ -26,6 +26,15 @@ vi.mock("@/services/export/export", () => ({
   exportReferencesToExcel: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("@/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/config")>();
+  return {
+    ...actual,
+    EXPORT_VOCABULARY_URL: "https://test.example/vocab",
+    EXPORT_CONTEXT_URL: "https://test.example/context",
+  };
+});
+
 import {
   searchReferences,
   requestSearchExport,

--- a/tests/services/export/export.test.ts
+++ b/tests/services/export/export.test.ts
@@ -264,6 +264,21 @@ describe("exportReferencesToExcel", () => {
     expect(captured.filename).toBe("chunked.xlsx");
     expect(captured.blob!.size).toBeGreaterThan(0);
   });
+
+  test("skips vocab/context fetches when URLs are undefined", async () => {
+    // Without the ternary guard, getCachedVocabulary(undefined) ends up at
+    // new URL(undefined) and throws. Verify the empty-map branch runs.
+    const { captured, fetchSpy } = installSpies();
+    await exportReferencesToExcel(JSONL_URL, undefined, undefined, "no-vocab.xlsx");
+    const urls = fetchSpy.mock.calls.map((c) =>
+      typeof c[0] === "string" ? c[0] : c[0]!.toString(),
+    );
+    expect(urls).toContain(JSONL_URL);
+    expect(urls.some((u) => u.includes("vocab"))).toBe(false);
+    expect(urls.some((u) => u.includes("context"))).toBe(false);
+    expect(captured.filename).toBe("no-vocab.xlsx");
+    expect(captured.blob!.size).toBeGreaterThan(0);
+  });
 });
 
 type CellValue = string | number | boolean | null;


### PR DESCRIPTION
Closes https://github.com/destiny-evidence/evidence-repo-ui/issues/45.

Wires the search page to the queued-export endpoint from https://github.com/destiny-evidence/destiny-repository/pull/678. New `useSearchExport` hook does POST + 2s polling + JSONL→xlsx via the existing pipeline. Button hard-disabled on empty query, empty results, `is_lower_bound && count >= 10000`, or in-flight.

Vocab/context URLs come from `VITE_EXPORT_VOCABULARY_URL` / `VITE_EXPORT_CONTEXT_URL` — single-vocab-per-export per https://github.com/destiny-evidence/evidence-repo-ui/issues/47.

Extracts a small `Tooltip` component.

Browser SAS downloads against prod blob storage are blocked by CORS — tracked in https://github.com/destiny-evidence/destiny-repository/issues/688.