### PR TITLE
Source ESEA vocab + context URLs from Terraform

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,5 +5,5 @@ VITE_KEYCLOAK_REALM=destiny
 VITE_KEYCLOAK_CLIENT_ID=evidence-repo-ui-client-development
 # VITE_MATOMO_CONTAINER_URL=https://cdn.matomo.cloud/futureevidence.matomo.cloud/container_<id>_dev_<hash>.js
 VITE_FEEDBACK_FORM_URL=https://forms.gle/zH9fsNZk8BApTaVj9
-VITE_EXPORT_VOCABULARY_URL=https://vocab.staging.evidence-repository.org/published/019d40cf-2a63-77af-9828-c6a70647792c/1.1/vocabulary.jsonld
-VITE_EXPORT_CONTEXT_URL=https://vocab.staging.evidence-repository.org/published/019d40cf-2a63-77af-9828-c6a70647792c/1.1/context.jsonld
+VITE_ESEA_VOCABULARY_URL=https://vocab.staging.evidence-repository.org/published/019d40cf-2a63-77af-9828-c6a70647792c/1.1/vocabulary.jsonld
+VITE_ESEA_CONTEXT_URL=https://vocab.staging.evidence-repository.org/published/019d40cf-2a63-77af-9828-c6a70647792c/1.1/context.jsonld

--- a/infra/app/github_actions.tf
+++ b/infra/app/github_actions.tf
@@ -123,6 +123,20 @@ resource "github_actions_environment_variable" "vite_feedback_form_url" {
   value         = var.feedback_form_url
 }
 
