### PR TITLE
Forward feedback and ESEA env vars to the build step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,6 +52,9 @@ jobs:
           VITE_KEYCLOAK_REALM: ${{ vars.VITE_KEYCLOAK_REALM }}
           VITE_KEYCLOAK_CLIENT_ID: ${{ vars.VITE_KEYCLOAK_CLIENT_ID }}
           VITE_MATOMO_CONTAINER_URL: ${{ vars.VITE_MATOMO_CONTAINER_URL }}
+          VITE_FEEDBACK_FORM_URL: ${{ vars.VITE_FEEDBACK_FORM_URL }}
+          VITE_ESEA_VOCABULARY_URL: ${{ vars.VITE_ESEA_VOCABULARY_URL }}
+          VITE_ESEA_CONTEXT_URL: ${{ vars.VITE_ESEA_CONTEXT_URL }}
         run: npm run build
 
       - name: Upload build artifacts


### PR DESCRIPTION
The deploy workflow's build step only forwarded the original five `VITE_*` vars. `VITE_FEEDBACK_FORM_URL` (added in https://github.com/destiny-evidence/evidence-repo-ui/pull/52) and `VITE_ESEA_VOCABULARY_URL` / `VITE_ESEA_CONTEXT_URL` (added in https://github.com/destiny-evidence/evidence-repo-ui/pull/64) were published as GitHub Actions environment variables via Terraform but never exposed to Vite at build time.