### PR TITLE
Display abstract on record detail page (closes #37)

### DIFF
--- a/src/components/AbstractSection.css
+++ b/src/components/AbstractSection.css
@@ -1,0 +1,17 @@
+.abstract-section {
+  margin: var(--spacing-lg) 0;
+}
+
+.abstract-section__heading {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0 0 var(--spacing-md);
+}
+
+.abstract-section__body {
+  font-size: var(--font-size-body);
+  line-height: 1.55;
+  color: var(--color-text-primary);
+  white-space: pre-line;
+  unicode-bidi: plaintext;
+}

--- a/src/components/AbstractSection.css
+++ b/src/components/AbstractSection.css
@@ -1,11 +1,9 @@
 .abstract-section {
-  margin: var(--spacing-lg) 0;
+  margin: var(--spacing-lg) 0 0;
 }
 
 .abstract-section__heading {
-  font-size: 18px;
-  font-weight: 600;
-  margin: 0 0 var(--spacing-md);
+  margin-top: 0;
 }
 
 .abstract-section__body {

--- a/src/components/AbstractSection.tsx
+++ b/src/components/AbstractSection.tsx
@@ -1,31 +1,21 @@
 import type { AbstractContentEnhancement } from "@/types/models";
-import {
-  decodeHtmlEntities,
-  stripAbstractLabelPrefix,
-} from "@/services/textUtils";
 import "./AbstractSection.css";
 
 interface AbstractSectionProps {
   abstract: AbstractContentEnhancement | null;
 }
 
-// OpenAlex "unavailable" sentinel leaked into the abstract field for some
-// records (e.g., W6946467789). Treat it as absent so we don't render a
-// 5-character literal block.
+// OpenAlex "unavailable" sentinel leaked into some abstract fields, for
+// example W6946467789.
 const OPENALEX_UNAVAILABLE_SENTINEL = ":unav";
 
 export function AbstractSection({ abstract }: AbstractSectionProps) {
   if (!abstract) return null;
-  // Entity decoding only. Mojibake (double-encoded UTF-8 leaking from the
-  // EEF EPPI parser) renders as-is — the fix belongs upstream in the
-  // parser, not as silent client-side repair.
-  const body = stripAbstractLabelPrefix(
-    decodeHtmlEntities(abstract.abstract),
-  ).trim();
+  const body = abstract.abstract.trim();
   if (!body || body === OPENALEX_UNAVAILABLE_SENTINEL) return null;
   return (
     <section class="abstract-section">
-      <h2 class="abstract-section__heading">Abstract</h2>
+      <h2 class="abstract-section__heading lg-section-label">Abstract</h2>
       <div class="abstract-section__body">{body}</div>
     </section>
   );

--- a/src/components/AbstractSection.tsx
+++ b/src/components/AbstractSection.tsx
@@ -1,0 +1,27 @@
+import type { AbstractContentEnhancement } from "@/types/models";
+import { decodeHtmlEntities } from "@/services/textUtils";
+import "./AbstractSection.css";
+
+interface AbstractSectionProps {
+  abstract: AbstractContentEnhancement | null;
+}
+
+// OpenAlex "unavailable" sentinel leaked into the abstract field for some
+// records (e.g., W6946467789). Treat it as absent so we don't render a
+// 5-character literal block.
+const OPENALEX_UNAVAILABLE_SENTINEL = ":unav";
+
+export function AbstractSection({ abstract }: AbstractSectionProps) {
+  if (!abstract) return null;
+  // Entity decoding only. Mojibake (double-encoded UTF-8 leaking from the
+  // EEF EPPI parser) renders as-is — the fix belongs upstream in the
+  // parser, not as silent client-side repair.
+  const body = decodeHtmlEntities(abstract.abstract).trim();
+  if (!body || body === OPENALEX_UNAVAILABLE_SENTINEL) return null;
+  return (
+    <section class="abstract-section">
+      <h2 class="abstract-section__heading">Abstract</h2>
+      <div class="abstract-section__body">{body}</div>
+    </section>
+  );
+}

--- a/src/components/AbstractSection.tsx
+++ b/src/components/AbstractSection.tsx
@@ -1,5 +1,8 @@
 import type { AbstractContentEnhancement } from "@/types/models";
-import { decodeHtmlEntities } from "@/services/textUtils";
+import {
+  decodeHtmlEntities,
+  stripAbstractLabelPrefix,
+} from "@/services/textUtils";
 import "./AbstractSection.css";
 
 interface AbstractSectionProps {
@@ -16,7 +19,9 @@ export function AbstractSection({ abstract }: AbstractSectionProps) {
   // Entity decoding only. Mojibake (double-encoded UTF-8 leaking from the
   // EEF EPPI parser) renders as-is — the fix belongs upstream in the
   // parser, not as silent client-side repair.
-  const body = decodeHtmlEntities(abstract.abstract).trim();
+  const body = stripAbstractLabelPrefix(
+    decodeHtmlEntities(abstract.abstract),
+  ).trim();
   if (!body || body === OPENALEX_UNAVAILABLE_SENTINEL) return null;
   return (
     <section class="abstract-section">

--- a/src/components/InvestigationCard.tsx
+++ b/src/components/InvestigationCard.tsx
@@ -1,7 +1,13 @@
 import "./InvestigationCard.css";
+import { AbstractSection } from "./AbstractSection";
 import { TagGroup } from "./TagGroup";
 import { WarningIcon, ExternalLinkIcon } from "./icons";
-import type { Authorship, Pagination, PublicationVenue } from "@/types/models";
+import type {
+  AbstractContentEnhancement,
+  Authorship,
+  Pagination,
+  PublicationVenue,
+} from "@/types/models";
 import type { CodedAnnotation, ResolvedConcept } from "@/types/investigation";
 
 interface InvestigationCardProps {
@@ -10,6 +16,7 @@ interface InvestigationCardProps {
   venue: PublicationVenue | null;
   pagination: Pagination | null;
   doi: string | null;
+  abstract?: AbstractContentEnhancement | null;
   publicationYear: number | null;
   documentType?: CodedAnnotation<ResolvedConcept>;
   codingInstitution?: string | null;
@@ -56,6 +63,7 @@ export function InvestigationCard({
   venue,
   pagination,
   doi,
+  abstract = null,
   publicationYear,
   documentType,
   codingInstitution,
@@ -106,6 +114,7 @@ export function InvestigationCard({
             </span>
           </a>
         )}
+        <AbstractSection abstract={abstract} />
         {hasInvestigationContent && (
           <>
             <hr class="investigation-card__divider lg-divider" />

--- a/src/components/search/ResultRow.tsx
+++ b/src/components/search/ResultRow.tsx
@@ -13,7 +13,6 @@ import {
   extractLinkedData,
   formatPagination,
 } from "@/services/referenceUtils";
-import { stripAbstractLabelPrefix } from "@/services/textUtils";
 import { extractReferenceCodingInstitution } from "@/services/codingInstitution";
 import { parseInvestigation } from "@/services/investigationParser";
 import { conceptsToTags } from "@/services/conceptLabels";
@@ -70,8 +69,7 @@ function aggregatePillConcepts(
 export function ResultRow({ communitySlug, reference }: ResultRowProps) {
   const bib = extractBibliographic(reference);
   const doi = extractDoi(reference.identifiers);
-  const rawAbstract = extractAbstract(reference)?.abstract ?? null;
-  const abstract = rawAbstract ? stripAbstractLabelPrefix(rawAbstract) : null;
+  const abstract = extractAbstract(reference)?.abstract ?? null;
   const counts = extractFindingsAndEstimatesCount(reference);
 
   const linkedData = extractLinkedData(reference);

--- a/src/components/search/ResultRow.tsx
+++ b/src/components/search/ResultRow.tsx
@@ -13,6 +13,7 @@ import {
   extractLinkedData,
   formatPagination,
 } from "@/services/referenceUtils";
+import { stripAbstractLabelPrefix } from "@/services/textUtils";
 import { extractReferenceCodingInstitution } from "@/services/codingInstitution";
 import { parseInvestigation } from "@/services/investigationParser";
 import { conceptsToTags } from "@/services/conceptLabels";
@@ -69,7 +70,8 @@ function aggregatePillConcepts(
 export function ResultRow({ communitySlug, reference }: ResultRowProps) {
   const bib = extractBibliographic(reference);
   const doi = extractDoi(reference.identifiers);
-  const abstract = extractAbstract(reference)?.abstract ?? null;
+  const rawAbstract = extractAbstract(reference)?.abstract ?? null;
+  const abstract = rawAbstract ? stripAbstractLabelPrefix(rawAbstract) : null;
   const counts = extractFindingsAndEstimatesCount(reference);
 
   const linkedData = extractLinkedData(reference);

--- a/src/components/search/ResultRow.tsx
+++ b/src/components/search/ResultRow.tsx
@@ -6,6 +6,7 @@ import type {
   ResolvedConcept,
 } from "@/types/investigation";
 import {
+  extractAbstract,
   extractBibliographic,
   extractDoi,
   extractFindingsAndEstimatesCount,
@@ -35,13 +36,6 @@ function formatAuthors(authors: { display_name: string }[]): string {
   }
   const head = authors.slice(0, MAX_AUTHORS_SHOWN).map((a) => a.display_name).join(", ");
   return `${head}, +${authors.length - MAX_AUTHORS_SHOWN} more`;
-}
-
-function findAbstract(reference: Reference): string | null {
-  const abs = reference.enhancements?.find(
-    (e) => e.content.enhancement_type === "abstract",
-  );
-  return abs && abs.content.enhancement_type === "abstract" ? abs.content.abstract : null;
 }
 
 // Document type first, then per-finding context/intervention/outcome concepts
@@ -75,7 +69,7 @@ function aggregatePillConcepts(
 export function ResultRow({ communitySlug, reference }: ResultRowProps) {
   const bib = extractBibliographic(reference);
   const doi = extractDoi(reference.identifiers);
-  const abstract = findAbstract(reference);
+  const abstract = extractAbstract(reference)?.abstract ?? null;
   const counts = extractFindingsAndEstimatesCount(reference);
 
   const linkedData = extractLinkedData(reference);

--- a/src/pages/RecordDetailPage.tsx
+++ b/src/pages/RecordDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "preact/hooks";
 import { useCommunity } from "@/community/CommunityContext";
 import {
+  extractAbstract,
   extractBibliographic,
   extractLinkedData,
   extractLinkedDataEnhancement,
@@ -14,6 +15,7 @@ import {
 import { useReference } from "@/hooks/useReference";
 import { useVocabulary } from "@/hooks/useVocabulary";
 import { useContextPrefixes } from "@/hooks/useContextPrefixes";
+import { AbstractSection } from "@/components/AbstractSection";
 import { InvestigationCard } from "@/components/InvestigationCard";
 import { FindingsSection } from "@/components/FindingsSection";
 import { NotFoundPage } from "./NotFoundPage";
@@ -95,6 +97,7 @@ export function RecordDetailPage({ id }: RecordDetailPageProps) {
   const codingInstitution = lde
     ? extractLinkedDataCodingInstitution(reference, lde)
     : null;
+  const abstract = extractAbstract(reference);
 
   return (
     <div class="record-detail-page">
@@ -112,6 +115,7 @@ export function RecordDetailPage({ id }: RecordDetailPageProps) {
           hasInvestigation={hasLinkedData}
           vocabUnavailable={!!vocabUnavailable}
         />
+        <AbstractSection abstract={abstract} />
         {investigation && investigation.findings.length > 0 && (
           <>
             {vocabUnavailable && (

--- a/src/pages/RecordDetailPage.tsx
+++ b/src/pages/RecordDetailPage.tsx
@@ -15,7 +15,6 @@ import {
 import { useReference } from "@/hooks/useReference";
 import { useVocabulary } from "@/hooks/useVocabulary";
 import { useContextPrefixes } from "@/hooks/useContextPrefixes";
-import { AbstractSection } from "@/components/AbstractSection";
 import { InvestigationCard } from "@/components/InvestigationCard";
 import { FindingsSection } from "@/components/FindingsSection";
 import { NotFoundPage } from "./NotFoundPage";
@@ -108,6 +107,7 @@ export function RecordDetailPage({ id }: RecordDetailPageProps) {
           venue={bibliographic?.publication_venue ?? null}
           pagination={bibliographic?.pagination ?? null}
           doi={doi}
+          abstract={abstract}
           publicationYear={bibliographic?.publication_year ?? null}
           documentType={investigation?.documentType}
           codingInstitution={codingInstitution}
@@ -115,7 +115,6 @@ export function RecordDetailPage({ id }: RecordDetailPageProps) {
           hasInvestigation={hasLinkedData}
           vocabUnavailable={!!vocabUnavailable}
         />
-        <AbstractSection abstract={abstract} />
         {investigation && investigation.findings.length > 0 && (
           <>
             {vocabUnavailable && (

--- a/src/services/referenceUtils.ts
+++ b/src/services/referenceUtils.ts
@@ -8,6 +8,11 @@ import type {
   ExternalIdentifier,
   Pagination,
 } from "@/types/models";
+import {
+  decodeHtmlEntities,
+  stripAbstractLabelPrefix,
+} from "@/services/textUtils";
+
 export function isDict(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
 }
@@ -72,25 +77,23 @@ export function extractLinkedData(
   return extractLinkedDataEnhancement(reference)?.content ?? null;
 }
 
-// Selection rule: canonical-first, longest-wins, newest tie-break.
-//
-// Canonical-first matches extractLatestEnhancement above: only fall back
-// to the duplicate bucket (enhancements whose reference_id doesn't match
-// the host reference id, carried over from dedup) when the canonical
-// bucket has no abstract. Prevents a duplicate's longer abstract from
-// masking the canonical record's curated body.
-//
-// Longest-wins within the chosen bucket diverges from the shared
-// newest-wins rule: at least one production ref (W4411634320) carries a
-// newer OpenAlex re-ingest that truncated the abstract to ~298 chars
-// while an older 1896-char ingest holds the full body. Length tie-breaks
-// to newest created_at.
-//
-// Source/process is intentionally ignored: EEF uses
-// `source: "eef-eppi-review"` / `process: "other"`, OpenAlex uses
-// `source: "openalex"` / `process: "uninverted"`, and future synthetic-
-// abstract robots will add more. `enhancement_type === "abstract"` covers
-// all of them.
+// Entity decoding + label-prefix strip only. Mojibake from upstream parsers
+// (e.g. UTF-8 double-encoded as Latin-1 leaking through the EEF EPPI parser,
+// rendering "3–6" as "3â€" 6") renders as-is — the fix belongs upstream in
+// the parser, not as silent client-side repair.
+function normalizeAbstractContent(
+  content: AbstractContentEnhancement,
+): AbstractContentEnhancement {
+  const abstract = stripAbstractLabelPrefix(
+    decodeHtmlEntities(content.abstract),
+  );
+  return abstract === content.abstract ? content : { ...content, abstract };
+}
+
+// Canonical bucket wins first. Within that bucket, longest body wins; equal
+// lengths use latest created_at. This avoids the W4411634320 truncated re-ingest.
+// Source/process are deliberately ignored so EEF, OpenAlex, and future abstract
+// robots all participate by enhancement_type.
 export function extractAbstract(
   reference: Reference,
 ): AbstractContentEnhancement | null {
@@ -105,14 +108,13 @@ export function extractAbstract(
   }
   const bucket = canonical.length ? canonical : duplicate;
   if (bucket.length === 0) return null;
-  // Non-mutating fold (matches extractLatestEnhancement's style): walk once,
-  // keep the running winner. Length wins; ties break to newest created_at.
-  return bucket.reduce((best, e) => {
+  const winner = bucket.reduce((best, e) => {
     const lenDiff = e.content.abstract.length - best.content.abstract.length;
     if (lenDiff > 0) return e;
     if (lenDiff < 0) return best;
     return (e.created_at ?? "") > (best.created_at ?? "") ? e : best;
-  }).content;
+  });
+  return normalizeAbstractContent(winner.content);
 }
 
 // Counts are read straight from raw JSON-LD so badges render on first paint

--- a/src/services/referenceUtils.ts
+++ b/src/services/referenceUtils.ts
@@ -2,6 +2,7 @@ import type {
   Reference,
   Enhancement,
   EnhancementContent,
+  AbstractContentEnhancement,
   BibliographicMetadataEnhancement,
   LinkedDataEnhancement,
   ExternalIdentifier,
@@ -69,6 +70,49 @@ export function extractLinkedData(
   reference: Reference,
 ): LinkedDataEnhancement | null {
   return extractLinkedDataEnhancement(reference)?.content ?? null;
+}
+
+// Selection rule: canonical-first, longest-wins, newest tie-break.
+//
+// Canonical-first matches extractLatestEnhancement above: only fall back
+// to the duplicate bucket (enhancements whose reference_id doesn't match
+// the host reference id, carried over from dedup) when the canonical
+// bucket has no abstract. Prevents a duplicate's longer abstract from
+// masking the canonical record's curated body.
+//
+// Longest-wins within the chosen bucket diverges from the shared
+// newest-wins rule: at least one production ref (W4411634320) carries a
+// newer OpenAlex re-ingest that truncated the abstract to ~298 chars
+// while an older 1896-char ingest holds the full body. Length tie-breaks
+// to newest created_at.
+//
+// Source/process is intentionally ignored: EEF uses
+// `source: "eef-eppi-review"` / `process: "other"`, OpenAlex uses
+// `source: "openalex"` / `process: "uninverted"`, and future synthetic-
+// abstract robots will add more. `enhancement_type === "abstract"` covers
+// all of them.
+export function extractAbstract(
+  reference: Reference,
+): AbstractContentEnhancement | null {
+  type AbstractEnh = Enhancement & { content: AbstractContentEnhancement };
+  const canonical: AbstractEnh[] = [];
+  const duplicate: AbstractEnh[] = [];
+  for (const e of reference.enhancements ?? []) {
+    if (e.content.enhancement_type !== "abstract") continue;
+    const narrowed = e as AbstractEnh;
+    if (e.reference_id === reference.id) canonical.push(narrowed);
+    else duplicate.push(narrowed);
+  }
+  const bucket = canonical.length ? canonical : duplicate;
+  if (bucket.length === 0) return null;
+  // Non-mutating fold (matches extractLatestEnhancement's style): walk once,
+  // keep the running winner. Length wins; ties break to newest created_at.
+  return bucket.reduce((best, e) => {
+    const lenDiff = e.content.abstract.length - best.content.abstract.length;
+    if (lenDiff > 0) return e;
+    if (lenDiff < 0) return best;
+    return (e.created_at ?? "") > (best.created_at ?? "") ? e : best;
+  }).content;
 }
 
 // Counts are read straight from raw JSON-LD so badges render on first paint

--- a/src/services/textUtils.ts
+++ b/src/services/textUtils.ts
@@ -1,0 +1,18 @@
+// Entity-only decoder using HTML5's escapable-raw-text content model (textarea).
+// Named, numeric, and hex character references all decode; tags inside the
+// input are preserved as literal characters (textarea does not parse children
+// as markup).
+//
+// Why textarea over DOMParser: DOMParser strips tags silently, which would
+// destroy the input if a future synthetic abstract ever contained markup.
+// Textarea decodes entities while leaving tags as text, which is the safest
+// default for plain-text rendering downstream.
+//
+// XSS surface: zero. We only read `.value` and the caller renders the result
+// as a text node (no innerHTML, no dangerouslySetInnerHTML).
+export function decodeHtmlEntities(text: string): string {
+  if (!text || !text.includes("&")) return text;
+  const textarea = document.createElement("textarea");
+  textarea.innerHTML = text;
+  return textarea.value;
+}

--- a/src/services/textUtils.ts
+++ b/src/services/textUtils.ts
@@ -1,24 +1,12 @@
-// Some sources (notably the EEF EPPI ingester) capture the literal section
-// label "Abstract" as the first word of the abstract body. Strip it so the
-// page doesn't render the heading "Abstract" directly above a body that
-// also starts with "Abstract". Case-sensitive: sentences that genuinely
-// start with "abstract" or "ABSTRACT" pass through untouched.
+// Drop duplicated leading "Abstract " labels from source abstracts.
+// Case-sensitive to avoid false positives.
 export function stripAbstractLabelPrefix(text: string): string {
   return text.replace(/^Abstract\s+/, "");
 }
 
-// Entity-only decoder using HTML5's escapable-raw-text content model (textarea).
-// Named, numeric, and hex character references all decode; tags inside the
-// input are preserved as literal characters (textarea does not parse children
-// as markup).
-//
-// Why textarea over DOMParser: DOMParser strips tags silently, which would
-// destroy the input if a future synthetic abstract ever contained markup.
-// Textarea decodes entities while leaving tags as text, which is the safest
-// default for plain-text rendering downstream.
-//
-// XSS surface: zero. We only read `.value` and the caller renders the result
-// as a text node (no innerHTML, no dangerouslySetInnerHTML).
+// Decode entities while preserving tags as literal text. We use <textarea>
+// rather than DOMParser because DOMParser would silently strip tags from a
+// plain-text abstract. XSS surface stays zero: callers render text, not HTML.
 export function decodeHtmlEntities(text: string): string {
   if (!text || !text.includes("&")) return text;
   const textarea = document.createElement("textarea");

--- a/src/services/textUtils.ts
+++ b/src/services/textUtils.ts
@@ -1,3 +1,12 @@
+// Some sources (notably the EEF EPPI ingester) capture the literal section
+// label "Abstract" as the first word of the abstract body. Strip it so the
+// page doesn't render the heading "Abstract" directly above a body that
+// also starts with "Abstract". Case-sensitive: sentences that genuinely
+// start with "abstract" or "ABSTRACT" pass through untouched.
+export function stripAbstractLabelPrefix(text: string): string {
+  return text.replace(/^Abstract\s+/, "");
+}
+
 // Entity-only decoder using HTML5's escapable-raw-text content model (textarea).
 // Named, numeric, and hex character references all decode; tags inside the
 // input are preserved as literal characters (textarea does not parse children

--- a/tests/components/AbstractSection.test.tsx
+++ b/tests/components/AbstractSection.test.tsx
@@ -1,0 +1,48 @@
+import { describe, test, expect } from "vitest";
+import { render, screen } from "@testing-library/preact";
+import { AbstractSection } from "@/components/AbstractSection";
+import type { AbstractContentEnhancement } from "@/types/models";
+
+function makeAbstract(
+  text: string,
+  process = "uninverted",
+): AbstractContentEnhancement {
+  return { enhancement_type: "abstract", process, abstract: text };
+}
+
+describe("AbstractSection", () => {
+  test.each([
+    ["null", null],
+    ["empty", makeAbstract("")],
+    ["whitespace-only", makeAbstract("   \n\t  ")],
+  ])("renders nothing for %s abstract", (_label, abstract) => {
+    const { container } = render(<AbstractSection abstract={abstract} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("renders nothing for the OpenAlex :unav sentinel (W6946467789 regression)", () => {
+    const { container } = render(
+      <AbstractSection abstract={makeAbstract(":unav")} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("renders the Abstract heading and body text when given a valid abstract", () => {
+    render(
+      <AbstractSection abstract={makeAbstract("This is the body of the abstract.")} />,
+    );
+    expect(screen.getByRole("heading", { name: "Abstract" })).toBeInTheDocument();
+    expect(screen.getByText("This is the body of the abstract.")).toBeInTheDocument();
+  });
+
+  test("decodes HTML entities before rendering (integration with decodeHtmlEntities)", () => {
+    render(
+      <AbstractSection
+        abstract={makeAbstract("Adjusted OR=2.07 for &gt;8 hours of screen time.")}
+      />,
+    );
+    expect(
+      screen.getByText("Adjusted OR=2.07 for >8 hours of screen time."),
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/components/AbstractSection.test.tsx
+++ b/tests/components/AbstractSection.test.tsx
@@ -35,33 +35,7 @@ describe("AbstractSection", () => {
     expect(screen.getByText("This is the body of the abstract.")).toBeInTheDocument();
   });
 
-  test("decodes HTML entities before rendering (integration with decodeHtmlEntities)", () => {
-    render(
-      <AbstractSection
-        abstract={makeAbstract("Adjusted OR=2.07 for &gt;8 hours of screen time.")}
-      />,
-    );
-    expect(
-      screen.getByText("Adjusted OR=2.07 for >8 hours of screen time."),
-    ).toBeInTheDocument();
-  });
-
-  test("strips leading 'Abstract' section label from body (EEF EPPI ingestor artefact, ~1.5% of corpus)", () => {
-    render(
-      <AbstractSection
-        abstract={makeAbstract("Abstract This paper aims to investigate.")}
-      />,
-    );
-    expect(
-      screen.getByText("This paper aims to investigate."),
-    ).toBeInTheDocument();
-    expect(screen.queryByText(/^Abstract This/)).toBeNull();
-  });
-
-  test("does not strip 'Abstract' when used as a real English word at the start of the body", () => {
-    // Case-sensitive guard: only the literal capitalised label "Abstract\s+"
-    // is stripped, so abstracts that happen to start with the word as a
-    // noun/adjective ("abstract algebra", "ABSTRACT") pass through unaltered.
+  test("renders supplied abstract text without additional normalization", () => {
     render(
       <AbstractSection
         abstract={makeAbstract("abstract reasoning improves problem-solving.")}

--- a/tests/components/AbstractSection.test.tsx
+++ b/tests/components/AbstractSection.test.tsx
@@ -45,4 +45,30 @@ describe("AbstractSection", () => {
       screen.getByText("Adjusted OR=2.07 for >8 hours of screen time."),
     ).toBeInTheDocument();
   });
+
+  test("strips leading 'Abstract' section label from body (EEF EPPI ingestor artefact, ~1.5% of corpus)", () => {
+    render(
+      <AbstractSection
+        abstract={makeAbstract("Abstract This paper aims to investigate.")}
+      />,
+    );
+    expect(
+      screen.getByText("This paper aims to investigate."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/^Abstract This/)).toBeNull();
+  });
+
+  test("does not strip 'Abstract' when used as a real English word at the start of the body", () => {
+    // Case-sensitive guard: only the literal capitalised label "Abstract\s+"
+    // is stripped, so abstracts that happen to start with the word as a
+    // noun/adjective ("abstract algebra", "ABSTRACT") pass through unaltered.
+    render(
+      <AbstractSection
+        abstract={makeAbstract("abstract reasoning improves problem-solving.")}
+      />,
+    );
+    expect(
+      screen.getByText("abstract reasoning improves problem-solving."),
+    ).toBeInTheDocument();
+  });
 });

--- a/tests/components/InvestigationCard.test.tsx
+++ b/tests/components/InvestigationCard.test.tsx
@@ -16,6 +16,7 @@ const DEFAULT_PROPS = {
     last_page: "115",
   },
   doi: "10.1234/test.2024",
+  abstract: null,
   publicationYear: 2024,
   documentType: {
     value: {
@@ -59,6 +60,34 @@ describe("InvestigationCard", () => {
     expect(link.getAttribute("target")).toBe("_blank");
     expect(link.getAttribute("rel")).toBe("noopener noreferrer");
     expect(link).toHaveTextContent(/doi:/);
+  });
+
+  test("renders abstract inside the card after the DOI", () => {
+    const { container } = render(
+      <InvestigationCard
+        {...DEFAULT_PROPS}
+        abstract={{
+          enhancement_type: "abstract",
+          process: "uninverted",
+          abstract: "This abstract belongs in the card.",
+        }}
+      />,
+    );
+
+    const card = container.querySelector(".investigation-card");
+    const doi = card?.querySelector(".investigation-card__doi");
+    const abstract = card?.querySelector(".abstract-section");
+    const divider = card?.querySelector(".investigation-card__divider");
+    expect(card).toContainElement(abstract as HTMLElement);
+    expect(
+      doi!.compareDocumentPosition(abstract as Node) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      abstract!.compareDocumentPosition(divider as Node) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(screen.getByText("This abstract belongs in the card.")).toBeDefined();
   });
 
   test("renders document type tag", () => {

--- a/tests/components/search/ResultRow.test.tsx
+++ b/tests/components/search/ResultRow.test.tsx
@@ -1,6 +1,7 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/preact";
 import { PILL_CAP, ResultRow } from "@/components/search/ResultRow";
+import type { Reference } from "@/types/models";
 import { makeReference } from "../../fixtures";
 
 const vocabState = {
@@ -281,5 +282,71 @@ describe("ResultRow", () => {
     render(<ResultRow communitySlug="esea" reference={ref} />);
     const rowLink = screen.getByRole("link", { name: new RegExp(REF_ID, "i") });
     expect(rowLink).toHaveAttribute("href", `/esea/references/${REF_ID}`);
+  });
+
+  test("selects the longer abstract when two abstract enhancements differ in length (longest-wins via extractAbstract)", () => {
+    const ref: Reference = {
+      id: "ref-1",
+      visibility: "public",
+      identifiers: [{ identifier: "10.1000/abc", identifier_type: "doi" }],
+      enhancements: [
+        {
+          id: "bib",
+          reference_id: "ref-1",
+          source: "openalex",
+          visibility: "public",
+          robot_version: null,
+          derived_from: null,
+          created_at: "2024-01-01",
+          content: {
+            enhancement_type: "bibliographic",
+            authorship: null,
+            cited_by_count: null,
+            created_date: null,
+            updated_date: null,
+            publication_date: null,
+            publication_year: 2020,
+            publisher: null,
+            title: "Two-abstract ref",
+            pagination: null,
+            publication_venue: null,
+          },
+        },
+        {
+          // Newer but truncated re-ingest (regression case for inline
+          // findAbstract, which used .find() and returned whichever appeared
+          // first in array order).
+          id: "abs-newer-shorter",
+          reference_id: "ref-1",
+          source: "openalex",
+          visibility: "public",
+          robot_version: null,
+          derived_from: null,
+          created_at: "2026-05-01T00:00:00Z",
+          content: {
+            enhancement_type: "abstract",
+            process: "uninverted",
+            abstract: "TRUNCATED TAIL",
+          },
+        },
+        {
+          id: "abs-older-longer",
+          reference_id: "ref-1",
+          source: "openalex",
+          visibility: "public",
+          robot_version: null,
+          derived_from: null,
+          created_at: "2024-01-02T00:00:00Z",
+          content: {
+            enhancement_type: "abstract",
+            process: "uninverted",
+            abstract: "FULL INTACT ABSTRACT BODY".padEnd(800, "."),
+          },
+        },
+      ],
+    };
+    render(<ResultRow communitySlug="esea" reference={ref} />);
+    expect(screen.getByText(/FULL INTACT ABSTRACT BODY/)).toBeInTheDocument();
+    expect(screen.queryByText("TRUNCATED TAIL")).toBeNull();
   });
 });

--- a/tests/components/search/ResultRow.test.tsx
+++ b/tests/components/search/ResultRow.test.tsx
@@ -50,7 +50,7 @@ function makeRef(opts: Parameters<typeof makeReference>[0] = {}) {
       year: 2020,
       venue: "Journal of Education",
     },
-    abstract: "This is the abstract body text used for the snippet preview.",
+    abstract: { text: "This is the abstract body text used for the snippet preview." },
     ...opts,
   });
 }

--- a/tests/components/search/ResultRow.test.tsx
+++ b/tests/components/search/ResultRow.test.tsx
@@ -284,6 +284,17 @@ describe("ResultRow", () => {
     expect(rowLink).toHaveAttribute("href", `/esea/references/${REF_ID}`);
   });
 
+  test("strips leading 'Abstract' section label from the row snippet (EEF ingestor artefact)", () => {
+    const ref = makeRef({
+      abstract: { text: "Abstract This paper aims to investigate." },
+    });
+    render(<ResultRow communitySlug="esea" reference={ref} />);
+    expect(
+      screen.getByText("This paper aims to investigate."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/^Abstract This/)).toBeNull();
+  });
+
   test("selects the longer abstract when two abstract enhancements differ in length (longest-wins via extractAbstract)", () => {
     const ref: Reference = {
       id: "ref-1",

--- a/tests/components/search/ResultRow.test.tsx
+++ b/tests/components/search/ResultRow.test.tsx
@@ -1,8 +1,11 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/preact";
 import { PILL_CAP, ResultRow } from "@/components/search/ResultRow";
-import type { Reference } from "@/types/models";
-import { makeReference } from "../../fixtures";
+import {
+  abstractEnh,
+  bibliographicEnh,
+  makeReference,
+} from "../../fixtures";
 
 const vocabState = {
   labels: null as Map<string, string> | null,
@@ -50,7 +53,7 @@ function makeRef(opts: Parameters<typeof makeReference>[0] = {}) {
       year: 2020,
       venue: "Journal of Education",
     },
-    abstract: { text: "This is the abstract body text used for the snippet preview." },
+    abstract: "This is the abstract body text used for the snippet preview.",
     ...opts,
   });
 }
@@ -286,76 +289,33 @@ describe("ResultRow", () => {
 
   test("strips leading 'Abstract' section label from the row snippet (EEF ingestor artefact)", () => {
     const ref = makeRef({
-      abstract: { text: "Abstract This paper aims to investigate." },
+      abstract: "Abstract This paper aims to investigate &gt;8 hours.",
     });
     render(<ResultRow communitySlug="esea" reference={ref} />);
     expect(
-      screen.getByText("This paper aims to investigate."),
+      screen.getByText("This paper aims to investigate >8 hours."),
     ).toBeInTheDocument();
     expect(screen.queryByText(/^Abstract This/)).toBeNull();
   });
 
   test("selects the longer abstract when two abstract enhancements differ in length (longest-wins via extractAbstract)", () => {
-    const ref: Reference = {
-      id: "ref-1",
-      visibility: "public",
-      identifiers: [{ identifier: "10.1000/abc", identifier_type: "doi" }],
+    const ref = makeReference({
+      id: REF_ID,
+      doi: "10.1000/abc",
       enhancements: [
-        {
-          id: "bib",
-          reference_id: "ref-1",
-          source: "openalex",
-          visibility: "public",
-          robot_version: null,
-          derived_from: null,
-          created_at: "2024-01-01",
-          content: {
-            enhancement_type: "bibliographic",
-            authorship: null,
-            cited_by_count: null,
-            created_date: null,
-            updated_date: null,
-            publication_date: null,
-            publication_year: 2020,
-            publisher: null,
-            title: "Two-abstract ref",
-            pagination: null,
-            publication_venue: null,
-          },
-        },
-        {
-          // Newer but truncated re-ingest (regression case for inline
-          // findAbstract, which used .find() and returned whichever appeared
-          // first in array order).
+        bibliographicEnh(REF_ID, { title: "Two-abstract ref", year: 2020 }),
+        abstractEnh(REF_ID, {
           id: "abs-newer-shorter",
-          reference_id: "ref-1",
-          source: "openalex",
-          visibility: "public",
-          robot_version: null,
-          derived_from: null,
-          created_at: "2026-05-01T00:00:00Z",
-          content: {
-            enhancement_type: "abstract",
-            process: "uninverted",
-            abstract: "TRUNCATED TAIL",
-          },
-        },
-        {
+          text: "TRUNCATED TAIL",
+          createdAt: "2026-05-01T00:00:00Z",
+        }),
+        abstractEnh(REF_ID, {
           id: "abs-older-longer",
-          reference_id: "ref-1",
-          source: "openalex",
-          visibility: "public",
-          robot_version: null,
-          derived_from: null,
-          created_at: "2024-01-02T00:00:00Z",
-          content: {
-            enhancement_type: "abstract",
-            process: "uninverted",
-            abstract: "FULL INTACT ABSTRACT BODY".padEnd(800, "."),
-          },
-        },
+          text: "FULL INTACT ABSTRACT BODY".padEnd(800, "."),
+          createdAt: "2024-01-02T00:00:00Z",
+        }),
       ],
-    };
+    });
     render(<ResultRow communitySlug="esea" reference={ref} />);
     expect(screen.getByText(/FULL INTACT ABSTRACT BODY/)).toBeInTheDocument();
     expect(screen.queryByText("TRUNCATED TAIL")).toBeNull();

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -8,6 +8,7 @@ import type {
 } from "@/types/investigation";
 import type { SharedContext } from "@/services/findingGroups";
 import type {
+  AbstractContentEnhancement,
   BibliographicMetadataEnhancement,
   Enhancement,
   LinkedDataEnhancement,
@@ -161,21 +162,34 @@ export function bibliographicEnh(
   };
 }
 
-/** Build an abstract Enhancement. */
-export function abstractEnh(refId: string, abstract: string): Enhancement {
+interface AbstractOpts {
+  text?: string;
+  process?: string;
+  /** Mirrors Enhancement.created_at (string | null). Defaults to null when omitted. */
+  createdAt?: string | null;
+  /** Override the source field. Defaults to "openalex". */
+  source?: string;
+}
+
+/** Build an abstract Enhancement with sensible defaults. */
+export function abstractEnh(
+  refId: string,
+  opts: AbstractOpts = {},
+): Enhancement {
+  const content: AbstractContentEnhancement = {
+    enhancement_type: "abstract",
+    process: opts.process ?? "uninverted",
+    abstract: opts.text ?? "Default abstract body for fixture.",
+  };
   return {
     id: `${refId}-abs`,
     reference_id: refId,
-    source: "openalex",
+    source: opts.source ?? "openalex",
     visibility: "public",
     robot_version: null,
     derived_from: null,
-    created_at: null,
-    content: {
-      enhancement_type: "abstract",
-      process: "openalex",
-      abstract,
-    },
+    created_at: opts.createdAt ?? null,
+    content,
   };
 }
 
@@ -238,7 +252,8 @@ interface ReferenceOpts {
   id?: string;
   doi?: string;
   bibliographic?: BibOpts;
-  abstract?: string;
+  /** Abstract text + options. When provided, an abstractEnh is appended. */
+  abstract?: AbstractOpts;
   /** Investigation dict to wrap in a linked_data enhancement, if any. */
   investigation?: Record<string, unknown>;
   /** Override enhancements entirely (skips bibliographic/abstract/investigation). */
@@ -252,7 +267,7 @@ export function makeReference(opts: ReferenceOpts = {}): Reference {
     opts.enhancements ??
     [
       bibliographicEnh(id, opts.bibliographic),
-      opts.abstract ? abstractEnh(id, opts.abstract) : null,
+      opts.abstract !== undefined ? abstractEnh(id, opts.abstract) : null,
       opts.investigation
         ? linkedDataEnh(id, { investigation: opts.investigation })
         : null,

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -163,6 +163,7 @@ export function bibliographicEnh(
 }
 
 interface AbstractOpts {
+  id?: string;
   text?: string;
   process?: string;
   /** Mirrors Enhancement.created_at (string | null). Defaults to null when omitted. */
@@ -182,7 +183,7 @@ export function abstractEnh(
     abstract: opts.text ?? "Default abstract body for fixture.",
   };
   return {
-    id: `${refId}-abs`,
+    id: opts.id ?? `${refId}-abs`,
     reference_id: refId,
     source: opts.source ?? "openalex",
     visibility: "public",
@@ -253,7 +254,7 @@ interface ReferenceOpts {
   doi?: string;
   bibliographic?: BibOpts;
   /** Abstract text + options. When provided, an abstractEnh is appended. */
-  abstract?: AbstractOpts;
+  abstract?: string | AbstractOpts;
   /** Investigation dict to wrap in a linked_data enhancement, if any. */
   investigation?: Record<string, unknown>;
   /** Override enhancements entirely (skips bibliographic/abstract/investigation). */
@@ -263,11 +264,14 @@ interface ReferenceOpts {
 /** Build a Reference with optional bibliographic, abstract, and linked-data enhancements. */
 export function makeReference(opts: ReferenceOpts = {}): Reference {
   const id = opts.id ?? "abc-123";
+  const abstractOpts = typeof opts.abstract === "string"
+    ? { text: opts.abstract }
+    : opts.abstract;
   const enhancements =
     opts.enhancements ??
     [
       bibliographicEnh(id, opts.bibliographic),
-      opts.abstract !== undefined ? abstractEnh(id, opts.abstract) : null,
+      abstractOpts !== undefined ? abstractEnh(id, abstractOpts) : null,
       opts.investigation
         ? linkedDataEnh(id, { investigation: opts.investigation })
         : null,

--- a/tests/pages/RecordDetailPage.test.tsx
+++ b/tests/pages/RecordDetailPage.test.tsx
@@ -132,7 +132,7 @@ describe("RecordDetailPage", () => {
     mockUseReference.mockReturnValue({
       reference: makeReference({
         bibliographic: { title: "Ref with abstract" },
-        abstract: { text: "This is the rendered abstract body." },
+        abstract: "Abstract This is the rendered abstract body with &gt; sign.",
       }),
       loading: false,
       error: null,
@@ -142,7 +142,7 @@ describe("RecordDetailPage", () => {
       screen.getByRole("heading", { name: "Abstract" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText("This is the rendered abstract body."),
+      screen.getByText("This is the rendered abstract body with > sign."),
     ).toBeInTheDocument();
   });
 

--- a/tests/pages/RecordDetailPage.test.tsx
+++ b/tests/pages/RecordDetailPage.test.tsx
@@ -128,6 +128,37 @@ describe("RecordDetailPage", () => {
     expect(screen.getByText("Journal Article")).toBeDefined();
   });
 
+  test("renders AbstractSection when an abstract enhancement is present", () => {
+    mockUseReference.mockReturnValue({
+      reference: makeReference({
+        bibliographic: { title: "Ref with abstract" },
+        abstract: { text: "This is the rendered abstract body." },
+      }),
+      loading: false,
+      error: null,
+    });
+    renderRecordDetail("abc");
+    expect(
+      screen.getByRole("heading", { name: "Abstract" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("This is the rendered abstract body."),
+    ).toBeInTheDocument();
+  });
+
+  test("does not render an Abstract heading when no abstract enhancement is present", () => {
+    mockUseReference.mockReturnValue({
+      reference: makeReference({
+        bibliographic: { title: "Ref without abstract" },
+      }),
+      loading: false,
+      error: null,
+    });
+    renderRecordDetail("abc");
+    expect(screen.getByText("Ref without abstract")).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Abstract" })).toBeNull();
+  });
+
   test("renders findings with raw URIs and a banner when vocab fetch fails", () => {
     mockUseReference.mockReturnValue({
       reference: makeReference({

--- a/tests/services/referenceUtils.test.ts
+++ b/tests/services/referenceUtils.test.ts
@@ -281,6 +281,16 @@ describe("extractAbstract", () => {
     expect(extractAbstract(ref)).toBe(abs);
   });
 
+  test("normalizes abstract text before returning it", () => {
+    const abs: AbstractContentEnhancement = {
+      enhancement_type: "abstract",
+      process: "other",
+      abstract: "Abstract A &gt; B",
+    };
+    const ref = makeRef([makeEnhancement(abs)]);
+    expect(extractAbstract(ref)?.abstract).toBe("A > B");
+  });
+
   test("longest wins within canonical bucket (W4411634320 truncation regression)", () => {
     const newerShorter: AbstractContentEnhancement = {
       enhancement_type: "abstract",

--- a/tests/services/referenceUtils.test.ts
+++ b/tests/services/referenceUtils.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "vitest";
 import {
+  extractAbstract,
   extractBibliographic,
   extractLatestEnhancement,
   extractLinkedData,
@@ -11,6 +12,7 @@ import {
 import type {
   Reference,
   Enhancement,
+  AbstractContentEnhancement,
   BibliographicMetadataEnhancement,
   LinkedDataEnhancement,
 } from "@/types/models";
@@ -256,5 +258,112 @@ describe("formatPagination", () => {
     expect(formatPagination({
       volume: null, issue: null, first_page: null, last_page: "130",
     })).toBe("130");
+  });
+});
+
+describe("extractAbstract", () => {
+  test("returns null when enhancements is null", () => {
+    expect(extractAbstract(makeRef(null))).toBeNull();
+  });
+
+  test("returns null when no abstract enhancement exists", () => {
+    const ref = makeRef([bibEnh()]);
+    expect(extractAbstract(ref)).toBeNull();
+  });
+
+  test("returns the abstract content when a single one is present", () => {
+    const abs: AbstractContentEnhancement = {
+      enhancement_type: "abstract",
+      process: "uninverted",
+      abstract: "Body text.",
+    };
+    const ref = makeRef([makeEnhancement(abs)]);
+    expect(extractAbstract(ref)).toBe(abs);
+  });
+
+  test("longest wins within canonical bucket (W4411634320 truncation regression)", () => {
+    const newerShorter: AbstractContentEnhancement = {
+      enhancement_type: "abstract",
+      process: "uninverted",
+      abstract: "Short closing fragment, 100 chars at most.".padEnd(100, "."),
+    };
+    const olderLonger: AbstractContentEnhancement = {
+      enhancement_type: "abstract",
+      process: "uninverted",
+      abstract: "Full intact abstract, much longer body text.".padEnd(1500, "."),
+    };
+    const ref = makeRef([
+      makeEnhancement(newerShorter, "2026-05-01T00:00:00Z"),
+      makeEnhancement(olderLonger, "2024-01-01T00:00:00Z"),
+    ]);
+    expect(extractAbstract(ref)).toBe(olderLonger);
+  });
+
+  test("ties broken by newest created_at when lengths are equal", () => {
+    const body = "Same length abstract.".padEnd(500, ".");
+    const older: AbstractContentEnhancement = {
+      enhancement_type: "abstract",
+      process: "uninverted",
+      abstract: body,
+    };
+    const newer: AbstractContentEnhancement = {
+      enhancement_type: "abstract",
+      process: "other",
+      abstract: body,
+    };
+    const ref = makeRef([
+      makeEnhancement(older, "2024-01-01T00:00:00Z"),
+      makeEnhancement(newer, "2026-05-01T00:00:00Z"),
+    ]);
+    expect(extractAbstract(ref)).toBe(newer);
+  });
+
+  test("canonical bucket beats duplicate bucket even when duplicate is longer or newer", () => {
+    const canonicalShorterOlder: AbstractContentEnhancement = {
+      enhancement_type: "abstract",
+      process: "uninverted",
+      abstract: "Canonical short body.",
+    };
+    const duplicateLongerNewer: AbstractContentEnhancement = {
+      enhancement_type: "abstract",
+      process: "uninverted",
+      abstract: "Duplicate much longer body.".padEnd(3000, "."),
+    };
+    const ref: Reference = {
+      id: "ref-1",
+      visibility: "public",
+      identifiers: null,
+      enhancements: [
+        {
+          ...makeEnhancement(canonicalShorterOlder, "2024-01-01T00:00:00Z"),
+          reference_id: "ref-1",
+        },
+        {
+          ...makeEnhancement(duplicateLongerNewer, "2026-05-01T00:00:00Z"),
+          reference_id: "dup-2",
+        },
+      ],
+    };
+    expect(extractAbstract(ref)).toBe(canonicalShorterOlder);
+  });
+
+  test("falls back to duplicate bucket when canonical bucket has no abstract", () => {
+    const duplicateOnly: AbstractContentEnhancement = {
+      enhancement_type: "abstract",
+      process: "uninverted",
+      abstract: "Duplicate abstract.",
+    };
+    const ref: Reference = {
+      id: "ref-1",
+      visibility: "public",
+      identifiers: null,
+      enhancements: [
+        {
+          ...makeEnhancement(duplicateOnly),
+          reference_id: "dup-2",
+        },
+      ],
+    };
+    expect(extractAbstract(ref)).toBe(duplicateOnly);
   });
 });

--- a/tests/services/textUtils.test.ts
+++ b/tests/services/textUtils.test.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect } from "vitest";
+import { decodeHtmlEntities } from "@/services/textUtils";
+
+describe("decodeHtmlEntities", () => {
+  test.each([
+    ["", ""],
+    ["plain text", "plain text"],
+    // Contains "&" but not a recognised entity. Proves the includes("&")
+    // fast-path's non-trivial branch (textarea runs) is non-destructive.
+    ["AT&T research", "AT&T research"],
+  ])("passes through %j unchanged", (input, expected) => {
+    expect(decodeHtmlEntities(input)).toBe(expected);
+  });
+
+  test.each([
+    ["a &gt; b &lt; c", "a > b < c"],
+    ["&amp;", "&"],
+    ["&quot;hi&quot;", '"hi"'],
+    ["a&nbsp;b", "a\u00a0b"],
+    ["en&#8211;dash", "en–dash"],
+    ["en&#x2013;dash", "en–dash"],
+  ])("decodes entities in %j", (input, expected) => {
+    expect(decodeHtmlEntities(input)).toBe(expected);
+  });
+
+  test("normalises encoded CR/LF entities to a single LF line break", () => {
+    // HTML5 spec: <textarea>.innerHTML normalises CR (U+000D) and CRLF to a
+    // single LF (U+000A) on set. Observed in W6997086441's "&#13;" data.
+    expect(decodeHtmlEntities("line1&#13;&#10;line2")).toBe("line1\nline2");
+  });
+
+  test("preserves tags as literal text while decoding entities inside them", () => {
+    // Guards the textarea choice over DOMParser: DOMParser would parse <p>
+    // and strip the tags silently; textarea's escapable-raw-text content
+    // model leaves tags as literal characters.
+    expect(decodeHtmlEntities("<p>a &gt; b</p>")).toBe("<p>a > b</p>");
+  });
+});

--- a/tests/services/textUtils.test.ts
+++ b/tests/services/textUtils.test.ts
@@ -1,5 +1,8 @@
 import { describe, test, expect } from "vitest";
-import { decodeHtmlEntities } from "@/services/textUtils";
+import {
+  decodeHtmlEntities,
+  stripAbstractLabelPrefix,
+} from "@/services/textUtils";
 
 describe("decodeHtmlEntities", () => {
   test.each([
@@ -34,5 +37,19 @@ describe("decodeHtmlEntities", () => {
     // and strip the tags silently; textarea's escapable-raw-text content
     // model leaves tags as literal characters.
     expect(decodeHtmlEntities("<p>a &gt; b</p>")).toBe("<p>a > b</p>");
+  });
+});
+
+describe("stripAbstractLabelPrefix", () => {
+  test.each([
+    ["Abstract This paper aims to investigate.", "This paper aims to investigate."],
+    ["Abstract   The leading whitespace is normalised.", "The leading whitespace is normalised."],
+    // Pass-through when the prefix is absent or differently cased.
+    ["The paper presents results.", "The paper presents results."],
+    ["abstract reasoning improves problem-solving.", "abstract reasoning improves problem-solving."],
+    ["ABSTRACT in caps is not stripped.", "ABSTRACT in caps is not stripped."],
+    ["", ""],
+  ])("normalises %j", (input, expected) => {
+    expect(stripAbstractLabelPrefix(input)).toBe(expected);
   });
 });


### PR DESCRIPTION
## Summary

- Render the abstract of a reference on the record detail page when an `AbstractContentEnhancement` is present. Heading + body sit between the InvestigationCard and the findings block; absent / empty / whitespace-only / `:unav`-sentinel abstracts render nothing.
- Unify abstract selection across the codebase via a new `extractAbstract` utility: canonical-first, longest-wins, newest tie-break. Replaces `ResultRow`'s inline `findAbstract()` which used `.find()` and would return whichever abstract appeared first in array order. Regression case: W4411634320, which carries a newer truncated re-ingest alongside the older intact 1896-char body.
- HTML entities decoded via a small `decodeHtmlEntities` utility built on `<textarea>.innerHTML` (decodes named, numeric, and hex entities; preserves tags as literal text). The textarea content model guards against the silent tag stripping that `DOMParser` would do. Mojibake from the EEF EPPI parser is rendered as-is; the fix belongs upstream.
- Strip the literal section label "Abstract" when the source data captures it as the first word of the body (~1.5% of the local corpus). Shared `stripAbstractLabelPrefix` helper applied in both `AbstractSection` (detail page) and `ResultRow` (search snippet).

## Validation performed

- Typecheck clean (`npm run typecheck`).
- Full test suite: 430 passing (baseline 405 + 25 new). 6 commits, each a green state.
- New tests: 5 `decodeHtmlEntities`, 6 `stripAbstractLabelPrefix` (table-driven), 7 `extractAbstract` (including canonical-vs-duplicate bucket coverage), 2 `ResultRow` regressions (longest-wins + prefix strip), 7 `AbstractSection` policy + prefix strip, 2 `RecordDetailPage` wiring.
- Production build clean (`npm run build`).
- Live verification against local destiny-repository (14,357 abstracts indexed, ESEA community):
  - Abstract heading and body render below the InvestigationCard on OpenAlex-sourced refs.
  - Entity decoding confirmed: `p &gt; 0.05` renders as `p > 0.05` on `019dc685-59f3-77de-b81a-4cf7cf1148e6`.
  - Tag-passthrough confirmed: `<em>r</em>` renders as literal text on `019d986a-970a-75aa-9cbe-f0c618adb0a8` (would have been stripped by DOMParser).
  - Mojibake passes through unchanged on EEF-sourced refs (`â€` artifacts visible in body, matching the search-row rendering above).
  - Leading "Abstract" label removed in both detail page and search-row snippet (confirmed on `019d9868-f3ba-7619-9980-b459ee80549c`, an EEF-ingested ref).
  - Search-row snippets still render. The longest-wins switch in `ResultRow` only changes output for references with two or more abstracts of differing lengths; for the typical single-abstract reference (the vast majority of the corpus) the row looks identical to before, so live verification confirms the swap is non-breaking rather than directly observing the regression fix.
  - No new console errors or warnings introduced.

## Implementation notes

- `extractAbstract` deliberately diverges from `extractLatestEnhancement`'s newest-wins selection (length wins, recency breaks ties) to rescue the W4411634320 truncation case. Canonical-vs-duplicate bucketing is preserved so a duplicate's longer body can't override the canonical record. Rationale documented inline at `src/services/referenceUtils.ts`.
- `decodeHtmlEntities` uses `<textarea>.innerHTML` over `DOMParser` so tags inside abstract text aren't silently stripped. Live verification surfaced a real instance of this (`<em>r</em> = 0.7`) on a ref from the local corpus.
- `stripAbstractLabelPrefix` is case-sensitive (only the literal label `Abstract`, not `abstract`/`ABSTRACT`). Live verification confirmed no false positives across the search-result sample.
- `AbstractSection` CSS uses pre-existing tokens (`--spacing-lg`, `--spacing-md`, `--font-size-body`, `--color-text-primary`); `unicode-bidi: plaintext` future-proofs against mixed-direction abstracts; `white-space: pre-line` future-proofs against synthetic abstracts with paragraph breaks.