+resource "github_actions_environment_variable" "vite_esea_vocabulary_url" {
+  repository    = github_repository_environment.environment.repository
+  environment   = github_repository_environment.environment.environment
+  variable_name = "VITE_ESEA_VOCABULARY_URL"
+  value         = var.esea_vocabulary_url
+}
+
+resource "github_actions_environment_variable" "vite_esea_context_url" {
+  repository    = github_repository_environment.environment.repository
+  environment   = github_repository_environment.environment.environment
+  variable_name = "VITE_ESEA_CONTEXT_URL"
+  value         = var.esea_context_url
+}
+
 resource "github_actions_environment_variable" "frontdoor_resource_group" {
   repository    = github_repository_environment.environment.repository
   environment   = github_repository_environment.environment.environment

--- a/infra/app/variables.tf
+++ b/infra/app/variables.tf
@@ -106,3 +106,13 @@ variable "feedback_form_url" {
   default     = "https://forms.gle/zH9fsNZk8BApTaVj9"
 }
 
+variable "esea_vocabulary_url" {
+  description = "URL of the ESEA community's published SKOS vocabulary (.jsonld) — used to resolve concept labels in exports and other vocabulary-driven features"
+  type        = string
+}
+
+variable "esea_context_url" {
+  description = "URL of the ESEA community's JSON-LD @context (.jsonld) — used to expand CURIE prefixes in exports and other vocabulary-driven features"
+  type        = string
+}
+

--- a/infra/app/variables.tf
+++ b/infra/app/variables.tf
@@ -109,10 +109,12 @@ variable "feedback_form_url" {
 variable "esea_vocabulary_url" {
   description = "URL of the ESEA community's published SKOS vocabulary (.jsonld) — used to resolve concept labels in exports and other vocabulary-driven features"
   type        = string
+  default     = "https://vocab.evidence-repository.org/published/019d9463-2780-7243-b4de-e547386f2a90/1.1/vocabulary.jsonld"
 }
 
 variable "esea_context_url" {
   description = "URL of the ESEA community's JSON-LD @context (.jsonld) — used to expand CURIE prefixes in exports and other vocabulary-driven features"
   type        = string
+  default     = "https://vocab.evidence-repository.org/published/019d9463-2780-7243-b4de-e547386f2a90/1.1/context.jsonld"
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,8 +9,8 @@ export const MATOMO_CONTAINER_URL = import.meta.env.VITE_MATOMO_CONTAINER_URL;
 export const FEEDBACK_FORM_URL: string | undefined =
   import.meta.env.VITE_FEEDBACK_FORM_URL;
 
-export const EXPORT_VOCABULARY_URL = import.meta.env.VITE_EXPORT_VOCABULARY_URL;
-export const EXPORT_CONTEXT_URL = import.meta.env.VITE_EXPORT_CONTEXT_URL;
+export const ESEA_VOCABULARY_URL = import.meta.env.VITE_ESEA_VOCABULARY_URL;
+export const ESEA_CONTEXT_URL = import.meta.env.VITE_ESEA_CONTEXT_URL;
 
 const VOCAB_PROXY_TARGET = import.meta.env.VITE_VOCAB_PROXY_TARGET;
 

--- a/src/hooks/useSearchExport.ts
+++ b/src/hooks/useSearchExport.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 
-import { EXPORT_CONTEXT_URL, EXPORT_VOCABULARY_URL } from "@/config";
+import { ESEA_CONTEXT_URL, ESEA_VOCABULARY_URL } from "@/config";
 import {
   getSearchExport,
   requestSearchExport,
@@ -74,10 +74,10 @@ export function useSearchExport(): UseSearchExportResult {
 
       // The workbook falls back to raw CURIEs when Vocab/context URLs are missing.
       // Warn so misconfiguration is visible in devtools without surfacing a user-facing error.
-      if (!EXPORT_VOCABULARY_URL || !EXPORT_CONTEXT_URL) {
+      if (!ESEA_VOCABULARY_URL || !ESEA_CONTEXT_URL) {
         console.warn(
           "Export vocab/context URLs not configured; concept cells will contain raw CURIEs.",
-          { EXPORT_VOCABULARY_URL, EXPORT_CONTEXT_URL },
+          { ESEA_VOCABULARY_URL, ESEA_CONTEXT_URL },
         );
       }
 
@@ -103,8 +103,8 @@ export function useSearchExport(): UseSearchExportResult {
         try {
           await exportReferencesToExcel(
             job.result_url,
-            EXPORT_VOCABULARY_URL,
-            EXPORT_CONTEXT_URL,
+            ESEA_VOCABULARY_URL,
+            ESEA_CONTEXT_URL,
             filename,
           );
         } catch (err) {

--- a/tests/hooks/useSearchExport.test.tsx
+++ b/tests/hooks/useSearchExport.test.tsx
@@ -20,8 +20,8 @@ vi.mock("@/config", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/config")>();
   return {
     ...actual,
-    EXPORT_VOCABULARY_URL: "https://test.example/vocab",
-    EXPORT_CONTEXT_URL: "https://test.example/context",
+    ESEA_VOCABULARY_URL: "https://test.example/vocab",
+    ESEA_CONTEXT_URL: "https://test.example/context",
   };
 });
 

--- a/tests/pages/SearchPage.test.tsx
+++ b/tests/pages/SearchPage.test.tsx
@@ -30,8 +30,8 @@ vi.mock("@/config", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/config")>();
   return {
     ...actual,
-    EXPORT_VOCABULARY_URL: "https://test.example/vocab",
-    EXPORT_CONTEXT_URL: "https://test.example/context",
+    ESEA_VOCABULARY_URL: "https://test.example/vocab",
+    ESEA_CONTEXT_URL: "https://test.example/context",
   };
 });
 


### PR DESCRIPTION
Follow-up to https://github.com/destiny-evidence/evidence-repo-ui/pull/55 — the export feature shipped without infra config for the two env vars it reads.

Adds `esea_vocabulary_url` / `esea_context_url` Terraform variables and plumbs them through to `VITE_ESEA_VOCABULARY_URL` / `VITE_ESEA_CONTEXT_URL` for the GitHub Actions build. Per-env values supplied via Terraform Cloud.

Renamed from `EXPORT_*` to `ESEA_*` to reflect that these are community-level vocabulary pointers — same URLs can be reused for faceted search and any other vocabulary-driven feature on the ESEA community.