### PR TITLE
Temporarily hide effect size metric concept scheme

### DIFF
--- a/src/components/filters/FilterDrawer.tsx
+++ b/src/components/filters/FilterDrawer.tsx
@@ -146,7 +146,12 @@ export function FilterDrawer({
         </header>
 
         <div class="filter-drawer__body">
-          {schemes.map((scheme) => {
+          {schemes
+            .filter(
+              (scheme) =>
+                scheme.uri !== "evrepo:EffectSizeMetricScheme",
+            )
+            .map((scheme) => {
             const state = draft.get(scheme.uri) ?? emptyConceptSchemeState();
             return (
               <FilterCard


### PR DESCRIPTION
There's an indexing bug affecting this field on the backend, hiding it to prevent zero result filtering.