### PR TITLE
Add linked_data_concepts faceted search (#62)

### DIFF
--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,15 +1,24 @@
 import { useState, useEffect, useCallback } from "preact/hooks";
 import { searchReferences, type SearchFilters } from "@/services/apiClient";
-import { SORT_BACKEND } from "@/services/searchParams";
+import { SORT_BACKEND, buildFacetedQuery, expandFacets } from "@/services/searchParams";
 import { useCommunity } from "@/community/CommunityContext";
 import type { SearchResult } from "@/types/models";
 import type { SearchParams } from "@/services/searchParams";
 
-function paramsKey(params: SearchParams, slug: string, annotations: string[]): string {
+function paramsKey(
+  params: SearchParams,
+  slug: string,
+  annotations: string[],
+  vocabBase: string,
+): string {
   // JSON.stringify is unambiguous for arbitrary string arrays — two distinct
   // inputs can never collapse to the same key even if annotations contain commas,
   // quotes, or other delimiters. Ad hoc joins are brittle here.
   // Intentionally order-sensitive: ["a","b"] and ["b","a"] are different keys.
+  // Facets keyed in compact form (typed state) — order-sensitive.
+  // vocabBase mirrors the value the effect uses via expandFacets; today it's
+  // determined by slug, but keying on it directly avoids a stale cache if a
+  // community ever decouples slug from vocab base.
   return [
     `q=${params.q}`,
     `page=${params.page}`,
@@ -18,6 +27,8 @@ function paramsKey(params: SearchParams, slug: string, annotations: string[]): s
     `sort=${params.sort ?? ""}`,
     `slug=${slug}`,
     `ann=${JSON.stringify(annotations)}`,
+    `facets=${JSON.stringify(params.searchFacets)}`,
+    `vocab=${vocabBase}`,
   ].join("&");
 }
 
@@ -28,7 +39,12 @@ export function useSearch(params: SearchParams): {
   retry: () => void;
 } {
   const community = useCommunity();
-  const key = paramsKey(params, community?.slug ?? "", community?.defaultAnnotations ?? []);
+  const key = paramsKey(
+    params,
+    community?.slug ?? "",
+    community?.defaultAnnotations ?? [],
+    community?.vocabBase ?? "",
+  );
   const [results, setResults] = useState<SearchResult | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
@@ -55,7 +71,9 @@ export function useSearch(params: SearchParams): {
     };
     if (params.sort !== undefined) filters.sort = [SORT_BACKEND[params.sort]];
 
-    searchReferences(params.q || undefined, filters)
+    const expanded = expandFacets(params.searchFacets, community.vocabBase);
+    const wireQuery = buildFacetedQuery(params.q, expanded);
+    searchReferences(wireQuery || undefined, filters)
       .then((r) => { if (!cancelled) setResults(r); })
       .catch((e) => {
         if (cancelled) return;

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -118,13 +118,15 @@ function SearchPageInner({ community }: { community: Community }) {
     results.error !== null ||
     params.q !== "" ||
     params.startYear !== undefined ||
-    params.endYear !== undefined;
+    params.endYear !== undefined ||
+    params.searchFacets.length > 0;
 
   // Browse mode skips the summary text to avoid duplicating the hero's corpus count.
   const showSummary =
     params.q !== "" ||
     params.startYear !== undefined ||
     params.endYear !== undefined ||
+    params.searchFacets.length > 0 ||
     results.error !== null;
 
   function handleSubmit() {

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -92,7 +92,7 @@ export function SearchPage(_props: SearchPageProps) {
 
 function SearchPageInner({ community }: { community: Community }) {
   const search = useUrlParams();
-  const params = parseSearchParams(search);
+  const params = parseSearchParams(search, community.vocabBase);
   const canonicalQs = toQueryString(params);
 
   // Canonicalize once: if URL query string doesn't match the canonical form,

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -169,7 +169,7 @@ function SearchPageInner({ community }: { community: Community }) {
   const exportAnnouncement = exportAnnouncementFor(exportJob.status);
 
   function handleExport() {
-    const { query, filters } = toExportSearchQuery(params, community.defaultAnnotations);
+    const { query, filters } = toExportSearchQuery(params, community.defaultAnnotations, community.vocabBase);
     exportJob.start(query, filters, formatExportFilename(community.slug));
   }
 

--- a/src/services/communities.ts
+++ b/src/services/communities.ts
@@ -5,6 +5,7 @@ const COMMUNITIES: Community[] = [
     slug: "esea",
     name: "Education",
     defaultAnnotations: ["domain-inclusion/jacobs-education"],
+    vocabBase: "https://vocab.esea.education/",
   },
 ];
 

--- a/src/services/searchParams.ts
+++ b/src/services/searchParams.ts
@@ -93,3 +93,21 @@ export function buildFacetedQuery(q: string, facets: string[]): string {
   const base = trimmed === "" ? "*" : `(${trimmed})`;
   return [base, ...facets.map((f) => `(${f})`)].join(" AND ");
 }
+
+const LDC_URI = /(linked_data_concepts:")([^"]+)(")/g;
+
+export function expandFacets(facets: string[], vocabBase: string): string[] {
+  return facets.map((f) =>
+    f.replace(LDC_URI, (_, prefix, uri, suffix) =>
+      uri.startsWith("http") ? `${prefix}${uri}${suffix}` : `${prefix}${vocabBase}${uri}${suffix}`,
+    ),
+  );
+}
+
+export function compactFacets(facets: string[], vocabBase: string): string[] {
+  return facets.map((f) =>
+    f.replace(LDC_URI, (_, prefix, uri, suffix) =>
+      uri.startsWith(vocabBase) ? `${prefix}${uri.slice(vocabBase.length)}${suffix}` : `${prefix}${uri}${suffix}`,
+    ),
+  );
+}

--- a/src/services/searchParams.ts
+++ b/src/services/searchParams.ts
@@ -15,6 +15,7 @@ export interface SearchParams {
   startYear: number | undefined;
   endYear: number | undefined;
   sort: SortOption | undefined;
+  searchFacets: string[];
 }
 
 // Unknown values fall back to undefined (relevance).
@@ -49,7 +50,7 @@ export function parseSearchParams(search: string): SearchParams {
 
   const sort = parseSort(params.get("sort"));
 
-  return { q, page, startYear, endYear, sort };
+  return { q, page, startYear, endYear, sort, searchFacets: [] };
 }
 
 export function toQueryString(params: SearchParams): string {

--- a/src/services/searchParams.ts
+++ b/src/services/searchParams.ts
@@ -85,7 +85,10 @@ export function parseSearchParams(search: string, vocabBase?: string): SearchPar
 
 export function toQueryString(params: SearchParams): string {
   const out = new URLSearchParams();
-  if (params.q) out.set("q", params.q);
+  const qSerialised = params.searchFacets.length > 0
+    ? buildFacetedQuery(params.q, params.searchFacets)
+    : params.q;
+  if (qSerialised) out.set("q", qSerialised);
   if (params.startYear !== undefined) out.set("start_year", String(params.startYear));
   if (params.endYear !== undefined) out.set("end_year", String(params.endYear));
   if (params.sort !== undefined) out.set("sort", params.sort);

--- a/src/services/searchParams.ts
+++ b/src/services/searchParams.ts
@@ -31,12 +31,42 @@ function parseDecimalInt(raw: string | null): number | undefined {
   return Number.isSafeInteger(n) ? n : undefined;
 }
 
-export function parseSearchParams(search: string): SearchParams {
+// Strips an outer ( ... ) pair iff the first "(" balances at the last ")".
+// "(a) AND (b)" → unchanged (first "(" closes before the end).
+function stripOuterWrap(s: string): string {
+  if (!s.startsWith("(") || !s.endsWith(")")) return s;
+  let depth = 0;
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] === "(") depth++;
+    else if (s[i] === ")") {
+      depth--;
+      if (depth === 0 && i < s.length - 1) return s;
+    }
+  }
+  return depth === 0 ? s.slice(1, -1) : s;
+}
+
+export function parseSearchParams(search: string, vocabBase?: string): SearchParams {
   const params = new URLSearchParams(
     search.startsWith("?") ? search.slice(1) : search,
   );
 
-  const q = (params.get("q") ?? "").trim();
+  let q = (params.get("q") ?? "").trim();
+
+  const facetTail = /\s+AND\s+\(\s*(linked_data_concepts:[^)]+?)\s*\)\s*$/;
+  let searchFacets: string[] = [];
+  while (true) {
+    const m = q.match(facetTail);
+    if (!m) break;
+    searchFacets.unshift(m[1]);
+    q = q.slice(0, q.length - m[0].length).trimEnd();
+  }
+
+  if (searchFacets.length > 0) {
+    if (q === "*") q = "";
+    else q = stripOuterWrap(q);
+    if (vocabBase !== undefined) searchFacets = compactFacets(searchFacets, vocabBase);
+  }
 
   const pageRaw = parseDecimalInt(params.get("page"));
   const page = pageRaw !== undefined && pageRaw >= 1 ? pageRaw : 1;
@@ -50,7 +80,7 @@ export function parseSearchParams(search: string): SearchParams {
 
   const sort = parseSort(params.get("sort"));
 
-  return { q, page, startYear, endYear, sort, searchFacets: [] };
+  return { q, page, startYear, endYear, sort, searchFacets };
 }
 
 export function toQueryString(params: SearchParams): string {

--- a/src/services/searchParams.ts
+++ b/src/services/searchParams.ts
@@ -84,3 +84,12 @@ export function toExportSearchQuery(
   const query = params.q.trim() === "" ? "*" : params.q;
   return { query, filters };
 }
+
+// Base is paren-wrapped because Lucene binds AND tighter than OR:
+// `a OR b AND (f)` would parse as `a OR (b AND (f))`. Empty base → `*`.
+export function buildFacetedQuery(q: string, facets: string[]): string {
+  const trimmed = q.trim();
+  if (facets.length === 0) return trimmed;
+  const base = trimmed === "" ? "*" : `(${trimmed})`;
+  return [base, ...facets.map((f) => `(${f})`)].join(" AND ");
+}

--- a/src/services/searchParams.ts
+++ b/src/services/searchParams.ts
@@ -102,12 +102,14 @@ export function buildSearchUrl(communitySlug: string, params: SearchParams): str
 }
 
 // Maps a SearchParams + community annotations to the query/filters shape the
-// export endpoint expects. Substitutes "*" for an empty `q` so the backend's
-// `min_length=1` constraint is satisfied for browse-mode and year-only
-// exports.
+// export endpoint expects. Facets expand to fully-qualified URIs at this
+// boundary so live search and export share one wire-format path. Substitutes
+// "*" for an empty browse-mode query (no q, no facets) so the backend's
+// `min_length=1` constraint is satisfied.
 export function toExportSearchQuery(
   params: SearchParams,
   annotations: string[] | undefined,
+  vocabBase: string,
 ): { query: string; filters: Omit<SearchFilters, "page"> } {
   const filters: Omit<SearchFilters, "page"> = {
     startYear: params.startYear,
@@ -115,7 +117,8 @@ export function toExportSearchQuery(
     annotation: annotations,
   };
   if (params.sort !== undefined) filters.sort = [SORT_BACKEND[params.sort]];
-  const query = params.q.trim() === "" ? "*" : params.q;
+  const expanded = expandFacets(params.searchFacets, vocabBase);
+  const query = buildFacetedQuery(params.q, expanded) || "*";
   return { query, filters };
 }
 

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -2,6 +2,7 @@ export interface Community {
   slug: string;
   name: string;
   defaultAnnotations: string[];
+  vocabBase: string;
 }
 
 export type Visibility = "public" | "restricted" | "hidden";

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -14,6 +14,22 @@ import type {
   LinkedDataEnhancement,
   Reference,
 } from "@/types/models";
+import type { SearchParams } from "@/services/searchParams";
+
+/** SearchParams with all-undefined filters and no facets — override per test. */
+export function makeSearchParams(
+  overrides: Partial<SearchParams> = {},
+): SearchParams {
+  return {
+    q: "",
+    page: 1,
+    startYear: undefined,
+    endYear: undefined,
+    sort: undefined,
+    searchFacets: [],
+    ...overrides,
+  };
+}
 
 /**
  * Minimal FindingData with all three slots populated and IDs that match.

--- a/tests/hooks/useSearch.test.tsx
+++ b/tests/hooks/useSearch.test.tsx
@@ -246,4 +246,76 @@ describe("useSearch", () => {
     expect(typeof result.current.retry).toBe("function");
     expect(mockSearch).not.toHaveBeenCalled();
   });
+
+  test("expands compact URIs and passes joined wire query when facets present", async () => {
+    mockSearch.mockResolvedValue(makeResult(1));
+    const params: SearchParams = {
+      ...baseParams,
+      searchFacets: ['linked_data_concepts:"EducationLevelScheme/C00002"'],
+    };
+    renderHook(() => useSearch(params), {
+      wrapper: withCommunityPath("/esea"),
+    });
+    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
+    expect(mockSearch).toHaveBeenCalledWith(
+      '(phonics) AND (linked_data_concepts:"https://vocab.esea.education/EducationLevelScheme/C00002")',
+      expect.objectContaining({
+        annotation: ["domain-inclusion/jacobs-education"],
+      }),
+    );
+  });
+
+  test("passes '* AND (expanded facet)' when q is empty and facets present", async () => {
+    mockSearch.mockResolvedValue(makeResult(1));
+    const params: SearchParams = {
+      ...baseParams, q: "",
+      searchFacets: ['linked_data_concepts:"EducationLevelScheme/C00002"'],
+    };
+    renderHook(() => useSearch(params), {
+      wrapper: withCommunityPath("/esea"),
+    });
+    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
+    expect(mockSearch).toHaveBeenCalledWith(
+      '* AND (linked_data_concepts:"https://vocab.esea.education/EducationLevelScheme/C00002")',
+      expect.anything(),
+    );
+  });
+
+  test("refetches when searchFacets change (cache key includes facets)", async () => {
+    mockSearch.mockResolvedValue(makeResult(1));
+    const { rerender } = renderHook(
+      ({ p }) => useSearch(p),
+      {
+        wrapper: withCommunityPath("/esea"),
+        initialProps: { p: baseParams },
+      },
+    );
+    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
+
+    rerender({ p: { ...baseParams, searchFacets: ['linked_data_concepts:"EducationLevelScheme/C00002"'] } });
+    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(2));
+
+    rerender({ p: { ...baseParams, searchFacets: ['linked_data_concepts:"EducationLevelScheme/C00003"'] } });
+    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(3));
+
+    // No refetch when facets array is structurally identical.
+    rerender({ p: { ...baseParams, searchFacets: ['linked_data_concepts:"EducationLevelScheme/C00003"'] } });
+    expect(mockSearch).toHaveBeenCalledTimes(3);
+  });
+
+  test("cache key is order-sensitive for facets", async () => {
+    mockSearch.mockResolvedValue(makeResult(1));
+    const facetsA = ['linked_data_concepts:"x"', 'linked_data_concepts:"y"'];
+    const facetsB = ['linked_data_concepts:"y"', 'linked_data_concepts:"x"'];
+    const { rerender } = renderHook(
+      ({ p }) => useSearch(p),
+      {
+        wrapper: withCommunityPath("/esea"),
+        initialProps: { p: { ...baseParams, searchFacets: facetsA } },
+      },
+    );
+    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
+    rerender({ p: { ...baseParams, searchFacets: facetsB } });
+    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(2));
+  });
 });

--- a/tests/hooks/useSearch.test.tsx
+++ b/tests/hooks/useSearch.test.tsx
@@ -4,7 +4,7 @@ import type { ComponentChildren } from "preact";
 import { useSearch } from "@/hooks/useSearch";
 import { CommunityProvider } from "@/community/CommunityContext";
 import type { SearchResult } from "@/types/models";
-import type { SearchParams } from "@/services/searchParams";
+import { makeSearchParams } from "../fixtures";
 
 vi.mock("@/services/apiClient", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/services/apiClient")>();
@@ -14,7 +14,7 @@ vi.mock("@/services/apiClient", async (importOriginal) => {
 import { searchReferences } from "@/services/apiClient";
 const mockSearch = vi.mocked(searchReferences);
 
-const baseParams: SearchParams = { q: "phonics", page: 1, startYear: undefined, endYear: undefined, sort: undefined, searchFacets: [] };
+const baseParams = makeSearchParams({ q: "phonics" });
 
 // Drive the real CommunityProvider through the URL the way the runtime does.
 function withCommunityPath(path: string) {
@@ -251,10 +251,10 @@ describe("useSearch", () => {
   // the wire query — exact join/precedence format owned by searchParams unit tests.
   test("expands compact facet URIs via community.vocabBase when calling searchReferences", async () => {
     mockSearch.mockResolvedValue(makeResult(1));
-    const params: SearchParams = {
-      ...baseParams,
+    const params = makeSearchParams({
+      q: "phonics",
       searchFacets: ['linked_data_concepts:"EducationLevelScheme/C00002"'],
-    };
+    });
     renderHook(() => useSearch(params), {
       wrapper: withCommunityPath("/esea"),
     });
@@ -264,6 +264,24 @@ describe("useSearch", () => {
       expect.objectContaining({
         annotation: ["domain-inclusion/jacobs-education"],
       }),
+    );
+  });
+
+  // Pins the composition for empty q + facets: useSearch must pass the
+  // faceted wire query (not undefined) so the backend receives the filter
+  // instead of dropping to browse mode.
+  test("empty q + facets calls searchReferences with the faceted wire query (not undefined)", async () => {
+    mockSearch.mockResolvedValue(makeResult(1));
+    const params = makeSearchParams({
+      searchFacets: ['linked_data_concepts:"EducationLevelScheme/C00002"'],
+    });
+    renderHook(() => useSearch(params), {
+      wrapper: withCommunityPath("/esea"),
+    });
+    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
+    expect(mockSearch).toHaveBeenCalledWith(
+      expect.stringContaining("https://vocab.esea.education/EducationLevelScheme/C00002"),
+      expect.anything(),
     );
   });
 

--- a/tests/hooks/useSearch.test.tsx
+++ b/tests/hooks/useSearch.test.tsx
@@ -247,7 +247,9 @@ describe("useSearch", () => {
     expect(mockSearch).not.toHaveBeenCalled();
   });
 
-  test("expands compact URIs and passes joined wire query when facets present", async () => {
+  // Witnesses that facets are expanded via community.vocabBase and threaded into
+  // the wire query — exact join/precedence format owned by searchParams unit tests.
+  test("expands compact facet URIs via community.vocabBase when calling searchReferences", async () => {
     mockSearch.mockResolvedValue(makeResult(1));
     const params: SearchParams = {
       ...baseParams,
@@ -258,30 +260,14 @@ describe("useSearch", () => {
     });
     await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
     expect(mockSearch).toHaveBeenCalledWith(
-      '(phonics) AND (linked_data_concepts:"https://vocab.esea.education/EducationLevelScheme/C00002")',
+      expect.stringContaining("https://vocab.esea.education/EducationLevelScheme/C00002"),
       expect.objectContaining({
         annotation: ["domain-inclusion/jacobs-education"],
       }),
     );
   });
 
-  test("passes '* AND (expanded facet)' when q is empty and facets present", async () => {
-    mockSearch.mockResolvedValue(makeResult(1));
-    const params: SearchParams = {
-      ...baseParams, q: "",
-      searchFacets: ['linked_data_concepts:"EducationLevelScheme/C00002"'],
-    };
-    renderHook(() => useSearch(params), {
-      wrapper: withCommunityPath("/esea"),
-    });
-    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
-    expect(mockSearch).toHaveBeenCalledWith(
-      '* AND (linked_data_concepts:"https://vocab.esea.education/EducationLevelScheme/C00002")',
-      expect.anything(),
-    );
-  });
-
-  test("refetches when searchFacets change (cache key includes facets)", async () => {
+  test("refetches on facet change; not on structurally-identical rerender", async () => {
     mockSearch.mockResolvedValue(makeResult(1));
     const { rerender } = renderHook(
       ({ p }) => useSearch(p),
@@ -298,8 +284,10 @@ describe("useSearch", () => {
     rerender({ p: { ...baseParams, searchFacets: ['linked_data_concepts:"EducationLevelScheme/C00003"'] } });
     await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(3));
 
-    // No refetch when facets array is structurally identical.
+    // Flush a tick so any async effect a regression might schedule has a chance
+    // to fire before we assert no extra call.
     rerender({ p: { ...baseParams, searchFacets: ['linked_data_concepts:"EducationLevelScheme/C00003"'] } });
+    await act(async () => {});
     expect(mockSearch).toHaveBeenCalledTimes(3);
   });
 

--- a/tests/hooks/useSearch.test.tsx
+++ b/tests/hooks/useSearch.test.tsx
@@ -14,7 +14,7 @@ vi.mock("@/services/apiClient", async (importOriginal) => {
 import { searchReferences } from "@/services/apiClient";
 const mockSearch = vi.mocked(searchReferences);
 
-const baseParams: SearchParams = { q: "phonics", page: 1, startYear: undefined, endYear: undefined, sort: undefined };
+const baseParams: SearchParams = { q: "phonics", page: 1, startYear: undefined, endYear: undefined, sort: undefined, searchFacets: [] };
 
 // Drive the real CommunityProvider through the URL the way the runtime does.
 function withCommunityPath(path: string) {

--- a/tests/pages/SearchPage.test.tsx
+++ b/tests/pages/SearchPage.test.tsx
@@ -545,8 +545,10 @@ describe("SearchPage", () => {
 
       fireEvent.click(screen.getByRole("button", { name: /export to excel/i }));
       await waitFor(() => expect(mockRequestExport).toHaveBeenCalledTimes(1));
+      // Page-layer integration witness: community.vocabBase reaches the call site.
+      // Exact join/precedence is owned by toExportSearchQuery unit tests.
       expect(mockRequestExport).toHaveBeenCalledWith(
-        '(phonics) AND (linked_data_concepts:"https://vocab.esea.education/EducationLevelScheme/C00002")',
+        expect.stringContaining("https://vocab.esea.education/EducationLevelScheme/C00002"),
         {
           startYear: undefined,
           endYear: undefined,

--- a/tests/pages/SearchPage.test.tsx
+++ b/tests/pages/SearchPage.test.tsx
@@ -348,6 +348,21 @@ describe("SearchPage", () => {
     pushSpy.mockRestore();
   });
 
+  test("renders summary line when only facets are set (no q, no years)", async () => {
+    // Issue #62 regression: a facet-only URL must trigger showSummary/showMetaBar,
+    // otherwise filtered results render under the browse-mode hero with no count.
+    // Asserts via class scope because the facet-only summary text has no q/year
+    // discriminator and the count + " results" text live in sibling elements.
+    history.replaceState(null, "", "/esea?q=%2A+AND+%28linked_data_concepts%3A%22EducationLevelScheme%2FC00002%22%29");
+    mockBoth({ results: makeResult(7, ["r1"]) });
+    const { container } = renderSearchPage();
+    await waitFor(() => {
+      const summary = container.querySelector(".search-results__meta-summary");
+      expect(summary).toBeInTheDocument();
+      expect(summary).toHaveTextContent(/7\s*results/);
+    });
+  });
+
   describe("export button", () => {
     test("enabled in browse mode; click POSTs with q=* and the community annotation", async () => {
       mockBoth({ results: makeResult(5721, ["r1"]) });
@@ -510,6 +525,33 @@ describe("SearchPage", () => {
         expect(
           screen.getByRole("button", { name: /preparing/i }),
         ).toBeInTheDocument(),
+      );
+    });
+
+    test("facet URL → Export sends fully-qualified URI to requestSearchExport", async () => {
+      // SearchPage-layer integration: catches misthreaded community.vocabBase
+      // or stale params at the call site, which the unit tests on
+      // toExportSearchQuery in isolation cannot.
+      history.replaceState(
+        null,
+        "",
+        "/esea?q=%28phonics%29+AND+%28linked_data_concepts%3A%22EducationLevelScheme%2FC00002%22%29",
+      );
+      mockBoth({ results: makeResult(7, ["r1"]) });
+      mockRequestExport.mockResolvedValue({ id: "job-facet", status: "pending", truncated: false });
+      mockGetExport.mockResolvedValue({ id: "job-facet", status: "pending", truncated: false });
+      renderSearchPage();
+      await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
+
+      fireEvent.click(screen.getByRole("button", { name: /export to excel/i }));
+      await waitFor(() => expect(mockRequestExport).toHaveBeenCalledTimes(1));
+      expect(mockRequestExport).toHaveBeenCalledWith(
+        '(phonics) AND (linked_data_concepts:"https://vocab.esea.education/EducationLevelScheme/C00002")',
+        {
+          startYear: undefined,
+          endYear: undefined,
+          annotation: ["domain-inclusion/jacobs-education"],
+        },
       );
     });
   });

--- a/tests/pages/SearchPage.test.tsx
+++ b/tests/pages/SearchPage.test.tsx
@@ -363,6 +363,24 @@ describe("SearchPage", () => {
     });
   });
 
+  test("renders meta bar in loading state when only facets are set", async () => {
+    // The summary-line test mocks resolved results, which satisfies showMetaBar
+    // via results.results !== null regardless of the facets gate. This test
+    // pins the harder case: the facets gate alone must fire showMetaBar while
+    // the fetch is still in flight, otherwise a facet URL loads under the
+    // browse-mode hero with no indication that a filter is active.
+    history.replaceState(null, "", "/esea?q=%2A+AND+%28linked_data_concepts%3A%22EducationLevelScheme%2FC00002%22%29");
+    mockSearch.mockImplementation((q) => {
+      if (q === undefined) return Promise.resolve(makeResult(5721, ["corpus-ref"]));
+      return new Promise(() => {}); // never resolves
+    });
+    const { container } = renderSearchPage();
+    await waitFor(() => {
+      expect(container.querySelector(".search-results__meta")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/searching/i)).toBeInTheDocument();
+  });
+
   describe("export button", () => {
     test("enabled in browse mode; click POSTs with q=* and the community annotation", async () => {
       mockBoth({ results: makeResult(5721, ["r1"]) });

--- a/tests/services/communities.test.ts
+++ b/tests/services/communities.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, test, expect } from "vitest";
+import { findCommunity } from "@/services/communities";
+
+const CONTEXT_FIXTURE_PATH = resolve(
+  __dirname,
+  "./export/fixtures/context.jsonld",
+);
+
+describe("Community.vocabBase drift guard", () => {
+  // Compact-URI expansion at the search/export boundary relies on
+  // Community.vocabBase matching the JSON-LD @context prefix served by the
+  // backend. If they drift, expanded URIs silently target the wrong vocab.
+  test("esea Community.vocabBase agrees with the JSON-LD context fixture's `esea` prefix", () => {
+    const base = findCommunity("esea")!.vocabBase;
+    const ctx = JSON.parse(readFileSync(CONTEXT_FIXTURE_PATH, "utf-8")) as {
+      "@context": Record<string, string>;
+    };
+    expect(ctx["@context"].esea).toBe(base);
+  });
+});

--- a/tests/services/searchParams.test.ts
+++ b/tests/services/searchParams.test.ts
@@ -266,20 +266,13 @@ describe("toQueryString", () => {
     expect(canonical).toBe("q=hello");
   });
 
-  test("no facets → q is unchanged (back-compat)", () => {
-    const p: SearchParams = {
-      q: "phonics", page: 1, startYear: undefined, endYear: undefined, sort: undefined,
-      searchFacets: [],
-    };
-    expect(toQueryString(p)).toBe("q=phonics");
-  });
-
-  test("empty q + one facet → '* AND (facet)' URL-encoded in q=", () => {
+  test("empty q + one facet → decoded q is '* AND (facet)'", () => {
     const p: SearchParams = {
       q: "", page: 1, startYear: undefined, endYear: undefined, sort: undefined,
       searchFacets: ['linked_data_concepts:"x"'],
     };
-    expect(toQueryString(p)).toBe('q=*+AND+%28linked_data_concepts%3A%22x%22%29');
+    const q = new URLSearchParams(toQueryString(p)).get("q");
+    expect(q).toBe('* AND (linked_data_concepts:"x")');
   });
 
   test("non-empty q + facets → '(base) AND (f1) AND (f2)'", () => {
@@ -328,17 +321,7 @@ describe("buildSearchUrl", () => {
 describe("buildFacetedQuery", () => {
   test.each([
     {
-      label: "no facets trims q",
-      q: "  phonics  ", facets: [],
-      expected: "phonics",
-    },
-    {
-      label: "no facets, empty q → empty",
-      q: "", facets: [],
-      expected: "",
-    },
-    {
-      label: "no facets, whitespace q → empty",
+      label: "no facets, whitespace q → empty (trim + collapse)",
       q: "   ", facets: [],
       expected: "",
     },
@@ -385,11 +368,6 @@ describe("expandFacets / compactFacets (inverse boundary transforms)", () => {
   });
 
   test.each([
-    {
-      label: "expand: empty array",
-      input: [],
-      expanded: [],
-    },
     {
       label: "expand: single compact URI",
       input: ['linked_data_concepts:"EducationLevelScheme/C00002"'],

--- a/tests/services/searchParams.test.ts
+++ b/tests/services/searchParams.test.ts
@@ -9,6 +9,7 @@ import {
   buildFacetedQuery,
   expandFacets,
   compactFacets,
+  toExportSearchQuery,
   type SearchParams,
 } from "@/services/searchParams";
 
@@ -467,5 +468,51 @@ describe("expandFacets / compactFacets (inverse boundary transforms)", () => {
   test("round-trip: compact(expand(x)) = x", () => {
     const compact = ['linked_data_concepts:"EducationLevelScheme/C00002"'];
     expect(compactFacets(expandFacets(compact, base), base)).toEqual(compact);
+  });
+});
+
+describe("toExportSearchQuery with facets", () => {
+  const base = { page: 1, startYear: undefined, endYear: undefined, sort: undefined };
+  const vocabBase = findCommunity("esea")!.vocabBase;
+
+  test("no facets, non-empty q → existing behaviour preserved", () => {
+    const p: SearchParams = { ...base, q: "phonics", searchFacets: [] };
+    expect(toExportSearchQuery(p, ["dom-x"], vocabBase).query).toBe("phonics");
+  });
+
+  test("no facets, empty q → '*' substitution preserved", () => {
+    const p: SearchParams = { ...base, q: "", searchFacets: [] };
+    expect(toExportSearchQuery(p, ["dom-x"], vocabBase).query).toBe("*");
+  });
+
+  test("facets present, non-empty q → compact URIs expanded to full in wire form", () => {
+    const p: SearchParams = {
+      ...base, q: "phonics",
+      searchFacets: ['linked_data_concepts:"EducationLevelScheme/C00002"'],
+    };
+    expect(toExportSearchQuery(p, ["dom-x"], vocabBase).query)
+      .toBe('(phonics) AND (linked_data_concepts:"https://vocab.esea.education/EducationLevelScheme/C00002")');
+  });
+
+  test("facets present, empty q → '* AND (expanded facet)'", () => {
+    const p: SearchParams = {
+      ...base, q: "",
+      searchFacets: ['linked_data_concepts:"EducationLevelScheme/C00002"'],
+    };
+    expect(toExportSearchQuery(p, ["dom-x"], vocabBase).query)
+      .toBe('* AND (linked_data_concepts:"https://vocab.esea.education/EducationLevelScheme/C00002")');
+  });
+
+  test("filters (annotation, years, sort) unaffected by facets", () => {
+    const p: SearchParams = {
+      q: "phonics", page: 1, startYear: 2010, endYear: 2024, sort: "newest",
+      searchFacets: ['linked_data_concepts:"EducationLevelScheme/C00002"'],
+    };
+    expect(toExportSearchQuery(p, ["dom-x"], vocabBase).filters).toEqual({
+      startYear: 2010,
+      endYear: 2024,
+      annotation: ["dom-x"],
+      sort: ["-publication_year"],
+    });
   });
 });

--- a/tests/services/searchParams.test.ts
+++ b/tests/services/searchParams.test.ts
@@ -1,5 +1,3 @@
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { describe, test, expect } from "vitest";
 import { findCommunity } from "@/services/communities";
 import {
@@ -12,11 +10,6 @@ import {
   toExportSearchQuery,
   type SearchParams,
 } from "@/services/searchParams";
-
-const CONTEXT_FIXTURE_PATH = resolve(
-  __dirname,
-  "../services/export/fixtures/context.jsonld",
-);
 
 describe("parseSearchParams", () => {
   test("empty search → defaults", () => {
@@ -359,13 +352,6 @@ describe("buildFacetedQuery", () => {
 
 describe("expandFacets / compactFacets (inverse boundary transforms)", () => {
   const base = findCommunity("esea")!.vocabBase;
-
-  test("esea Community.vocabBase agrees with the JSON-LD context fixture's `esea` prefix", () => {
-    const ctx = JSON.parse(readFileSync(CONTEXT_FIXTURE_PATH, "utf-8")) as {
-      "@context": Record<string, string>;
-    };
-    expect(ctx["@context"].esea).toBe(base);
-  });
 
   test.each([
     {

--- a/tests/services/searchParams.test.ts
+++ b/tests/services/searchParams.test.ts
@@ -3,6 +3,7 @@ import {
   parseSearchParams,
   toQueryString,
   buildSearchUrl,
+  buildFacetedQuery,
   type SearchParams,
 } from "@/services/searchParams";
 
@@ -155,5 +156,54 @@ describe("buildSearchUrl", () => {
   test("with params → slug + querystring", () => {
     const p: SearchParams = { q: "phonics", page: 2, startYear: undefined, endYear: undefined, sort: undefined };
     expect(buildSearchUrl("esea", p)).toBe("/esea?q=phonics&page=2");
+  });
+});
+
+describe("buildFacetedQuery", () => {
+  test.each([
+    {
+      label: "no facets trims q",
+      q: "  phonics  ", facets: [],
+      expected: "phonics",
+    },
+    {
+      label: "no facets, empty q → empty",
+      q: "", facets: [],
+      expected: "",
+    },
+    {
+      label: "no facets, whitespace q → empty",
+      q: "   ", facets: [],
+      expected: "",
+    },
+    {
+      label: "empty q + one facet → * AND (facet)",
+      q: "", facets: ['linked_data_concepts:"x"'],
+      expected: '* AND (linked_data_concepts:"x")',
+    },
+    {
+      label: "empty q + multiple facets",
+      q: "", facets: ['linked_data_concepts:"x"', 'linked_data_concepts:"y"'],
+      expected: '* AND (linked_data_concepts:"x") AND (linked_data_concepts:"y")',
+    },
+    {
+      label: "non-empty q wraps base",
+      q: "phonics", facets: ['linked_data_concepts:"x"'],
+      expected: '(phonics) AND (linked_data_concepts:"x")',
+    },
+    // Without the wrap, `phonics OR reading AND (f)` binds as
+    // `phonics OR (reading AND (f))` — wrong semantics.
+    {
+      label: "boolean base is wrapped (precedence)",
+      q: "phonics OR reading", facets: ['linked_data_concepts:"x"'],
+      expected: '(phonics OR reading) AND (linked_data_concepts:"x")',
+    },
+    {
+      label: "facet with OR clause passes through verbatim",
+      q: "phonics", facets: ['linked_data_concepts:"x" OR linked_data_concepts:"y"'],
+      expected: '(phonics) AND (linked_data_concepts:"x" OR linked_data_concepts:"y")',
+    },
+  ])("$label", ({ q, facets, expected }) => {
+    expect(buildFacetedQuery(q, facets)).toBe(expected);
   });
 });

--- a/tests/services/searchParams.test.ts
+++ b/tests/services/searchParams.test.ts
@@ -25,6 +25,7 @@ describe("parseSearchParams", () => {
       startYear: undefined,
       endYear: undefined,
       sort: undefined,
+      searchFacets: [],
     });
   });
 
@@ -36,6 +37,7 @@ describe("parseSearchParams", () => {
       startYear: 2010,
       endYear: 2024,
       sort: "newest",
+      searchFacets: [],
     });
   });
 
@@ -118,27 +120,27 @@ describe("parseSearchParams", () => {
 
 describe("toQueryString", () => {
   test("omits defaults", () => {
-    const p: SearchParams = { q: "", page: 1, startYear: undefined, endYear: undefined, sort: undefined };
+    const p: SearchParams = { q: "", page: 1, startYear: undefined, endYear: undefined, sort: undefined, searchFacets: [] };
     expect(toQueryString(p)).toBe("");
   });
 
   test("fixed key order: q, start_year, end_year, sort, page", () => {
-    const p: SearchParams = { q: "phonics", page: 3, startYear: 2010, endYear: 2024, sort: "newest" };
+    const p: SearchParams = { q: "phonics", page: 3, startYear: 2010, endYear: 2024, sort: "newest", searchFacets: [] };
     expect(toQueryString(p)).toBe("q=phonics&start_year=2010&end_year=2024&sort=newest&page=3");
   });
 
   test("page=1 (default) is dropped from output, q is kept", () => {
-    const p: SearchParams = { q: "phonics", page: 1, startYear: undefined, endYear: undefined, sort: undefined };
+    const p: SearchParams = { q: "phonics", page: 1, startYear: undefined, endYear: undefined, sort: undefined, searchFacets: [] };
     expect(toQueryString(p)).toBe("q=phonics");
   });
 
   test("URL-encodes q", () => {
-    const p: SearchParams = { q: "a b&c", page: 1, startYear: undefined, endYear: undefined, sort: undefined };
+    const p: SearchParams = { q: "a b&c", page: 1, startYear: undefined, endYear: undefined, sort: undefined, searchFacets: [] };
     expect(toQueryString(p)).toBe("q=a+b%26c");
   });
 
   test("sort omitted when undefined (relevance default)", () => {
-    const p: SearchParams = { q: "phonics", page: 1, startYear: undefined, endYear: undefined, sort: undefined };
+    const p: SearchParams = { q: "phonics", page: 1, startYear: undefined, endYear: undefined, sort: undefined, searchFacets: [] };
     expect(toQueryString(p)).toBe("q=phonics");
   });
 
@@ -146,7 +148,7 @@ describe("toQueryString", () => {
     { sort: "newest" as const },
     { sort: "oldest" as const },
   ])("sort=$sort is emitted", ({ sort }) => {
-    const p: SearchParams = { q: "", page: 1, startYear: undefined, endYear: undefined, sort };
+    const p: SearchParams = { q: "", page: 1, startYear: undefined, endYear: undefined, sort, searchFacets: [] };
     expect(toQueryString(p)).toBe(`sort=${sort}`);
   });
 
@@ -159,12 +161,12 @@ describe("toQueryString", () => {
 
 describe("buildSearchUrl", () => {
   test("empty params → bare slug path", () => {
-    const p: SearchParams = { q: "", page: 1, startYear: undefined, endYear: undefined, sort: undefined };
+    const p: SearchParams = { q: "", page: 1, startYear: undefined, endYear: undefined, sort: undefined, searchFacets: [] };
     expect(buildSearchUrl("esea", p)).toBe("/esea");
   });
 
   test("with params → slug + querystring", () => {
-    const p: SearchParams = { q: "phonics", page: 2, startYear: undefined, endYear: undefined, sort: undefined };
+    const p: SearchParams = { q: "phonics", page: 2, startYear: undefined, endYear: undefined, sort: undefined, searchFacets: [] };
     expect(buildSearchUrl("esea", p)).toBe("/esea?q=phonics&page=2");
   });
 });

--- a/tests/services/searchParams.test.ts
+++ b/tests/services/searchParams.test.ts
@@ -1,11 +1,21 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, test, expect } from "vitest";
+import { findCommunity } from "@/services/communities";
 import {
   parseSearchParams,
   toQueryString,
   buildSearchUrl,
   buildFacetedQuery,
+  expandFacets,
+  compactFacets,
   type SearchParams,
 } from "@/services/searchParams";
+
+const CONTEXT_FIXTURE_PATH = resolve(
+  __dirname,
+  "../services/export/fixtures/context.jsonld",
+);
 
 describe("parseSearchParams", () => {
   test("empty search → defaults", () => {
@@ -205,5 +215,102 @@ describe("buildFacetedQuery", () => {
     },
   ])("$label", ({ q, facets, expected }) => {
     expect(buildFacetedQuery(q, facets)).toBe(expected);
+  });
+});
+
+describe("expandFacets / compactFacets (inverse boundary transforms)", () => {
+  const base = findCommunity("esea")!.vocabBase;
+
+  test("esea Community.vocabBase agrees with the JSON-LD context fixture's `esea` prefix", () => {
+    const ctx = JSON.parse(readFileSync(CONTEXT_FIXTURE_PATH, "utf-8")) as {
+      "@context": Record<string, string>;
+    };
+    expect(ctx["@context"].esea).toBe(base);
+  });
+
+  test.each([
+    {
+      label: "expand: empty array",
+      input: [],
+      expanded: [],
+    },
+    {
+      label: "expand: single compact URI",
+      input: ['linked_data_concepts:"EducationLevelScheme/C00002"'],
+      expanded: ['linked_data_concepts:"https://vocab.esea.education/EducationLevelScheme/C00002"'],
+    },
+    {
+      label: "expand: OR-joined URIs in one facet",
+      input: [
+        'linked_data_concepts:"EducationLevelScheme/C00002" OR linked_data_concepts:"EducationLevelScheme/C00003"',
+      ],
+      expanded: [
+        'linked_data_concepts:"https://vocab.esea.education/EducationLevelScheme/C00002" OR linked_data_concepts:"https://vocab.esea.education/EducationLevelScheme/C00003"',
+      ],
+    },
+    {
+      label: "expand: multiple facets expand independently",
+      input: [
+        'linked_data_concepts:"EducationLevelScheme/C00002"',
+        'linked_data_concepts:"OutcomeScheme/C00123"',
+      ],
+      expanded: [
+        'linked_data_concepts:"https://vocab.esea.education/EducationLevelScheme/C00002"',
+        'linked_data_concepts:"https://vocab.esea.education/OutcomeScheme/C00123"',
+      ],
+    },
+  ])("$label", ({ input, expanded }) => {
+    expect(expandFacets(input, base)).toEqual(expanded);
+  });
+
+  test.each([
+    {
+      label: "compact: single full URI",
+      input: ['linked_data_concepts:"https://vocab.esea.education/EducationLevelScheme/C00002"'],
+      compact: ['linked_data_concepts:"EducationLevelScheme/C00002"'],
+    },
+    {
+      label: "compact: OR-joined full URIs",
+      input: [
+        'linked_data_concepts:"https://vocab.esea.education/EducationLevelScheme/C00002" OR linked_data_concepts:"https://vocab.esea.education/OutcomeScheme/C00123"',
+      ],
+      compact: [
+        'linked_data_concepts:"EducationLevelScheme/C00002" OR linked_data_concepts:"OutcomeScheme/C00123"',
+      ],
+    },
+    {
+      label: "compact: already-compact passes through",
+      input: ['linked_data_concepts:"EducationLevelScheme/C00002"'],
+      compact: ['linked_data_concepts:"EducationLevelScheme/C00002"'],
+    },
+    {
+      label: "compact: URI from foreign vocab is left alone",
+      input: ['linked_data_concepts:"https://other.example.org/Foo/Bar"'],
+      compact: ['linked_data_concepts:"https://other.example.org/Foo/Bar"'],
+    },
+  ])("$label", ({ input, compact }) => {
+    expect(compactFacets(input, base)).toEqual(compact);
+  });
+
+  test("expand is defensive: already-expanded URI passes through", () => {
+    expect(expandFacets(
+      ['linked_data_concepts:"https://vocab.esea.education/EducationLevelScheme/C00002"'],
+      base,
+    )).toEqual([
+      'linked_data_concepts:"https://vocab.esea.education/EducationLevelScheme/C00002"',
+    ]);
+  });
+
+  test("mixed compact + expanded in one facet → expand normalises all", () => {
+    expect(expandFacets([
+      'linked_data_concepts:"EducationLevelScheme/C00002" OR linked_data_concepts:"https://vocab.esea.education/EducationLevelScheme/C00003"',
+    ], base)).toEqual([
+      'linked_data_concepts:"https://vocab.esea.education/EducationLevelScheme/C00002" OR linked_data_concepts:"https://vocab.esea.education/EducationLevelScheme/C00003"',
+    ]);
+  });
+
+  test("round-trip: compact(expand(x)) = x", () => {
+    const compact = ['linked_data_concepts:"EducationLevelScheme/C00002"'];
+    expect(compactFacets(expandFacets(compact, base), base)).toEqual(compact);
   });
 });

--- a/tests/services/searchParams.test.ts
+++ b/tests/services/searchParams.test.ts
@@ -264,6 +264,52 @@ describe("toQueryString", () => {
     const canonical = toQueryString(parseSearchParams(raw));
     expect(canonical).toBe("q=hello");
   });
+
+  test("no facets → q is unchanged (back-compat)", () => {
+    const p: SearchParams = {
+      q: "phonics", page: 1, startYear: undefined, endYear: undefined, sort: undefined,
+      searchFacets: [],
+    };
+    expect(toQueryString(p)).toBe("q=phonics");
+  });
+
+  test("empty q + one facet → '* AND (facet)' URL-encoded in q=", () => {
+    const p: SearchParams = {
+      q: "", page: 1, startYear: undefined, endYear: undefined, sort: undefined,
+      searchFacets: ['linked_data_concepts:"x"'],
+    };
+    expect(toQueryString(p)).toBe('q=*+AND+%28linked_data_concepts%3A%22x%22%29');
+  });
+
+  test("non-empty q + facets → '(base) AND (f1) AND (f2)'", () => {
+    const p: SearchParams = {
+      q: "phonics", page: 1, startYear: undefined, endYear: undefined, sort: undefined,
+      searchFacets: [
+        'linked_data_concepts:"x"',
+        'linked_data_concepts:"y"',
+      ],
+    };
+    const decoded = decodeURIComponent(toQueryString(p).replace(/\+/g, " "));
+    expect(decoded).toBe('q=(phonics) AND (linked_data_concepts:"x") AND (linked_data_concepts:"y")');
+  });
+
+  test("round-trip is idempotent: parse → serialise → parse", () => {
+    const url = '?q=(phonics OR reading) AND (linked_data_concepts:"EducationLevelScheme/C00002") AND (linked_data_concepts:"OutcomeScheme/C00123")&page=2';
+    const first = parseSearchParams(url);
+    const serialised = toQueryString(first);
+    const second = parseSearchParams("?" + serialised);
+    expect(second).toEqual(first);
+  });
+
+  test("round-trip from typed state with empty q + facets", () => {
+    const input: SearchParams = {
+      q: "", page: 1, startYear: undefined, endYear: undefined, sort: undefined,
+      searchFacets: ['linked_data_concepts:"x"'],
+    };
+    const serialised = toQueryString(input);
+    const parsed = parseSearchParams("?" + serialised);
+    expect(parsed).toEqual(input);
+  });
 });
 
 describe("buildSearchUrl", () => {

--- a/tests/services/searchParams.test.ts
+++ b/tests/services/searchParams.test.ts
@@ -8,8 +8,8 @@ import {
   expandFacets,
   compactFacets,
   toExportSearchQuery,
-  type SearchParams,
 } from "@/services/searchParams";
+import { makeSearchParams } from "../fixtures";
 
 describe("parseSearchParams", () => {
   test("empty search → defaults", () => {
@@ -221,36 +221,31 @@ describe("parseSearchParams URI compaction", () => {
 
 describe("toQueryString", () => {
   test("omits defaults", () => {
-    const p: SearchParams = { q: "", page: 1, startYear: undefined, endYear: undefined, sort: undefined, searchFacets: [] };
-    expect(toQueryString(p)).toBe("");
+    expect(toQueryString(makeSearchParams())).toBe("");
   });
 
   test("fixed key order: q, start_year, end_year, sort, page", () => {
-    const p: SearchParams = { q: "phonics", page: 3, startYear: 2010, endYear: 2024, sort: "newest", searchFacets: [] };
+    const p = makeSearchParams({ q: "phonics", page: 3, startYear: 2010, endYear: 2024, sort: "newest" });
     expect(toQueryString(p)).toBe("q=phonics&start_year=2010&end_year=2024&sort=newest&page=3");
   });
 
   test("page=1 (default) is dropped from output, q is kept", () => {
-    const p: SearchParams = { q: "phonics", page: 1, startYear: undefined, endYear: undefined, sort: undefined, searchFacets: [] };
-    expect(toQueryString(p)).toBe("q=phonics");
+    expect(toQueryString(makeSearchParams({ q: "phonics" }))).toBe("q=phonics");
   });
 
   test("URL-encodes q", () => {
-    const p: SearchParams = { q: "a b&c", page: 1, startYear: undefined, endYear: undefined, sort: undefined, searchFacets: [] };
-    expect(toQueryString(p)).toBe("q=a+b%26c");
+    expect(toQueryString(makeSearchParams({ q: "a b&c" }))).toBe("q=a+b%26c");
   });
 
   test("sort omitted when undefined (relevance default)", () => {
-    const p: SearchParams = { q: "phonics", page: 1, startYear: undefined, endYear: undefined, sort: undefined, searchFacets: [] };
-    expect(toQueryString(p)).toBe("q=phonics");
+    expect(toQueryString(makeSearchParams({ q: "phonics" }))).toBe("q=phonics");
   });
 
   test.each([
     { sort: "newest" as const },
     { sort: "oldest" as const },
   ])("sort=$sort is emitted", ({ sort }) => {
-    const p: SearchParams = { q: "", page: 1, startYear: undefined, endYear: undefined, sort, searchFacets: [] };
-    expect(toQueryString(p)).toBe(`sort=${sort}`);
+    expect(toQueryString(makeSearchParams({ sort }))).toBe(`sort=${sort}`);
   });
 
   test("round-trip normalization", () => {
@@ -260,27 +255,21 @@ describe("toQueryString", () => {
   });
 
   test("empty q + one facet → decoded q is '* AND (facet)'", () => {
-    const p: SearchParams = {
-      q: "", page: 1, startYear: undefined, endYear: undefined, sort: undefined,
-      searchFacets: ['linked_data_concepts:"x"'],
-    };
+    const p = makeSearchParams({ searchFacets: ['linked_data_concepts:"x"'] });
     const q = new URLSearchParams(toQueryString(p)).get("q");
     expect(q).toBe('* AND (linked_data_concepts:"x")');
   });
 
   test("non-empty q + facets → '(base) AND (f1) AND (f2)'", () => {
-    const p: SearchParams = {
-      q: "phonics", page: 1, startYear: undefined, endYear: undefined, sort: undefined,
-      searchFacets: [
-        'linked_data_concepts:"x"',
-        'linked_data_concepts:"y"',
-      ],
-    };
-    const decoded = decodeURIComponent(toQueryString(p).replace(/\+/g, " "));
-    expect(decoded).toBe('q=(phonics) AND (linked_data_concepts:"x") AND (linked_data_concepts:"y")');
+    const p = makeSearchParams({
+      q: "phonics",
+      searchFacets: ['linked_data_concepts:"x"', 'linked_data_concepts:"y"'],
+    });
+    const q = new URLSearchParams(toQueryString(p)).get("q");
+    expect(q).toBe('(phonics) AND (linked_data_concepts:"x") AND (linked_data_concepts:"y")');
   });
 
-  test("round-trip is idempotent: parse → serialise → parse", () => {
+  test("compact-form facet URL round-trips through parse → serialise → parse", () => {
     const url = '?q=(phonics OR reading) AND (linked_data_concepts:"EducationLevelScheme/C00002") AND (linked_data_concepts:"OutcomeScheme/C00123")&page=2';
     const first = parseSearchParams(url);
     const serialised = toQueryString(first);
@@ -289,25 +278,50 @@ describe("toQueryString", () => {
   });
 
   test("round-trip from typed state with empty q + facets", () => {
-    const input: SearchParams = {
-      q: "", page: 1, startYear: undefined, endYear: undefined, sort: undefined,
+    const input = makeSearchParams({
       searchFacets: ['linked_data_concepts:"x"'],
-    };
+    });
     const serialised = toQueryString(input);
     const parsed = parseSearchParams("?" + serialised);
     expect(parsed).toEqual(input);
+  });
+
+  // Closes the canonicalization path actually used in production: SearchPage
+  // hands parseSearchParams its vocabBase, so a hand-crafted URL with a full
+  // ESEA URI must collapse to compact state, and the next toQueryString must
+  // emit the compact form (full URI must not appear in the URL).
+  test("full ESEA URI in facet URL canonicalizes to compact via vocabBase", () => {
+    const vocabBase = findCommunity("esea")!.vocabBase;
+    const rawFullUriUrl = '?q=phonics AND (linked_data_concepts:"https://vocab.esea.education/EducationLevelScheme/C00002")';
+    const parsed = parseSearchParams(rawFullUriUrl, vocabBase);
+    expect(parsed.searchFacets).toEqual([
+      'linked_data_concepts:"EducationLevelScheme/C00002"',
+    ]);
+    const serialisedQ = new URLSearchParams(toQueryString(parsed)).get("q");
+    expect(serialisedQ).not.toContain("https://");
+    expect(serialisedQ).toContain("EducationLevelScheme/C00002");
+  });
+
+  test("q stays first when facets are combined with start_year/sort/page", () => {
+    const p = makeSearchParams({
+      q: "phonics",
+      page: 3,
+      startYear: 2010,
+      sort: "newest",
+      searchFacets: ['linked_data_concepts:"x"'],
+    });
+    const keyOrder = Array.from(new URLSearchParams(toQueryString(p)).keys());
+    expect(keyOrder).toEqual(["q", "start_year", "sort", "page"]);
   });
 });
 
 describe("buildSearchUrl", () => {
   test("empty params → bare slug path", () => {
-    const p: SearchParams = { q: "", page: 1, startYear: undefined, endYear: undefined, sort: undefined, searchFacets: [] };
-    expect(buildSearchUrl("esea", p)).toBe("/esea");
+    expect(buildSearchUrl("esea", makeSearchParams())).toBe("/esea");
   });
 
   test("with params → slug + querystring", () => {
-    const p: SearchParams = { q: "phonics", page: 2, startYear: undefined, endYear: undefined, sort: undefined, searchFacets: [] };
-    expect(buildSearchUrl("esea", p)).toBe("/esea?q=phonics&page=2");
+    expect(buildSearchUrl("esea", makeSearchParams({ q: "phonics", page: 2 }))).toBe("/esea?q=phonics&page=2");
   });
 });
 
@@ -436,42 +450,42 @@ describe("expandFacets / compactFacets (inverse boundary transforms)", () => {
 });
 
 describe("toExportSearchQuery with facets", () => {
-  const base = { page: 1, startYear: undefined, endYear: undefined, sort: undefined };
   const vocabBase = findCommunity("esea")!.vocabBase;
 
   test("no facets, non-empty q → existing behaviour preserved", () => {
-    const p: SearchParams = { ...base, q: "phonics", searchFacets: [] };
+    const p = makeSearchParams({ q: "phonics" });
     expect(toExportSearchQuery(p, ["dom-x"], vocabBase).query).toBe("phonics");
   });
 
   test("no facets, empty q → '*' substitution preserved", () => {
-    const p: SearchParams = { ...base, q: "", searchFacets: [] };
-    expect(toExportSearchQuery(p, ["dom-x"], vocabBase).query).toBe("*");
+    expect(toExportSearchQuery(makeSearchParams(), ["dom-x"], vocabBase).query).toBe("*");
   });
 
   test("facets present, non-empty q → compact URIs expanded to full in wire form", () => {
-    const p: SearchParams = {
-      ...base, q: "phonics",
+    const p = makeSearchParams({
+      q: "phonics",
       searchFacets: ['linked_data_concepts:"EducationLevelScheme/C00002"'],
-    };
+    });
     expect(toExportSearchQuery(p, ["dom-x"], vocabBase).query)
       .toBe('(phonics) AND (linked_data_concepts:"https://vocab.esea.education/EducationLevelScheme/C00002")');
   });
 
   test("facets present, empty q → '* AND (expanded facet)'", () => {
-    const p: SearchParams = {
-      ...base, q: "",
+    const p = makeSearchParams({
       searchFacets: ['linked_data_concepts:"EducationLevelScheme/C00002"'],
-    };
+    });
     expect(toExportSearchQuery(p, ["dom-x"], vocabBase).query)
       .toBe('* AND (linked_data_concepts:"https://vocab.esea.education/EducationLevelScheme/C00002")');
   });
 
   test("filters (annotation, years, sort) unaffected by facets", () => {
-    const p: SearchParams = {
-      q: "phonics", page: 1, startYear: 2010, endYear: 2024, sort: "newest",
+    const p = makeSearchParams({
+      q: "phonics",
+      startYear: 2010,
+      endYear: 2024,
+      sort: "newest",
       searchFacets: ['linked_data_concepts:"EducationLevelScheme/C00002"'],
-    };
+    });
     expect(toExportSearchQuery(p, ["dom-x"], vocabBase).filters).toEqual({
       startYear: 2010,
       endYear: 2024,

--- a/tests/services/searchParams.test.ts
+++ b/tests/services/searchParams.test.ts
@@ -118,6 +118,113 @@ describe("parseSearchParams", () => {
   });
 });
 
+describe("parseSearchParams facet peel + unwrap", () => {
+  const vocabBase = findCommunity("esea")!.vocabBase;
+
+  test.each([
+    {
+      label: "peels single trailing facet",
+      raw: '?q=phonics AND (linked_data_concepts:"EducationLevelScheme/C00002")',
+      q: "phonics",
+      facets: ['linked_data_concepts:"EducationLevelScheme/C00002"'],
+    },
+    {
+      label: "peels multiple trailing facets in order",
+      raw: '?q=phonics AND (linked_data_concepts:"x") AND (linked_data_concepts:"y")',
+      q: "phonics",
+      facets: ['linked_data_concepts:"x"', 'linked_data_concepts:"y"'],
+    },
+    {
+      label: "peels facet with internal OR",
+      raw: '?q=phonics AND (linked_data_concepts:"x" OR linked_data_concepts:"y")',
+      q: "phonics",
+      facets: ['linked_data_concepts:"x" OR linked_data_concepts:"y"'],
+    },
+    {
+      label: "non-facet trailing AND clause stays in q (no silent drop)",
+      raw: '?q=phonics AND (something_else:"x")',
+      q: 'phonics AND (something_else:"x")',
+      facets: [],
+    },
+    {
+      label: "non-trailing facet-shaped text stays in q",
+      raw: '?q=foo AND (linked_data_concepts:"x") bar',
+      q: 'foo AND (linked_data_concepts:"x") bar',
+      facets: [],
+    },
+    {
+      label: "unwraps lone-paren base after peel",
+      raw: '?q=(phonics) AND (linked_data_concepts:"x")',
+      q: "phonics",
+      facets: ['linked_data_concepts:"x"'],
+    },
+    {
+      label: "unwraps multi-token paren-wrapped base after peel",
+      raw: '?q=(phonics OR reading) AND (linked_data_concepts:"x")',
+      q: "phonics OR reading",
+      facets: ['linked_data_concepts:"x"'],
+    },
+    // Nested-paren base must still unwrap, or parse→serialise adds a layer each cycle.
+    {
+      label: "unwraps nested-paren base (balanced walker)",
+      raw: '?q=(phonics OR (reading)) AND (linked_data_concepts:"x")',
+      q: "phonics OR (reading)",
+      facets: ['linked_data_concepts:"x"'],
+    },
+    {
+      label: "unwraps base with field-scoped subquery",
+      raw: '?q=(title:(phonics OR reading)) AND (linked_data_concepts:"x")',
+      q: "title:(phonics OR reading)",
+      facets: ['linked_data_concepts:"x"'],
+    },
+    // Outer pair isn't balanced — first "(" closes mid-string. Leave untouched.
+    {
+      label: "does NOT unwrap when outer parens are not a balanced pair",
+      raw: '?q=(a) AND (b) AND (linked_data_concepts:"x")',
+      q: "(a) AND (b)",
+      facets: ['linked_data_concepts:"x"'],
+    },
+    {
+      label: "strips lone * sentinel after peel",
+      raw: '?q=* AND (linked_data_concepts:"x")',
+      q: "",
+      facets: ['linked_data_concepts:"x"'],
+    },
+    {
+      label: "literal * with no facets is preserved",
+      raw: "?q=*",
+      q: "*",
+      facets: [],
+    },
+  ])("$label", ({ raw, q, facets }) => {
+    const p = parseSearchParams(raw, vocabBase);
+    expect(p.q).toBe(q);
+    expect(p.searchFacets).toEqual(facets);
+  });
+});
+
+describe("parseSearchParams URI compaction", () => {
+  const vocabBase = findCommunity("esea")!.vocabBase;
+
+  test("hand-crafted full URI in facet tail is compacted on parse", () => {
+    const raw = '?q=phonics AND (linked_data_concepts:"https://vocab.esea.education/EducationLevelScheme/C00002")';
+    const p = parseSearchParams(raw, vocabBase);
+    expect(p.searchFacets).toEqual(['linked_data_concepts:"EducationLevelScheme/C00002"']);
+  });
+
+  test("foreign-vocab full URI is left alone", () => {
+    const raw = '?q=phonics AND (linked_data_concepts:"https://other.example.org/Foo/Bar")';
+    const p = parseSearchParams(raw, vocabBase);
+    expect(p.searchFacets).toEqual(['linked_data_concepts:"https://other.example.org/Foo/Bar"']);
+  });
+
+  test("without vocabBase, full URIs are preserved (back-compat)", () => {
+    const raw = '?q=phonics AND (linked_data_concepts:"https://vocab.esea.education/EducationLevelScheme/C00002")';
+    const p = parseSearchParams(raw);
+    expect(p.searchFacets).toEqual(['linked_data_concepts:"https://vocab.esea.education/EducationLevelScheme/C00002"']);
+  });
+});
+
 describe("toQueryString", () => {
   test("omits defaults", () => {
     const p: SearchParams = { q: "", page: 1, startYear: undefined, endYear: undefined, sort: undefined, searchFacets: [] };


### PR DESCRIPTION
Closes #62.

## Summary

Plumbs `searchFacets: string[]` through `SearchParams`, the URL, `useSearch`, and the export flow. The upcoming FilterDrawer (Issue #67) can now attach `linked_data_concepts:"<URI>"` clauses to live search and export requests. This PR is the data path only; no UI for editing facets.

URIs in typed state and the URL use a compact `Scheme/C-id` form (e.g. `EducationLevelScheme/C00002`). New helpers `expandFacets(facets, vocabBase)` (API boundary) and `compactFacets(facets, vocabBase)` (URL parse) move URIs between compact and fully-qualified form. `vocabBase` lives on `Community` alongside `defaultAnnotations`, with a drift guard asserting the esea community's value matches the JSON-LD context fixture's `esea` prefix.

The wire-format builder `buildFacetedQuery(q, facets)` joins facets as `(base) AND (facet1) AND (facet2)`, with `*` substituted for empty base. Non-empty base is wrapped in parens for boolean-precedence safety; without the wrap, `phonics OR reading AND (facet)` would bind in Lucene as `phonics OR (reading AND (facet))`.

`parseSearchParams` peels strict trailing `\s+AND\s+\(linked_data_concepts:[^)]+\)\s*$` clauses out of `q`, strips a lone `*` sentinel, and unwraps a single-level paren-wrap. Anything outside that strict grammar stays in `q` so user-typed Lucene is never silently dropped. `toQueryString(parseSearchParams(url))` is idempotent.

`SearchPage`'s `showMetaBar` and `showSummary` gates now include facets so a facet-only URL renders the meta region (regression-tested at unit and page layers, including the loading state).

`useSearchDraft` is unchanged; facets are not edited from the search bar.

## Stopgap note

destiny-repository#695 proposes a structured `?concept=URI_A&concept=URI_B` API parameter that would replace this approach. The team deferred #695 on 2026-05-21. When it lands, expect to remove the `parseSearchParams` peel/unwrap/compact logic, `buildFacetedQuery`, `expandFacets`, `compactFacets`, and the URL grammar shipped here.

URL verbosity (each selected concept emits a `linked_data_concepts:"..."` clause with field-name repetition) is the known cost. At 20 selections across 5 schemes the URL reaches roughly 1,500 to 2,000 encoded characters. Within browser limits, but visually rough; part of why #695 is the proper long-term shape.

## Migration note

The peel regex matches any trailing `\s+AND\s+\(linked_data_concepts:[^)]+\)\s*$`. Shareable URLs from before this PR that contain hand-typed `linked_data_concepts:` clauses will be reclassified into `searchFacets` on parse, with compact-looking values expanded via `vocabBase` at the API boundary. This is deliberate: the field's semantics are vocab URIs, so compact-looking literals never match the backend index anyway, and the wire query is preserved either way.

## Validation performed

- Full test suite green: 496 tests across 48 files.
- Typecheck and production build clean.
- Live dev server verified end-to-end against the local destiny-repository docker stack:
  - Compact URI facet URL: `q=phonics` plus one facet returned 63 results; the same facet alone returned 1,854; the GET network request contained the fully-qualified URI `https://vocab.esea.education/EducationLevelScheme/C00002`.
  - Facet-only URL (empty base) showed an empty search input and rendered the meta bar with the summary line.
  - Plain query `q=phonics` returned 105 results unchanged.
  - Browse mode unchanged.
  - Export POST request URL contained the fully-qualified wire query verbatim.

## Follow-ups (out of scope)

- FilterDrawer UI to edit `searchFacets` (Issue #67).
- Migration to destiny-repository#695's structured `?concept=` parameter once that lands backend-side.