### PR TITLE
FilterDrawer basic implementation

### DIFF
--- a/src/components/filters/FilterDrawer.css
+++ b/src/components/filters/FilterDrawer.css
@@ -1,0 +1,115 @@
+.filter-drawer {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+}
+
+.filter-drawer__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(22, 27, 34, 0.4);
+}
+
+.filter-drawer__panel {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(420px, 100vw);
+  background: var(--color-bg-surface);
+  border-left: 1px solid var(--color-border);
+  box-shadow: var(--shadow-lg);
+  display: flex;
+  flex-direction: column;
+}
+
+.filter-drawer__header {
+  padding: var(--spacing-md) var(--spacing-lg);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.filter-drawer__title {
+  margin: 0;
+  font-size: var(--font-size-xl);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.filter-drawer__panel:focus {
+  outline: none;
+}
+
+.filter-drawer__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--spacing-md) var(--spacing-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.filter-drawer__footer {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md) var(--spacing-lg);
+  border-top: 1px solid var(--color-border);
+  background: var(--color-bg-surface);
+}
+
+.filter-drawer__footer-spacer {
+  flex: 1;
+}
+
+.filter-drawer__btn {
+  font-family: var(--font-body);
+  font-size: var(--font-size-small);
+  font-weight: 600;
+  padding: 8px 16px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.filter-drawer__btn:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.filter-drawer__btn--reset {
+  background: none;
+  border: none;
+  color: var(--color-text-secondary);
+  padding: 8px 4px;
+}
+
+.filter-drawer__btn--reset:hover {
+  color: var(--color-text-primary);
+  text-decoration: underline;
+}
+
+.filter-drawer__btn--cancel {
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-primary);
+}
+
+.filter-drawer__btn--cancel:hover {
+  background: var(--color-bg-hover);
+}
+
+.filter-drawer__btn--apply {
+  background: var(--color-accent);
+  color: #fff;
+  border: 1px solid var(--color-accent);
+}
+
+.filter-drawer__btn--apply:hover:not(:disabled) {
+  background: var(--color-accent-hover);
+  border-color: var(--color-accent-hover);
+}
+
+.filter-drawer__btn--apply:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/src/components/filters/FilterDrawer.css
+++ b/src/components/filters/FilterDrawer.css
@@ -1,7 +1,9 @@
 .filter-drawer {
   position: fixed;
   inset: 0;
-  z-index: 100;
+  /* Above AppShell header (100) and FeedbackFAB (200) — a modal must
+     cover everything else on the page. */
+  z-index: 1000;
 }
 
 .filter-drawer__backdrop {

--- a/src/components/filters/FilterDrawer.tsx
+++ b/src/components/filters/FilterDrawer.tsx
@@ -62,17 +62,14 @@ export function FilterDrawer({
   const previousFocusRef = useRef<Element | null>(null);
   const titleId = useId();
 
-  // Reset draft from URL on each open, and capture pre-open focus. Re-runs
-  // when `appliedFacets` identity changes too so reopening after a sibling
-  // navigation (e.g. q changed via the search bar) picks up the new state.
+  // Reset draft from URL on each open, and capture pre-open focus.
   useEffect(() => {
     if (!open) return;
     previousFocusRef.current = document.activeElement;
     setDraft(parseFacets(appliedFacets, schemes));
   }, [open, appliedFacets, schemes]);
 
-  // Lock body scroll while the modal is up; restore the prior overflow
-  // value on close so we don't clobber an ancestor that was managing it.
+  // Lock body scroll while the modal is up;
   useEffect(() => {
     if (!open) return;
     const previous = document.body.style.overflow;
@@ -82,9 +79,8 @@ export function FilterDrawer({
     };
   }, [open]);
 
-  // Focus the dialog panel itself on open (it carries tabindex=-1) so the
-  // first Tab lands on something inside the drawer rather than the page
-  // beneath. Restore focus to wherever it was on close.
+  // Focus the dialog panel itself on open (it carries tabindex=-1)
+  // Restore focus to wherever it was on close.
   useEffect(() => {
     if (!open) return;
     panelRef.current?.focus();
@@ -94,9 +90,7 @@ export function FilterDrawer({
     };
   }, [open]);
 
-  // Escape dismisses the drawer (treated as Cancel). The ticket says users
-  // must use a button, but that wording is mouse-shaped — keyboard users
-  // need a non-mouse exit, and Esc is the universal modal convention.
+  // Escape dismisses the drawer (treated as Cancel).
   useEffect(() => {
     if (!open) return;
     function handleKey(e: KeyboardEvent) {

--- a/src/components/filters/FilterDrawer.tsx
+++ b/src/components/filters/FilterDrawer.tsx
@@ -62,12 +62,13 @@ export function FilterDrawer({
   const previousFocusRef = useRef<Element | null>(null);
   const titleId = useId();
 
-  // Reset draft from URL on each open, and capture pre-open focus.
+  // Reset draft from URL on each FilterDrawer open and capture pre-open focus.
   useEffect(() => {
     if (!open) return;
     previousFocusRef.current = document.activeElement;
     setDraft(parseFacets(appliedFacets, schemes));
-  }, [open, appliedFacets, schemes]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
 
   // Lock body scroll while the modal is up;
   useEffect(() => {

--- a/src/components/filters/FilterDrawer.tsx
+++ b/src/components/filters/FilterDrawer.tsx
@@ -3,6 +3,7 @@ import { FilterCard } from "./FilterCard";
 import { ConceptSchemeFilter } from "./ConceptSchemeFilter";
 import {
   emptyConceptSchemeState,
+  parseFacets,
   summary,
   toSearchFacet,
   type ConceptSchemeFilterState,
@@ -19,10 +20,6 @@ interface FilterDrawerProps {
 }
 
 type Draft = Map<string, ConceptSchemeFilterState>;
-
-function emptyDraft(): Draft {
-  return new Map();
-}
 
 // Serialise the drawer's per-scheme draft back into the wire format expected
 // by SearchParams.searchFacets — one entry per scheme that has at least one
@@ -58,18 +55,21 @@ export function FilterDrawer({
   onApply,
   onCancel,
 }: FilterDrawerProps) {
-  const [draft, setDraft] = useState<Draft>(emptyDraft);
+  const [draft, setDraft] = useState<Draft>(() =>
+    parseFacets(appliedFacets, schemes),
+  );
   const panelRef = useRef<HTMLElement>(null);
   const previousFocusRef = useRef<Element | null>(null);
   const titleId = useId();
 
-  // Reset draft and capture pre-open focus each time the drawer opens.
-  // URL hydration is wired in commit 5; for now the seed is always empty.
+  // Reset draft from URL on each open, and capture pre-open focus. Re-runs
+  // when `appliedFacets` identity changes too so reopening after a sibling
+  // navigation (e.g. q changed via the search bar) picks up the new state.
   useEffect(() => {
     if (!open) return;
     previousFocusRef.current = document.activeElement;
-    setDraft(emptyDraft());
-  }, [open]);
+    setDraft(parseFacets(appliedFacets, schemes));
+  }, [open, appliedFacets, schemes]);
 
   // Lock body scroll while the modal is up; restore the prior overflow
   // value on close so we don't clobber an ancestor that was managing it.
@@ -124,7 +124,7 @@ export function FilterDrawer({
   }
 
   function handleReset() {
-    setDraft(emptyDraft());
+    setDraft(new Map());
   }
 
   function handleApply() {

--- a/src/components/filters/FilterDrawer.tsx
+++ b/src/components/filters/FilterDrawer.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useId, useRef, useState } from "preact/hooks";
+import { FilterCard } from "./FilterCard";
+import { ConceptSchemeFilter } from "./ConceptSchemeFilter";
+import {
+  emptyConceptSchemeState,
+  summary,
+  toSearchFacet,
+  type ConceptSchemeFilterState,
+} from "./conceptSchemeFilterState";
+import type { ConceptScheme } from "@/services/vocabulary/vocabularyService";
+import "./FilterDrawer.css";
+
+interface FilterDrawerProps {
+  open: boolean;
+  schemes: ConceptScheme[];
+  appliedFacets: string[];
+  onApply: (next: string[]) => void;
+  onCancel: () => void;
+}
+
+type Draft = Map<string, ConceptSchemeFilterState>;
+
+function emptyDraft(): Draft {
+  return new Map();
+}
+
+// Serialise the drawer's per-scheme draft back into the wire format expected
+// by SearchParams.searchFacets — one entry per scheme that has at least one
+// concept selected.
+function draftToFacets(
+  draft: Draft,
+  schemes: ConceptScheme[],
+): string[] {
+  const facets: string[] = [];
+  for (const scheme of schemes) {
+    const state = draft.get(scheme.uri);
+    if (!state || state.size === 0) continue;
+    const facet = toSearchFacet(state, scheme);
+    if (facet !== "") facets.push(facet);
+  }
+  return facets;
+}
+
+// Order-insensitive set equality on facet strings. URL ordering of
+// `searchFacets` is incidental — we don't want to flag the draft as dirty
+// just because two schemes' fragments swapped position.
+function facetsEqual(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  const seen = new Set(a);
+  for (const x of b) if (!seen.has(x)) return false;
+  return true;
+}
+
+export function FilterDrawer({
+  open,
+  schemes,
+  appliedFacets,
+  onApply,
+  onCancel,
+}: FilterDrawerProps) {
+  const [draft, setDraft] = useState<Draft>(emptyDraft);
+  const panelRef = useRef<HTMLElement>(null);
+  const previousFocusRef = useRef<Element | null>(null);
+  const titleId = useId();
+
+  // Reset draft and capture pre-open focus each time the drawer opens.
+  // URL hydration is wired in commit 5; for now the seed is always empty.
+  useEffect(() => {
+    if (!open) return;
+    previousFocusRef.current = document.activeElement;
+    setDraft(emptyDraft());
+  }, [open]);
+
+  // Lock body scroll while the modal is up; restore the prior overflow
+  // value on close so we don't clobber an ancestor that was managing it.
+  useEffect(() => {
+    if (!open) return;
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, [open]);
+
+  // Focus the dialog panel itself on open (it carries tabindex=-1) so the
+  // first Tab lands on something inside the drawer rather than the page
+  // beneath. Restore focus to wherever it was on close.
+  useEffect(() => {
+    if (!open) return;
+    panelRef.current?.focus();
+    return () => {
+      const target = previousFocusRef.current;
+      if (target instanceof HTMLElement) target.focus();
+    };
+  }, [open]);
+
+  // Escape dismisses the drawer (treated as Cancel). The ticket says users
+  // must use a button, but that wording is mouse-shaped — keyboard users
+  // need a non-mouse exit, and Esc is the universal modal convention.
+  useEffect(() => {
+    if (!open) return;
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onCancel();
+      }
+    }
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [open, onCancel]);
+
+  if (!open) return null;
+
+  function onSchemeChange(
+    scheme: ConceptScheme,
+    next: ConceptSchemeFilterState,
+  ) {
+    setDraft((prev) => {
+      const updated = new Map(prev);
+      if (next.size === 0) updated.delete(scheme.uri);
+      else updated.set(scheme.uri, next);
+      return updated;
+    });
+  }
+
+  function handleReset() {
+    setDraft(emptyDraft());
+  }
+
+  function handleApply() {
+    onApply(draftToFacets(draft, schemes));
+  }
+
+  const dirty = !facetsEqual(draftToFacets(draft, schemes), appliedFacets);
+
+  return (
+    <div class="filter-drawer" role="presentation">
+      <div class="filter-drawer__backdrop" aria-hidden="true" />
+      <aside
+        ref={panelRef}
+        class="filter-drawer__panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+      >
+        <header class="filter-drawer__header">
+          <h2 id={titleId} class="filter-drawer__title">
+            Filters
+          </h2>
+        </header>
+
+        <div class="filter-drawer__body">
+          {schemes.map((scheme) => {
+            const state = draft.get(scheme.uri) ?? emptyConceptSchemeState();
+            return (
+              <FilterCard
+                key={scheme.uri}
+                title={scheme.label}
+                summary={summary(state)}
+              >
+                <ConceptSchemeFilter
+                  scheme={scheme}
+                  state={state}
+                  onChange={(next) => onSchemeChange(scheme, next)}
+                />
+              </FilterCard>
+            );
+          })}
+        </div>
+
+        <footer class="filter-drawer__footer">
+          <button
+            type="button"
+            class="filter-drawer__btn filter-drawer__btn--reset"
+            onClick={handleReset}
+          >
+            Reset
+          </button>
+          <div class="filter-drawer__footer-spacer" />
+          <button
+            type="button"
+            class="filter-drawer__btn filter-drawer__btn--cancel"
+            onClick={onCancel}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            class="filter-drawer__btn filter-drawer__btn--apply"
+            onClick={handleApply}
+            disabled={!dirty}
+          >
+            Update Results
+          </button>
+        </footer>
+      </aside>
+    </div>
+  );
+}

--- a/src/components/filters/conceptSchemeFilterState.ts
+++ b/src/components/filters/conceptSchemeFilterState.ts
@@ -132,3 +132,48 @@ export function toSearchFacet(
   }
   return clauses.join(" OR ");
 }
+
+const FACET_URI_RE = /linked_data_concepts:"([^"]+)"/g;
+
+function indexConceptUrisByScheme(
+  schemes: ConceptScheme[],
+): Map<string, string> {
+  const index = new Map<string, string>();
+  for (const scheme of schemes) {
+    for (const concept of walkConcepts(scheme.topConcepts)) {
+      index.set(concept.uri, scheme.uri);
+    }
+  }
+  return index;
+}
+
+// Reverse of `toSearchFacet`, lifted to operate over the full
+// `SearchParams.searchFacets` array: extract every concept URI from each
+// fragment and bucket the URIs by the scheme that contains them. URIs that
+// don't belong to any of the supplied schemes are silently dropped —
+// defensive for stale URLs pointing at a vocabulary that has since changed.
+export function parseFacets(
+  searchFacets: readonly string[],
+  schemes: ConceptScheme[],
+): Map<string, ConceptSchemeFilterState> {
+  const uriToScheme = indexConceptUrisByScheme(schemes);
+  const buckets = new Map<string, Set<string>>();
+  for (const fragment of searchFacets) {
+    for (const match of fragment.matchAll(FACET_URI_RE)) {
+      const uri = match[1];
+      const schemeUri = uriToScheme.get(uri);
+      if (schemeUri === undefined) continue;
+      let bucket = buckets.get(schemeUri);
+      if (!bucket) {
+        bucket = new Set();
+        buckets.set(schemeUri, bucket);
+      }
+      bucket.add(uri);
+    }
+  }
+  const result = new Map<string, ConceptSchemeFilterState>();
+  for (const [schemeUri, uris] of buckets) {
+    result.set(schemeUri, conceptSchemeStateFromUris(uris));
+  }
+  return result;
+}

--- a/src/components/search/RefineButton.css
+++ b/src/components/search/RefineButton.css
@@ -1,0 +1,44 @@
+.refine-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 5px 12px;
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.refine-btn:hover:not(:disabled) {
+  background: var(--color-bg-hover);
+}
+
+.refine-btn:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -1px;
+}
+
+.refine-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.refine-btn__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 6px;
+  border-radius: 9px;
+  background: var(--color-accent);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+}

--- a/src/components/search/RefineButton.tsx
+++ b/src/components/search/RefineButton.tsx
@@ -1,0 +1,34 @@
+import { Tooltip } from "@/components/Tooltip";
+import "./RefineButton.css";
+
+interface RefineButtonProps {
+  count: number;
+  disabled?: boolean;
+  disabledReason?: string;
+  onClick: () => void;
+}
+
+export function RefineButton({
+  count,
+  disabled = false,
+  disabledReason,
+  onClick,
+}: RefineButtonProps) {
+  const button = (
+    <button
+      type="button"
+      class="refine-btn"
+      onClick={onClick}
+      disabled={disabled}
+    >
+      Refine
+      {count > 0 && <span class="refine-btn__count">{count}</span>}
+    </button>
+  );
+  // Tooltip wrapper lives outside the disabled <button> so the bubble still
+  // appears on hover even though the disabled button itself can't receive
+  // pointer/focus events in all browsers.
+  return disabled && disabledReason
+    ? <Tooltip text={disabledReason}>{button}</Tooltip>
+    : button;
+}

--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -1,5 +1,13 @@
 import { MagnifierIcon } from "@/components/icons";
+import { RefineButton } from "./RefineButton";
 import "./SearchBar.css";
+
+interface RefineConfig {
+  count: number;
+  disabled: boolean;
+  disabledReason?: string;
+  onClick: () => void;
+}
 
 interface SearchBarProps {
   draftQ: string;
@@ -11,6 +19,8 @@ interface SearchBarProps {
   validationError: string | null;
   onSubmit: () => void;
   disabled?: boolean;
+  /** Optional Refine trigger; omit to hide the filter drawer entry point. */
+  refine?: RefineConfig;
 }
 
 export function SearchBar({
@@ -23,6 +33,7 @@ export function SearchBar({
   validationError,
   onSubmit,
   disabled = false,
+  refine,
 }: SearchBarProps) {
   function handleSubmit(e?: Event) {
     e?.preventDefault();
@@ -79,6 +90,14 @@ export function SearchBar({
           onInput={(e) => onDraftEndChange((e.target as HTMLInputElement).value)}
           disabled={disabled}
         />
+        {refine && (
+          <RefineButton
+            count={refine.count}
+            disabled={refine.disabled}
+            disabledReason={refine.disabledReason}
+            onClick={refine.onClick}
+          />
+        )}
       </div>
 
       {validationError && (

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "preact/hooks";
+import { useEffect, useState } from "preact/hooks";
 import { useCommunity } from "@/community/CommunityContext";
 import type { Community } from "@/types/models";
 import {
@@ -14,11 +14,13 @@ import { useCorpusTotal } from "@/hooks/useCorpusTotal";
 import { useSearch } from "@/hooks/useSearch";
 import { useSearchDraft } from "@/hooks/useSearchDraft";
 import { useSearchExport, type ExportStatus } from "@/hooks/useSearchExport";
+import { useVocabulary } from "@/hooks/useVocabulary";
 import { SearchBar } from "@/components/search/SearchBar";
 import { SortDropdown } from "@/components/search/SortDropdown";
 import { ExportButton } from "@/components/search/ExportButton";
 import { ResultRow } from "@/components/search/ResultRow";
 import { Pagination } from "@/components/Pagination";
+import { FilterDrawer } from "@/components/filters/FilterDrawer";
 import { NotFoundPage } from "./NotFoundPage";
 import "./SearchPage.css";
 
@@ -43,6 +45,28 @@ function formatYearClause(start: number | undefined, end: number | undefined): s
 // 10k is destiny-repository's max_result_window; deep pagination + exports
 // past that are explicitly out of scope. Mirrors the search backend cap.
 const EXPORT_MAX_RESULTS = 10000;
+
+// Maps the useVocabulary() result to the SearchBar `refine` prop. Returns
+// undefined when there are no facets to offer (empty schemes) so the Refine
+// trigger isn't rendered at all.
+function buildRefineConfig(
+  vocab: ReturnType<typeof useVocabulary>,
+  count: number,
+  open: () => void,
+):
+  | { count: number; disabled: boolean; disabledReason?: string; onClick: () => void }
+  | undefined {
+  if (vocab.schemes && vocab.schemes.length > 0) {
+    return { count, disabled: false, onClick: open };
+  }
+  if (vocab.error) {
+    return { count: 0, disabled: true, disabledReason: "Filters unavailable", onClick: () => {} };
+  }
+  if (vocab.loading) {
+    return { count: 0, disabled: true, disabledReason: "Loading filters…", onClick: () => {} };
+  }
+  return undefined;
+}
 
 function formatExportFilename(slug: string, now: Date = new Date()): string {
   // UTC so the same wall-clock click in different timezones produces the
@@ -110,6 +134,33 @@ function SearchPageInner({ community }: { community: Community }) {
   const corpus = useCorpusTotal();
   const results = useSearch(params);
   const exportJob = useSearchExport();
+
+  // Kick off the vocabulary fetch on page mount (not on drawer open) via the
+  // shared cache, so the Refine button is almost always ready by the time
+  // the user reaches for it. The drawer itself never renders a loading
+  // state — the trigger is the gate.
+  const vocab = useVocabulary(community.vocabularyUrl);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  const refine = buildRefineConfig(
+    vocab,
+    params.searchFacets.length,
+    () => setDrawerOpen(true),
+  );
+
+  function handleApplyFacets(nextFacets: string[]) {
+    const committed = draft.commitDraft();
+    if (!committed) return;
+    navigate(
+      buildSearchUrl(community.slug, {
+        ...params,
+        ...committed,
+        searchFacets: nextFacets,
+        page: 1,
+      }),
+    );
+    setDrawerOpen(false);
+  }
 
   // Hide the bar on the initial browse-mode load so the skeleton owns the
   // full vertical space; show it as soon as there's anything to put in it.
@@ -215,6 +266,7 @@ function SearchPageInner({ community }: { community: Community }) {
           validationError={draft.validationError}
           onSubmit={handleSubmit}
           disabled={results.loading && results.results !== null}
+          refine={refine}
         />
       </section>
 
@@ -311,6 +363,16 @@ function SearchPageInner({ community }: { community: Community }) {
           />
         )}
       </section>
+
+      {vocab.schemes && vocab.schemes.length > 0 && (
+        <FilterDrawer
+          open={drawerOpen}
+          schemes={vocab.schemes}
+          appliedFacets={params.searchFacets}
+          onApply={handleApplyFacets}
+          onCancel={() => setDrawerOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/tests/components/filters/FilterDrawer.test.tsx
+++ b/tests/components/filters/FilterDrawer.test.tsx
@@ -283,10 +283,31 @@ describe("FilterDrawer", () => {
     expect(document.body.style.overflow).toBe("auto");
   });
 
-  test("with a non-empty draft matching appliedFacets, Update Results stays disabled", () => {
-    // appliedFacets carries the URI for "Educational Outcomes and Learning".
-    // After the user clicks that same concept, the draft now equals applied
-    // (one URI in one scheme) so the apply button should remain disabled.
+  test("hydrates the draft from appliedFacets on open", () => {
+    // appliedFacets carries the URI for "Educational Outcomes and Learning";
+    // the drawer should open with that concept already checked and Update
+    // Results disabled (draft == applied).
+    const appliedFacets = [`linked_data_concepts:"${URI_LEARNING}"`];
+    render(
+      <FilterDrawer
+        open={true}
+        schemes={[OUTCOME_SCHEME_FIXTURE]}
+        appliedFacets={appliedFacets}
+        onApply={noop}
+        onCancel={noop}
+      />,
+    );
+    expect(
+      (screen.getByLabelText("Educational Outcomes and Learning") as HTMLInputElement)
+        .checked,
+    ).toBe(true);
+    expect(
+      (screen.getByRole("button", { name: "Update Results" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+  });
+
+  test("toggling away from a hydrated selection enables Update Results", () => {
     const appliedFacets = [`linked_data_concepts:"${URI_LEARNING}"`];
     render(
       <FilterDrawer
@@ -301,6 +322,53 @@ describe("FilterDrawer", () => {
     expect(
       (screen.getByRole("button", { name: "Update Results" }) as HTMLButtonElement)
         .disabled,
+    ).toBe(false);
+  });
+
+  test("re-hydrates when reopened after appliedFacets change", () => {
+    const initial = [`linked_data_concepts:"${URI_LEARNING}"`];
+    const { rerender } = render(
+      <FilterDrawer
+        open={true}
+        schemes={[OUTCOME_SCHEME_FIXTURE]}
+        appliedFacets={initial}
+        onApply={noop}
+        onCancel={noop}
+      />,
+    );
+    expect(
+      (screen.getByLabelText("Educational Outcomes and Learning") as HTMLInputElement)
+        .checked,
     ).toBe(true);
+
+    // Close → URL changes externally → reopen.
+    const next = [`linked_data_concepts:"${URI_ACCESS}"`];
+    rerender(
+      <FilterDrawer
+        open={false}
+        schemes={[OUTCOME_SCHEME_FIXTURE]}
+        appliedFacets={next}
+        onApply={noop}
+        onCancel={noop}
+      />,
+    );
+    rerender(
+      <FilterDrawer
+        open={true}
+        schemes={[OUTCOME_SCHEME_FIXTURE]}
+        appliedFacets={next}
+        onApply={noop}
+        onCancel={noop}
+      />,
+    );
+
+    // toggleConceptSubtree selects the whole subtree under "Access to Education".
+    expect(
+      (screen.getByLabelText("Access to Education") as HTMLInputElement).checked,
+    ).toBe(true);
+    expect(
+      (screen.getByLabelText("Educational Outcomes and Learning") as HTMLInputElement)
+        .checked,
+    ).toBe(false);
   });
 });

--- a/tests/components/filters/FilterDrawer.test.tsx
+++ b/tests/components/filters/FilterDrawer.test.tsx
@@ -1,0 +1,306 @@
+import { describe, test, expect, vi } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/preact";
+import { FilterDrawer } from "@/components/filters/FilterDrawer";
+import type { ConceptScheme } from "@/services/vocabulary/vocabularyService";
+import {
+  OUTCOME_SCHEME_FIXTURE,
+  URI_ACCESS,
+  URI_EDUCATION_FINANCE,
+  URI_ENROLMENT,
+  URI_LEARNING,
+} from "./fixtures";
+
+// A second scheme exercises the multi-scheme rendering and the per-scheme
+// draft Map.
+const URI_JOURNAL = "https://vocab.esea.education/DocumentTypeScheme/C00008";
+const DOCUMENT_TYPE_SCHEME: ConceptScheme = {
+  uri: "https://vocab.esea.education/DocumentTypeScheme",
+  label: "Document type",
+  topConcepts: [{ uri: URI_JOURNAL, label: "Journal Article" }],
+};
+
+const TWO_SCHEMES: ConceptScheme[] = [
+  OUTCOME_SCHEME_FIXTURE,
+  DOCUMENT_TYPE_SCHEME,
+];
+
+function noop() {}
+
+describe("FilterDrawer", () => {
+  test("renders nothing when closed", () => {
+    const { container } = render(
+      <FilterDrawer
+        open={false}
+        schemes={TWO_SCHEMES}
+        appliedFacets={[]}
+        onApply={noop}
+        onCancel={noop}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("renders one FilterCard per scheme", () => {
+    render(
+      <FilterDrawer
+        open={true}
+        schemes={TWO_SCHEMES}
+        appliedFacets={[]}
+        onApply={noop}
+        onCancel={noop}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /^Outcome/ }),
+    ).toBeDefined();
+    expect(
+      screen.getByRole("button", { name: /^Document type/ }),
+    ).toBeDefined();
+  });
+
+  test("opens with Update Results disabled when nothing is selected", () => {
+    render(
+      <FilterDrawer
+        open={true}
+        schemes={TWO_SCHEMES}
+        appliedFacets={[]}
+        onApply={noop}
+        onCancel={noop}
+      />,
+    );
+    const apply = screen.getByRole("button", { name: "Update Results" });
+    expect((apply as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  test("toggling a concept enables Update Results", () => {
+    render(
+      <FilterDrawer
+        open={true}
+        schemes={TWO_SCHEMES}
+        appliedFacets={[]}
+        onApply={noop}
+        onCancel={noop}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Journal Article"));
+    const apply = screen.getByRole("button", { name: "Update Results" });
+    expect((apply as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  test("Update Results fires onApply with one facet entry per non-empty scheme", () => {
+    const onApply = vi.fn();
+    render(
+      <FilterDrawer
+        open={true}
+        schemes={TWO_SCHEMES}
+        appliedFacets={[]}
+        onApply={onApply}
+        onCancel={noop}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Journal Article"));
+    fireEvent.click(screen.getByLabelText("Returns to Education"));
+    fireEvent.click(screen.getByRole("button", { name: "Update Results" }));
+
+    expect(onApply).toHaveBeenCalledTimes(1);
+    const facets = onApply.mock.calls[0][0] as string[];
+    expect(facets).toHaveLength(2);
+    expect(facets).toContain(
+      `linked_data_concepts:"https://vocab.esea.education/OutcomeScheme/C00130"`,
+    );
+    expect(facets).toContain(`linked_data_concepts:"${URI_JOURNAL}"`);
+  });
+
+  test("toggling parent concept selects descendants via subtree semantics", () => {
+    // Sanity check that the drawer plumbs the scheme through to
+    // ConceptSchemeFilter correctly (which owns the subtree toggle).
+    const onApply = vi.fn();
+    render(
+      <FilterDrawer
+        open={true}
+        schemes={[OUTCOME_SCHEME_FIXTURE]}
+        appliedFacets={[]}
+        onApply={onApply}
+        onCancel={noop}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Access to Education"));
+    fireEvent.click(screen.getByRole("button", { name: "Update Results" }));
+
+    const facet = (onApply.mock.calls[0][0] as string[])[0];
+    expect(facet).toContain(URI_ACCESS);
+    expect(facet).toContain(URI_EDUCATION_FINANCE);
+    expect(facet).toContain(URI_ENROLMENT);
+  });
+
+  test("Reset clears the draft without closing the drawer", () => {
+    const onCancel = vi.fn();
+    render(
+      <FilterDrawer
+        open={true}
+        schemes={TWO_SCHEMES}
+        appliedFacets={[]}
+        onApply={noop}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Journal Article"));
+    expect(
+      (screen.getByLabelText("Journal Article") as HTMLInputElement).checked,
+    ).toBe(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Reset" }));
+
+    expect(
+      (screen.getByLabelText("Journal Article") as HTMLInputElement).checked,
+    ).toBe(false);
+    // Update Results re-greys because the draft is back to equal-to-applied.
+    expect(
+      (screen.getByRole("button", { name: "Update Results" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    // And Reset does not bubble out to Cancel.
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  test("Cancel button fires onCancel", () => {
+    const onCancel = vi.fn();
+    render(
+      <FilterDrawer
+        open={true}
+        schemes={TWO_SCHEMES}
+        appliedFacets={[]}
+        onApply={noop}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  test("Escape key fires onCancel", () => {
+    const onCancel = vi.fn();
+    render(
+      <FilterDrawer
+        open={true}
+        schemes={TWO_SCHEMES}
+        appliedFacets={[]}
+        onApply={noop}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  test("backdrop click does NOT fire onCancel", () => {
+    const onCancel = vi.fn();
+    const { container } = render(
+      <FilterDrawer
+        open={true}
+        schemes={TWO_SCHEMES}
+        appliedFacets={[]}
+        onApply={noop}
+        onCancel={onCancel}
+      />,
+    );
+    const backdrop = container.querySelector(".filter-drawer__backdrop");
+    expect(backdrop).not.toBeNull();
+    fireEvent.click(backdrop!);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  test("focus lands on the dialog panel when opened", () => {
+    const { container } = render(
+      <FilterDrawer
+        open={true}
+        schemes={TWO_SCHEMES}
+        appliedFacets={[]}
+        onApply={noop}
+        onCancel={noop}
+      />,
+    );
+    const panel = container.querySelector(".filter-drawer__panel");
+    expect(panel).not.toBeNull();
+    expect(document.activeElement).toBe(panel);
+  });
+
+  test("returns focus to the previously-focused element on close", () => {
+    document.body.innerHTML = '<button id="trigger">open</button>';
+    const trigger = document.getElementById("trigger") as HTMLButtonElement;
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    const { rerender } = render(
+      <FilterDrawer
+        open={true}
+        schemes={TWO_SCHEMES}
+        appliedFacets={[]}
+        onApply={noop}
+        onCancel={noop}
+      />,
+    );
+    expect(document.activeElement).not.toBe(trigger);
+
+    rerender(
+      <FilterDrawer
+        open={false}
+        schemes={TWO_SCHEMES}
+        appliedFacets={[]}
+        onApply={noop}
+        onCancel={noop}
+      />,
+    );
+    expect(document.activeElement).toBe(trigger);
+
+    // Tidy up so the next test starts with a fresh body.
+    cleanup();
+    document.body.innerHTML = "";
+  });
+
+  test("locks body scroll while open and restores prior value on close", () => {
+    document.body.style.overflow = "auto";
+    const { rerender } = render(
+      <FilterDrawer
+        open={true}
+        schemes={TWO_SCHEMES}
+        appliedFacets={[]}
+        onApply={noop}
+        onCancel={noop}
+      />,
+    );
+    expect(document.body.style.overflow).toBe("hidden");
+
+    rerender(
+      <FilterDrawer
+        open={false}
+        schemes={TWO_SCHEMES}
+        appliedFacets={[]}
+        onApply={noop}
+        onCancel={noop}
+      />,
+    );
+    expect(document.body.style.overflow).toBe("auto");
+  });
+
+  test("with a non-empty draft matching appliedFacets, Update Results stays disabled", () => {
+    // appliedFacets carries the URI for "Educational Outcomes and Learning".
+    // After the user clicks that same concept, the draft now equals applied
+    // (one URI in one scheme) so the apply button should remain disabled.
+    const appliedFacets = [`linked_data_concepts:"${URI_LEARNING}"`];
+    render(
+      <FilterDrawer
+        open={true}
+        schemes={[OUTCOME_SCHEME_FIXTURE]}
+        appliedFacets={appliedFacets}
+        onApply={noop}
+        onCancel={noop}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Educational Outcomes and Learning"));
+    expect(
+      (screen.getByRole("button", { name: "Update Results" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+  });
+});

--- a/tests/components/filters/conceptSchemeFilterState.test.ts
+++ b/tests/components/filters/conceptSchemeFilterState.test.ts
@@ -5,6 +5,7 @@ import {
   emptyConceptSchemeState,
   isEmpty,
   isSelected,
+  parseFacets,
   selectedCount,
   selectedUris,
   summary,
@@ -416,6 +417,117 @@ describe("toSearchFacet", () => {
     expect(toSearchFacet(state, OUTCOME_SCHEME_FIXTURE)).toBe(
       `linked_data_concepts:"${URI_ACCESS}"` +
         ` OR linked_data_concepts:"${URI_EDUCATION_FINANCE}"`,
+    );
+  });
+});
+
+describe("parseFacets", () => {
+  const DOCUMENT_TYPE_SCHEME: ConceptScheme = SCHEME;
+
+  test("empty input → empty map", () => {
+    const result = parseFacets([], [OUTCOME_SCHEME_FIXTURE]);
+    expect(result.size).toBe(0);
+  });
+
+  test("empty schemes → empty map even if facets carry URIs", () => {
+    const result = parseFacets(
+      [`linked_data_concepts:"${URI_JOURNAL_ARTICLE}"`],
+      [],
+    );
+    expect(result.size).toBe(0);
+  });
+
+  test("single fragment with one URI lands in the owning scheme bucket", () => {
+    const result = parseFacets(
+      [`linked_data_concepts:"${URI_JOURNAL_ARTICLE}"`],
+      [DOCUMENT_TYPE_SCHEME],
+    );
+    expect(result.size).toBe(1);
+    const state = result.get(DOCUMENT_TYPE_SCHEME.uri);
+    expect(state).toBeDefined();
+    expect(selectedUris(state!)).toEqual([URI_JOURNAL_ARTICLE]);
+  });
+
+  test("multi-URI fragment splits into a single scheme bucket", () => {
+    const fragment =
+      `linked_data_concepts:"${URI_JOURNAL_ARTICLE}"` +
+      ` OR linked_data_concepts:"${URI_THESIS}"`;
+    const result = parseFacets([fragment], [DOCUMENT_TYPE_SCHEME]);
+    const state = result.get(DOCUMENT_TYPE_SCHEME.uri)!;
+    expect(selectedCount(state)).toBe(2);
+    expect(isSelected(state, URI_JOURNAL_ARTICLE)).toBe(true);
+    expect(isSelected(state, URI_THESIS)).toBe(true);
+  });
+
+  test("URIs from two schemes split into two buckets", () => {
+    const result = parseFacets(
+      [
+        `linked_data_concepts:"${URI_JOURNAL_ARTICLE}"`,
+        `linked_data_concepts:"${URI_ACCESS}"`,
+      ],
+      [DOCUMENT_TYPE_SCHEME, OUTCOME_SCHEME_FIXTURE],
+    );
+    expect(result.size).toBe(2);
+    expect(
+      selectedUris(result.get(DOCUMENT_TYPE_SCHEME.uri)!),
+    ).toEqual([URI_JOURNAL_ARTICLE]);
+    expect(
+      selectedUris(result.get(OUTCOME_SCHEME_FIXTURE.uri)!),
+    ).toEqual([URI_ACCESS]);
+  });
+
+  test("URIs from the same scheme spread across fragments merge into one bucket", () => {
+    const result = parseFacets(
+      [
+        `linked_data_concepts:"${URI_JOURNAL_ARTICLE}"`,
+        `linked_data_concepts:"${URI_THESIS}"`,
+      ],
+      [DOCUMENT_TYPE_SCHEME],
+    );
+    expect(result.size).toBe(1);
+    expect(
+      selectedCount(result.get(DOCUMENT_TYPE_SCHEME.uri)!),
+    ).toBe(2);
+  });
+
+  test("URIs that don't belong to any scheme are silently dropped", () => {
+    const stale = "https://vocab.esea.education/RetiredScheme/X1";
+    const result = parseFacets(
+      [
+        `linked_data_concepts:"${stale}"` +
+          ` OR linked_data_concepts:"${URI_JOURNAL_ARTICLE}"`,
+      ],
+      [DOCUMENT_TYPE_SCHEME],
+    );
+    const state = result.get(DOCUMENT_TYPE_SCHEME.uri)!;
+    expect(selectedUris(state)).toEqual([URI_JOURNAL_ARTICLE]);
+  });
+
+  test("ignores everything when no URI matches any scheme", () => {
+    const result = parseFacets(
+      [`linked_data_concepts:"u:does-not-exist"`],
+      [DOCUMENT_TYPE_SCHEME, OUTCOME_SCHEME_FIXTURE],
+    );
+    expect(result.size).toBe(0);
+  });
+
+  test("picks up narrower-tier concept URIs, not just top-level ones", () => {
+    const result = parseFacets(
+      [`linked_data_concepts:"${URI_EDUCATION_FINANCE}"`],
+      [OUTCOME_SCHEME_FIXTURE],
+    );
+    const state = result.get(OUTCOME_SCHEME_FIXTURE.uri)!;
+    expect(isSelected(state, URI_EDUCATION_FINANCE)).toBe(true);
+  });
+
+  test("round-trips through toSearchFacet", () => {
+    // Pick a selection that exercises both a parent and narrower concept.
+    const original = conceptSchemeStateFromUris([URI_ACCESS, URI_LEARNING]);
+    const fragment = toSearchFacet(original, OUTCOME_SCHEME_FIXTURE);
+    const parsed = parseFacets([fragment], [OUTCOME_SCHEME_FIXTURE]);
+    const state = parsed.get(OUTCOME_SCHEME_FIXTURE.uri)!;
+    expect([...selectedUris(state)].sort()).toEqual(
+      [URI_ACCESS, URI_LEARNING].sort(),
     );
   });
 });

--- a/tests/components/search/RefineButton.test.tsx
+++ b/tests/components/search/RefineButton.test.tsx
@@ -1,0 +1,66 @@
+import { describe, test, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/preact";
+import { RefineButton } from "@/components/search/RefineButton";
+
+describe("RefineButton", () => {
+  test("renders the Refine label", () => {
+    render(<RefineButton count={0} onClick={() => {}} />);
+    expect(screen.getByRole("button", { name: /Refine/ })).toBeDefined();
+  });
+
+  test("no badge node when count is zero", () => {
+    const { container } = render(<RefineButton count={0} onClick={() => {}} />);
+    expect(container.querySelector(".refine-btn__count")).toBeNull();
+  });
+
+  test("renders a badge with the count when greater than zero", () => {
+    const { container } = render(<RefineButton count={3} onClick={() => {}} />);
+    const badge = container.querySelector(".refine-btn__count");
+    expect(badge?.textContent).toBe("3");
+  });
+
+  test("clicking fires onClick when enabled", () => {
+    const onClick = vi.fn();
+    render(<RefineButton count={0} onClick={onClick} />);
+    fireEvent.click(screen.getByRole("button", { name: /Refine/ }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test("applies the disabled attribute when disabled", () => {
+    render(<RefineButton count={0} disabled onClick={() => {}} />);
+    const btn = screen.getByRole("button", { name: /Refine/ });
+    expect((btn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  test("wraps the button in a Tooltip when disabled with a reason", () => {
+    const { container } = render(
+      <RefineButton
+        count={0}
+        disabled
+        disabledReason="Loading filters…"
+        onClick={() => {}}
+      />,
+    );
+    const tooltip = container.querySelector(".tooltip");
+    expect(tooltip).not.toBeNull();
+    expect(tooltip?.getAttribute("data-tooltip")).toBe("Loading filters…");
+  });
+
+  test("no Tooltip wrapper when enabled, even if reason is provided", () => {
+    const { container } = render(
+      <RefineButton
+        count={0}
+        disabledReason="should be ignored"
+        onClick={() => {}}
+      />,
+    );
+    expect(container.querySelector(".tooltip")).toBeNull();
+  });
+
+  test("no Tooltip wrapper when disabled without a reason", () => {
+    const { container } = render(
+      <RefineButton count={0} disabled onClick={() => {}} />,
+    );
+    expect(container.querySelector(".tooltip")).toBeNull();
+  });
+});

--- a/tests/pages/SearchPage.test.tsx
+++ b/tests/pages/SearchPage.test.tsx
@@ -3,6 +3,14 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/preact";
 import { SearchPage } from "@/pages/SearchPage";
 import { CommunityProvider } from "@/community/CommunityContext";
 import type { SearchResult } from "@/types/models";
+import {
+  OUTCOME_SCHEME_FIXTURE,
+  URI_LEARNING,
+  URI_RETURNS,
+  URI_ACCESS,
+  URI_EDUCATION_FINANCE,
+  URI_ENROLMENT,
+} from "../components/filters/fixtures";
 
 function renderSearchPage() {
   return render(
@@ -26,14 +34,46 @@ vi.mock("@/services/export/export", () => ({
   exportReferencesToExcel: vi.fn().mockResolvedValue(undefined),
 }));
 
+// useVocabulary is mocked so we don't fire real fetches at the stubbed
+// VITE_ESEA_VOCABULARY_URL during tests. The default below silences the
+// hook (no schemes, not loading, no error) which makes the Refine button
+// disappear entirely; tests that exercise the drawer override this.
+vi.mock("@/hooks/useVocabulary", () => ({
+  useVocabulary: vi.fn(),
+}));
+
 import {
   searchReferences,
   requestSearchExport,
   getSearchExport,
 } from "@/services/apiClient";
+import { useVocabulary } from "@/hooks/useVocabulary";
 const mockSearch = vi.mocked(searchReferences);
 const mockRequestExport = vi.mocked(requestSearchExport);
 const mockGetExport = vi.mocked(getSearchExport);
+const mockVocab = vi.mocked(useVocabulary);
+
+function silentVocab(): ReturnType<typeof useVocabulary> {
+  return {
+    labels: null,
+    broader: null,
+    definitions: null,
+    schemes: null,
+    loading: false,
+    error: null,
+  };
+}
+
+function vocabWith(schemes: typeof OUTCOME_SCHEME_FIXTURE[]): ReturnType<typeof useVocabulary> {
+  return {
+    labels: null,
+    broader: null,
+    definitions: null,
+    schemes,
+    loading: false,
+    error: null,
+  };
+}
 
 function makeResult(count: number, ids: string[] = [], isLowerBound = false): SearchResult {
   return {
@@ -82,6 +122,7 @@ beforeEach(() => {
   mockSearch.mockReset();
   mockRequestExport.mockReset();
   mockGetExport.mockReset();
+  mockVocab.mockReset().mockReturnValue(silentVocab());
   history.replaceState(null, "", "/esea");
 });
 
@@ -370,6 +411,129 @@ describe("SearchPage", () => {
       expect(container.querySelector(".search-results__meta")).toBeInTheDocument();
     });
     expect(screen.getByText(/searching/i)).toBeInTheDocument();
+  });
+
+  describe("filter drawer", () => {
+    beforeEach(() => {
+      mockVocab.mockReturnValue(vocabWith([OUTCOME_SCHEME_FIXTURE]));
+    });
+
+    test("URL with one facet → Refine shows count 1 and drawer opens with concept pre-checked", async () => {
+      const startQ = `* AND (linked_data_concepts:"${URI_LEARNING}")`;
+      history.replaceState(null, "", `/esea?q=${encodeURIComponent(startQ)}`);
+      mockBoth({ results: makeResult(7, ["r1"]) });
+
+      renderSearchPage();
+      await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
+
+      // Refine label includes the count when > 0.
+      const refine = screen.getByRole("button", { name: /Refine\s*1/ });
+      fireEvent.click(refine);
+
+      expect(
+        (screen.getByLabelText("Educational Outcomes and Learning") as HTMLInputElement)
+          .checked,
+      ).toBe(true);
+      // Other top-level concepts in the same scheme stay unchecked.
+      expect(
+        (screen.getByLabelText("Returns to Education") as HTMLInputElement).checked,
+      ).toBe(false);
+    });
+
+    test("toggling a second concept and applying navigates with both URIs in q", async () => {
+      const startQ = `* AND (linked_data_concepts:"${URI_LEARNING}")`;
+      history.replaceState(null, "", `/esea?q=${encodeURIComponent(startQ)}`);
+      mockBoth({ results: makeResult(7, ["r1"]) });
+
+      renderSearchPage();
+      await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
+
+      fireEvent.click(screen.getByRole("button", { name: /Refine/ }));
+      fireEvent.click(screen.getByLabelText("Returns to Education"));
+      fireEvent.click(screen.getByRole("button", { name: "Update Results" }));
+
+      await waitFor(() => {
+        const q = new URLSearchParams(window.location.search).get("q") ?? "";
+        expect(q).toContain(URI_LEARNING);
+        expect(q).toContain(URI_RETURNS);
+      });
+    });
+
+    test("empty URL → adding a facet through the drawer navigates with the URI in q", async () => {
+      mockBoth({ results: makeResult(120, ["r1"]) });
+      renderSearchPage();
+      await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
+
+      // Refine shows no badge.
+      const refine = screen.getByRole("button", { name: "Refine" });
+      fireEvent.click(refine);
+
+      fireEvent.click(screen.getByLabelText("Returns to Education"));
+      fireEvent.click(screen.getByRole("button", { name: "Update Results" }));
+
+      await waitFor(() => {
+        const q = new URLSearchParams(window.location.search).get("q") ?? "";
+        expect(q).toContain(URI_RETURNS);
+      });
+    });
+
+    test("selecting a parent concept applies the whole subtree (parent + descendants) to the URL", async () => {
+      mockBoth({ results: makeResult(120, ["r1"]) });
+      renderSearchPage();
+      await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
+
+      fireEvent.click(screen.getByRole("button", { name: /Refine/ }));
+      fireEvent.click(screen.getByLabelText("Access to Education"));
+      fireEvent.click(screen.getByRole("button", { name: "Update Results" }));
+
+      await waitFor(() => {
+        const q = new URLSearchParams(window.location.search).get("q") ?? "";
+        expect(q).toContain(URI_ACCESS);
+        expect(q).toContain(URI_EDUCATION_FINANCE);
+        expect(q).toContain(URI_ENROLMENT);
+      });
+    });
+
+    test("Cancel closes the drawer without changing the URL", async () => {
+      mockBoth({ results: makeResult(120, ["r1"]) });
+      renderSearchPage();
+      await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
+      const before = window.location.search;
+
+      fireEvent.click(screen.getByRole("button", { name: /Refine/ }));
+      fireEvent.click(screen.getByLabelText("Returns to Education"));
+      fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+      expect(window.location.search).toBe(before);
+      // Drawer is gone — no Update Results / Cancel button left in the DOM.
+      expect(screen.queryByRole("button", { name: "Update Results" })).toBeNull();
+    });
+
+    test("Refine is hidden when vocabulary has no schemes", async () => {
+      mockVocab.mockReturnValue(vocabWith([]));
+      mockBoth({ results: makeResult(120, ["r1"]) });
+      renderSearchPage();
+      await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
+
+      expect(screen.queryByRole("button", { name: /Refine/ })).toBeNull();
+    });
+
+    test("Refine is disabled while vocabulary is loading", async () => {
+      mockVocab.mockReturnValue({
+        labels: null,
+        broader: null,
+        definitions: null,
+        schemes: null,
+        loading: true,
+        error: null,
+      });
+      mockBoth({ results: makeResult(120, ["r1"]) });
+      renderSearchPage();
+      await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
+
+      const refine = screen.getByRole("button", { name: /Refine/ });
+      expect((refine as HTMLButtonElement).disabled).toBe(true);
+    });
   });
 
   describe("export button", () => {


### PR DESCRIPTION
Closes of #67 

Adds the FilterDrawer and allows application of concept scheme filtering to search results. Very quick implementation that can be demoed to our stakeholders. 

When reviewing the PR please focus on unintended behavior over beautiful UI goodness. There will be a follow up PR to improve the design. 

Best way to test this is to checkout the branch, connect your local to staging (or prod) destiny repo and have a go with the filter drawer. 

## Changes

- **FilterDrawer** — modal dialog (backdrop, escape-to-close,
  body scroll lock, focus restoration) that renders one `FilterCard` per
  ConceptScheme in the ESEA vocabulary. Apply is disabled until the draft differs from the applied
  facets; Reset clears the draft; Cancel reverts.
- **RefineButton** — search-bar trigger with a selected-count badge and a
  tooltip-on-disabled state for when vocabulary is loading or
  unavailable.
- **parseFacets** — reverses `toSearchFacet` across the whole
  `SearchParams.searchFacets` array, bucketing concept URIs back into
  per-scheme state. URIs not found in the current schemes are dropped
  defensively (stale URLs after a vocabulary change).
- **SearchPage wiring** — `useVocabulary` is called on page mount so the
  drawer is gated by the trigger, not by an in-modal spinner. Applying
  facets commits the draft search params and navigates with `page=1`.
- Tests for the drawer (open/close, focus, dirty-gating, apply payload),
  the RefineButton, the `parseFacets` round-trip, and an integration
  test covering the full facet flow on `SearchPage`.

## What's explicitly missing for now
* Refine button is ugly and not where it should be as per prototype
* Cancel button is not where it should be as per prototype 
* Reset does not trigger navigation (requirement on ticket) but simply resets the search draft. 