### PR TITLE
Minimal UI polish for usability

### DIFF
--- a/src/components/Tooltip.css
+++ b/src/components/Tooltip.css
@@ -6,7 +6,8 @@
  * - No viewport-edge clamping; tooltips near the right edge of narrow
  *   viewports may clip.
  * - No portaling; an ancestor with `overflow: hidden` will clip the
- *   bubble.
+ *   bubble. Consumers near such an ancestor should reposition the bubble
+ *   so it fits inside the available space (see ConceptSchemeFilter.css).
  */
 
 .tooltip {

--- a/src/components/filters/ConceptSchemeFilter.css
+++ b/src/components/filters/ConceptSchemeFilter.css
@@ -12,6 +12,10 @@
 }
 
 .concept-scheme-filter__row {
+  /* Positioning context for the tooltip bubble below — anchors the bubble
+     to the row's left edge (the checkbox) instead of the label, while the
+     hover/focus trigger stays on the label only. */
+  position: relative;
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
@@ -30,6 +34,23 @@
   text-decoration: underline dotted;
   text-underline-offset: 2px;
   outline: none;
+}
+
+/* Make the row (not the .tooltip span) the positioned ancestor for the
+   bubble: with position: static here the bubble falls through to the row.
+   Hover/focus still triggers on the .tooltip span (around the label only),
+   but the bubble is anchored at the row's left edge so it lines up with
+   the checkbox and extends rightward into the panel, avoiding the
+   horizontal clipping the drawer body would otherwise impose. */
+.concept-scheme-filter__row > .tooltip {
+  position: static;
+}
+
+.concept-scheme-filter__row > .tooltip:hover::after,
+.concept-scheme-filter__row > .tooltip:focus-within::after,
+.concept-scheme-filter__row > .tooltip:focus-visible::after {
+  left: 0;
+  transform: none;
 }
 
 .concept-scheme-filter__children {

--- a/src/components/filters/FilterCard.css
+++ b/src/components/filters/FilterCard.css
@@ -46,9 +46,9 @@
 }
 
 .filter-card__arrow {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
   margin-left: auto;
-  width: 1em;
   color: var(--color-text-tertiary);
 }
 

--- a/src/components/filters/FilterCard.css
+++ b/src/components/filters/FilterCard.css
@@ -30,7 +30,6 @@
 }
 
 .filter-card__title {
-  flex: 1;
   font-weight: 600;
   font-size: var(--font-size-small);
   letter-spacing: 0.04em;
@@ -42,8 +41,13 @@
   color: var(--color-text-secondary);
 }
 
+.filter-card__summary::before {
+  content: "· ";
+}
+
 .filter-card__arrow {
   display: inline-block;
+  margin-left: auto;
   width: 1em;
   color: var(--color-text-tertiary);
 }

--- a/src/components/filters/FilterCard.css
+++ b/src/components/filters/FilterCard.css
@@ -1,8 +1,9 @@
 .filter-card {
-  background: var(--color-bg-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  box-shadow: var(--shadow-card);
+  background: transparent;
+}
+
+.filter-card + .filter-card {
+  border-top: 1px solid var(--color-border);
 }
 
 .filter-card__header {
@@ -13,15 +14,10 @@
   padding: var(--spacing-md) var(--spacing-lg);
   background: none;
   border: none;
-  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
   cursor: pointer;
   text-align: left;
   font-family: inherit;
   color: var(--color-text-primary);
-}
-
-.filter-card__header[aria-expanded="false"] {
-  border-radius: var(--radius-sm);
 }
 
 .filter-card__header:hover {
@@ -36,7 +32,9 @@
 .filter-card__title {
   flex: 1;
   font-weight: 600;
-  font-size: var(--font-size-body);
+  font-size: var(--font-size-small);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .filter-card__summary {
@@ -51,6 +49,5 @@
 }
 
 .filter-card__panel {
-  padding: var(--spacing-md) var(--spacing-lg);
-  border-top: 1px solid var(--color-border);
+  padding: 0 var(--spacing-lg) var(--spacing-md);
 }

--- a/src/components/filters/FilterCard.tsx
+++ b/src/components/filters/FilterCard.tsx
@@ -1,5 +1,6 @@
 import type { ComponentChildren } from "preact";
 import { useId, useState } from "preact/hooks";
+import { ChevronDownIcon, ChevronRightIcon } from "@/components/icons";
 import "./FilterCard.css";
 
 interface FilterCardProps {
@@ -27,7 +28,7 @@ export function FilterCard({ title, summary, children }: FilterCardProps) {
           <span class="filter-card__summary">{summary}</span>
         )}
         <span class="filter-card__arrow" aria-hidden="true">
-          {expanded ? "▾" : "▸"}
+          {expanded ? <ChevronDownIcon /> : <ChevronRightIcon />}
         </span>
       </button>
       <div id={panelId} class="filter-card__panel" hidden={!expanded}>

--- a/src/components/filters/FilterCard.tsx
+++ b/src/components/filters/FilterCard.tsx
@@ -11,7 +11,7 @@ interface FilterCardProps {
 export function FilterCard({ title, summary, children }: FilterCardProps) {
   const [expanded, setExpanded] = useState(false);
   const panelId = useId();
-  const showSummary = !expanded && !!summary;
+  const showSummary = !!summary;
 
   return (
     <div class="filter-card">

--- a/src/components/filters/FilterDrawer.css
+++ b/src/components/filters/FilterDrawer.css
@@ -26,6 +26,10 @@
 }
 
 .filter-drawer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
   padding: var(--spacing-md) var(--spacing-lg);
   border-bottom: 1px solid var(--color-border);
 }
@@ -53,14 +57,11 @@
 .filter-drawer__footer {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: var(--spacing-sm);
   padding: var(--spacing-md) var(--spacing-lg);
   border-top: 1px solid var(--color-border);
   background: var(--color-bg-surface);
-}
-
-.filter-drawer__footer-spacer {
-  flex: 1;
 }
 
 .filter-drawer__btn {
@@ -79,15 +80,13 @@
 }
 
 .filter-drawer__btn--reset {
-  background: none;
-  border: none;
-  color: var(--color-text-secondary);
-  padding: 8px 4px;
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-primary);
 }
 
 .filter-drawer__btn--reset:hover {
-  color: var(--color-text-primary);
-  text-decoration: underline;
+  background: var(--color-bg-hover);
 }
 
 .filter-drawer__btn--cancel {

--- a/src/components/filters/FilterDrawer.css
+++ b/src/components/filters/FilterDrawer.css
@@ -48,10 +48,9 @@
 .filter-drawer__body {
   flex: 1;
   overflow-y: auto;
-  padding: var(--spacing-md) var(--spacing-lg);
+  padding: var(--spacing-sm) 0;
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-md);
 }
 
 .filter-drawer__footer {

--- a/src/components/filters/FilterDrawer.tsx
+++ b/src/components/filters/FilterDrawer.tsx
@@ -48,6 +48,14 @@ function facetsEqual(a: readonly string[], b: readonly string[]): boolean {
   return true;
 }
 
+// Scheme labels arrive from the vocabulary as e.g. "Document Type Scheme" —
+// the trailing word is implementation detail of the SKOS model and noise to
+// the reader. Strip it (case-insensitive, only as a trailing whole word) for
+// display in the drawer.
+function schemeDisplayLabel(label: string): string {
+  return label.replace(/\s+Scheme$/i, "");
+}
+
 export function FilterDrawer({
   open,
   schemes,
@@ -163,7 +171,7 @@ export function FilterDrawer({
             return (
               <FilterCard
                 key={scheme.uri}
-                title={scheme.label}
+                title={schemeDisplayLabel(scheme.label)}
                 summary={summary(state)}
               >
                 <ConceptSchemeFilter

--- a/src/components/filters/FilterDrawer.tsx
+++ b/src/components/filters/FilterDrawer.tsx
@@ -141,8 +141,15 @@ export function FilterDrawer({
       >
         <header class="filter-drawer__header">
           <h2 id={titleId} class="filter-drawer__title">
-            Filters
+            Refine the evidence
           </h2>
+          <button
+            type="button"
+            class="filter-drawer__btn filter-drawer__btn--cancel"
+            onClick={onCancel}
+          >
+            Cancel
+          </button>
         </header>
 
         <div class="filter-drawer__body">
@@ -175,15 +182,7 @@ export function FilterDrawer({
             class="filter-drawer__btn filter-drawer__btn--reset"
             onClick={handleReset}
           >
-            Reset
-          </button>
-          <div class="filter-drawer__footer-spacer" />
-          <button
-            type="button"
-            class="filter-drawer__btn filter-drawer__btn--cancel"
-            onClick={onCancel}
-          >
-            Cancel
+            Reset all
           </button>
           <button
             type="button"
@@ -191,7 +190,7 @@ export function FilterDrawer({
             onClick={handleApply}
             disabled={!dirty}
           >
-            Update Results
+            Show results
           </button>
         </footer>
       </aside>

--- a/src/components/filters/FilterDrawer.tsx
+++ b/src/components/filters/FilterDrawer.tsx
@@ -165,7 +165,8 @@ export function FilterDrawer({
             .filter(
               (scheme) =>
                 scheme.uri !== "evrepo:EffectSizeMetricScheme" &&
-                scheme.uri !== "evrepo:EstimateSourceScheme",
+                scheme.uri !== "evrepo:EstimateSourceScheme" &&
+                scheme.uri !== "esea:ImplementationDescriptionScheme",
             )
             .map((scheme) => {
             const state = draft.get(scheme.uri) ?? emptyConceptSchemeState();

--- a/src/components/filters/FilterDrawer.tsx
+++ b/src/components/filters/FilterDrawer.tsx
@@ -164,7 +164,8 @@ export function FilterDrawer({
           {schemes
             .filter(
               (scheme) =>
-                scheme.uri !== "evrepo:EffectSizeMetricScheme",
+                scheme.uri !== "evrepo:EffectSizeMetricScheme" &&
+                scheme.uri !== "evrepo:EstimateSourceScheme",
             )
             .map((scheme) => {
             const state = draft.get(scheme.uri) ?? emptyConceptSchemeState();

--- a/src/components/filters/FilterDrawer.tsx
+++ b/src/components/filters/FilterDrawer.tsx
@@ -161,14 +161,7 @@ export function FilterDrawer({
         </header>
 
         <div class="filter-drawer__body">
-          {schemes
-            .filter(
-              (scheme) =>
-                scheme.uri !== "evrepo:EffectSizeMetricScheme" &&
-                scheme.uri !== "evrepo:EstimateSourceScheme" &&
-                scheme.uri !== "esea:ImplementationDescriptionScheme",
-            )
-            .map((scheme) => {
+          {schemes.map((scheme) => {
             const state = draft.get(scheme.uri) ?? emptyConceptSchemeState();
             return (
               <FilterCard

--- a/src/components/filters/conceptSchemeFilterState.ts
+++ b/src/components/filters/conceptSchemeFilterState.ts
@@ -147,6 +147,20 @@ function indexConceptUrisByScheme(
   return index;
 }
 
+// Sum of `selectedCount` across every per-scheme state derived from the
+// URL. Used to drive the Refine button's badge — each scheme contributes
+// its own checkbox count, the drawer never aggregates URIs directly.
+export function totalSelectedCount(
+  searchFacets: readonly string[],
+  schemes: ConceptScheme[],
+): number {
+  let total = 0;
+  for (const state of parseFacets(searchFacets, schemes).values()) {
+    total += selectedCount(state);
+  }
+  return total;
+}
+
 // Reverse of `toSearchFacet`, lifted to operate over the full
 // `SearchParams.searchFacets` array: extract every concept URI from each
 // fragment and bucket the URIs by the scheme that contains them. URIs that

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -37,6 +37,33 @@ export function MagnifierIcon({ size = 16 }: { size?: number }) {
   );
 }
 
+/** Three horizontal sliders — used to denote a filter/refine control. */
+export function FilterIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.75"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      width={size}
+      height={size}
+      aria-hidden="true"
+    >
+      <path d="M3 5h10" />
+      <path d="M16 5h1" />
+      <path d="M3 10h4" />
+      <path d="M10 10h7" />
+      <path d="M3 15h10" />
+      <path d="M16 15h1" />
+      <circle cx="14.5" cy="5" r="1.75" fill="currentColor" />
+      <circle cx="8.5" cy="10" r="1.75" fill="currentColor" />
+      <circle cx="14.5" cy="15" r="1.75" fill="currentColor" />
+    </svg>
+  );
+}
+
 /** Arrow pointing to upper-right — indicates an external link. */
 export function ExternalLinkIcon({ size = 12 }: { size?: number }) {
   return (

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -64,6 +64,50 @@ export function FilterIcon({ size = 16 }: { size?: number }) {
   );
 }
 
+/**
+ * Chevron pointing right — used to indicate a collapsed disclosure.
+ * Sizes to the surrounding text by default so it tracks the header.
+ */
+export function ChevronRightIcon({ size = "1em" }: { size?: number | string } = {}) {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.75"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      width={size}
+      height={size}
+      aria-hidden="true"
+    >
+      <path d="m7 4 6 6-6 6" />
+    </svg>
+  );
+}
+
+/**
+ * Chevron pointing down — used to indicate an expanded disclosure.
+ * Sizes to the surrounding text by default so it tracks the header.
+ */
+export function ChevronDownIcon({ size = "1em" }: { size?: number | string } = {}) {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.75"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      width={size}
+      height={size}
+      aria-hidden="true"
+    >
+      <path d="m4 7 6 6 6-6" />
+    </svg>
+  );
+}
+
 /** Arrow pointing to upper-right — indicates an external link. */
 export function ExternalLinkIcon({ size = 12 }: { size?: number }) {
   return (

--- a/src/components/search/ExportButton.css
+++ b/src/components/search/ExportButton.css
@@ -1,5 +1,5 @@
 .export-button {
-  background: var(--color-bg-inset);
+  background: var(--color-bg-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   color: var(--color-text-secondary);
@@ -7,7 +7,7 @@
   font-family: var(--font-body);
   font-size: var(--font-size-xs);
   line-height: 1.2;
-  padding: 5px 12px;
+  padding: 7px 12px;
 }
 
 .export-button:hover:not([aria-disabled="true"]) {

--- a/src/components/search/RefineButton.css
+++ b/src/components/search/RefineButton.css
@@ -2,16 +2,21 @@
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-xs);
-  background: var(--color-bg-surface);
+  background: var(--color-bg-inset);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   padding: 5px 12px;
   font-family: var(--font-body);
-  font-size: 13px;
+  font-size: var(--font-size-xs);
+  line-height: 1.2;
   font-weight: 600;
-  color: var(--color-text-primary);
+  color: var(--color-text-secondary);
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background 0.15s, color 0.15s;
+}
+
+.refine-btn__label {
+  display: inline-block;
 }
 
 .refine-btn:hover:not(:disabled) {

--- a/src/components/search/RefineButton.css
+++ b/src/components/search/RefineButton.css
@@ -2,10 +2,10 @@
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-xs);
-  background: var(--color-bg-inset);
+  background: var(--color-bg-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  padding: 5px 12px;
+  padding: 7px 12px;
   font-family: var(--font-body);
   font-size: var(--font-size-xs);
   line-height: 1.2;
@@ -37,10 +37,10 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 18px;
-  height: 18px;
-  padding: 0 6px;
-  border-radius: 9px;
+  min-width: 16px;
+  height: 14px;
+  padding: 0 5px;
+  border-radius: 7px;
   background: var(--color-accent);
   color: #fff;
   font-size: 11px;

--- a/src/components/search/RefineButton.tsx
+++ b/src/components/search/RefineButton.tsx
@@ -1,4 +1,5 @@
 import { Tooltip } from "@/components/Tooltip";
+import { FilterIcon } from "@/components/icons";
 import "./RefineButton.css";
 
 interface RefineButtonProps {
@@ -21,7 +22,8 @@ export function RefineButton({
       onClick={onClick}
       disabled={disabled}
     >
-      Refine
+      <FilterIcon size={14} />
+      <span class="refine-btn__label">Refine</span>
       {count > 0 && <span class="refine-btn__count">{count}</span>}
     </button>
   );

--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -1,13 +1,5 @@
 import { MagnifierIcon } from "@/components/icons";
-import { RefineButton } from "./RefineButton";
 import "./SearchBar.css";
-
-interface RefineConfig {
-  count: number;
-  disabled: boolean;
-  disabledReason?: string;
-  onClick: () => void;
-}
 
 interface SearchBarProps {
   draftQ: string;
@@ -19,8 +11,6 @@ interface SearchBarProps {
   validationError: string | null;
   onSubmit: () => void;
   disabled?: boolean;
-  /** Optional Refine trigger; omit to hide the filter drawer entry point. */
-  refine?: RefineConfig;
 }
 
 export function SearchBar({
@@ -33,7 +23,6 @@ export function SearchBar({
   validationError,
   onSubmit,
   disabled = false,
-  refine,
 }: SearchBarProps) {
   function handleSubmit(e?: Event) {
     e?.preventDefault();
@@ -90,14 +79,6 @@ export function SearchBar({
           onInput={(e) => onDraftEndChange((e.target as HTMLInputElement).value)}
           disabled={disabled}
         />
-        {refine && (
-          <RefineButton
-            count={refine.count}
-            disabled={refine.disabled}
-            disabledReason={refine.disabledReason}
-            onClick={refine.onClick}
-          />
-        )}
       </div>
 
       {validationError && (

--- a/src/components/search/SortDropdown.css
+++ b/src/components/search/SortDropdown.css
@@ -6,7 +6,7 @@
 .sort-dropdown__select {
   appearance: none;
   -webkit-appearance: none;
-  background: var(--color-bg-inset);
+  background: var(--color-bg-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   color: var(--color-text-secondary);
@@ -14,7 +14,7 @@
   font-family: var(--font-body);
   font-size: var(--font-size-xs);
   line-height: 1.2;
-  padding: 5px 26px 5px 12px;
+  padding: 7px 26px 7px 12px;
 }
 
 .sort-dropdown__select:focus {

--- a/src/components/search/SortDropdown.tsx
+++ b/src/components/search/SortDropdown.tsx
@@ -21,9 +21,9 @@ export function SortDropdown({ value, onChange, disabled = false }: SortDropdown
         onChange={handleChange}
         disabled={disabled}
       >
-        <option value="">Relevance</option>
-        <option value="newest">Publication year (newest)</option>
-        <option value="oldest">Publication year (oldest)</option>
+        <option value="">Sort: Relevance</option>
+        <option value="newest">Sort: Publication year (newest)</option>
+        <option value="oldest">Sort: Publication year (oldest)</option>
       </select>
     </span>
   );

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "preact/hooks";
+import { useEffect, useMemo, useState } from "preact/hooks";
 import { useCommunity } from "@/community/CommunityContext";
 import type { Community } from "@/types/models";
 import {
@@ -144,9 +144,20 @@ function SearchPageInner({ community }: { community: Community }) {
   const vocab = useVocabulary(community.vocabularyUrl);
   const [drawerOpen, setDrawerOpen] = useState(false);
 
+  // Excluded schemes are still kept in the vocabulary cache so labels and
+  // definitions resolve on result rows and the record detail page; they're
+  // only hidden from the filter UI (drawer + applied-filter count).
+  const filterableSchemes = useMemo(
+    () =>
+      (vocab.schemes ?? []).filter(
+        (s) => !community.filterExcludedSchemes.includes(s.uri),
+      ),
+    [vocab.schemes, community.filterExcludedSchemes],
+  );
+
   const refine = buildRefineConfig(
     vocab,
-    totalSelectedCount(params.searchFacets, vocab.schemes ?? []),
+    totalSelectedCount(params.searchFacets, filterableSchemes),
     () => setDrawerOpen(true),
   );
 
@@ -382,10 +393,10 @@ function SearchPageInner({ community }: { community: Community }) {
         )}
       </section>
 
-      {vocab.schemes && vocab.schemes.length > 0 && (
+      {filterableSchemes.length > 0 && (
         <FilterDrawer
           open={drawerOpen}
-          schemes={vocab.schemes}
+          schemes={filterableSchemes}
           appliedFacets={params.searchFacets}
           onApply={handleApplyFacets}
           onCancel={() => setDrawerOpen(false)}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -18,6 +18,7 @@ import { useVocabulary } from "@/hooks/useVocabulary";
 import { SearchBar } from "@/components/search/SearchBar";
 import { SortDropdown } from "@/components/search/SortDropdown";
 import { ExportButton } from "@/components/search/ExportButton";
+import { RefineButton } from "@/components/search/RefineButton";
 import { ResultRow } from "@/components/search/ResultRow";
 import { Pagination } from "@/components/Pagination";
 import { FilterDrawer } from "@/components/filters/FilterDrawer";
@@ -164,13 +165,16 @@ function SearchPageInner({ community }: { community: Community }) {
 
   // Hide the bar on the initial browse-mode load so the skeleton owns the
   // full vertical space; show it as soon as there's anything to put in it.
+  // Refine living in the meta bar means we also keep the bar visible whenever
+  // a Refine trigger is offered, so it stays reachable before the first result.
   const showMetaBar =
     results.results !== null ||
     results.error !== null ||
     params.q !== "" ||
     params.startYear !== undefined ||
     params.endYear !== undefined ||
-    params.searchFacets.length > 0;
+    params.searchFacets.length > 0 ||
+    refine !== undefined;
 
   // Browse mode skips the summary text to avoid duplicating the hero's corpus count.
   const showSummary =
@@ -266,7 +270,6 @@ function SearchPageInner({ community }: { community: Community }) {
           validationError={draft.validationError}
           onSubmit={handleSubmit}
           disabled={results.loading && results.results !== null}
-          refine={refine}
         />
       </section>
 
@@ -297,9 +300,9 @@ function SearchPageInner({ community }: { community: Community }) {
                         : null
                 : null}
             </span>
-            {results.results && (
+            {(refine || results.results) && (
               <span class="search-results__meta-right">
-                {exportJob.status === "error" && (
+                {results.results && exportJob.status === "error" && (
                   <span
                     class="search-results__export-status"
                     role="alert"
@@ -307,24 +310,38 @@ function SearchPageInner({ community }: { community: Community }) {
                     {exportJob.errorMessage ?? "Export failed."}
                   </span>
                 )}
-                <span
-                  class="visually-hidden"
-                  role="status"
-                  aria-live="polite"
-                >
-                  {exportAnnouncement}
-                </span>
-                <ExportButton
-                  disabled={exportDisabled}
-                  status={exportJob.status}
-                  onClick={handleExport}
-                  tooltip={exportTooltip}
-                />
-                <SortDropdown
-                  value={params.sort}
-                  onChange={handleSortChange}
-                  disabled={results.loading}
-                />
+                {results.results && (
+                  <span
+                    class="visually-hidden"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    {exportAnnouncement}
+                  </span>
+                )}
+                {results.results && (
+                  <ExportButton
+                    disabled={exportDisabled}
+                    status={exportJob.status}
+                    onClick={handleExport}
+                    tooltip={exportTooltip}
+                  />
+                )}
+                {refine && (
+                  <RefineButton
+                    count={refine.count}
+                    disabled={refine.disabled}
+                    disabledReason={refine.disabledReason}
+                    onClick={refine.onClick}
+                  />
+                )}
+                {results.results && (
+                  <SortDropdown
+                    value={params.sort}
+                    onChange={handleSortChange}
+                    disabled={results.loading}
+                  />
+                )}
               </span>
             )}
           </div>

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -22,6 +22,7 @@ import { RefineButton } from "@/components/search/RefineButton";
 import { ResultRow } from "@/components/search/ResultRow";
 import { Pagination } from "@/components/Pagination";
 import { FilterDrawer } from "@/components/filters/FilterDrawer";
+import { totalSelectedCount } from "@/components/filters/conceptSchemeFilterState";
 import { NotFoundPage } from "./NotFoundPage";
 import "./SearchPage.css";
 
@@ -145,7 +146,7 @@ function SearchPageInner({ community }: { community: Community }) {
 
   const refine = buildRefineConfig(
     vocab,
-    params.searchFacets.length,
+    totalSelectedCount(params.searchFacets, vocab.schemes ?? []),
     () => setDrawerOpen(true),
   );
 

--- a/src/services/communities.ts
+++ b/src/services/communities.ts
@@ -23,6 +23,11 @@ const COMMUNITIES: Community[] = [
       "VITE_ESEA_CONTEXT_URL",
       import.meta.env.VITE_ESEA_CONTEXT_URL,
     ),
+    filterExcludedSchemes: [
+      "evrepo:EffectSizeMetricScheme",
+      "evrepo:EstimateSourceScheme",
+      "esea:ImplementationDescriptionScheme",
+    ],
   },
 ];
 

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -4,6 +4,7 @@ export interface Community {
   defaultAnnotations: string[];
   vocabularyUrl: string;
   contextUrl: string;
+  filterExcludedSchemes: string[];
 }
 
 export type Visibility = "public" | "restricted" | "hidden";

--- a/tests/components/filters/FilterCard.test.tsx
+++ b/tests/components/filters/FilterCard.test.tsx
@@ -73,14 +73,14 @@ describe("FilterCard", () => {
     expect(screen.getByText("3 selected")).toBeDefined();
   });
 
-  test("hides the summary once expanded", () => {
+  test("keeps the summary visible when expanded", () => {
     render(
       <FilterCard title="Document type" summary="3 selected">
         <div>child</div>
       </FilterCard>,
     );
     fireEvent.click(screen.getByRole("button", { name: /Document type/ }));
-    expect(screen.queryByText("3 selected")).toBeNull();
+    expect(screen.queryByText("3 selected")).not.toBeNull();
   });
 
   test("renders no summary node when prop is omitted", () => {

--- a/tests/components/filters/FilterDrawer.test.tsx
+++ b/tests/components/filters/FilterDrawer.test.tsx
@@ -58,6 +58,29 @@ describe("FilterDrawer", () => {
     ).toBeDefined();
   });
 
+  test("strips a trailing ' Scheme' from the scheme label", () => {
+    const scheme: ConceptScheme = {
+      uri: "https://vocab.esea.education/EducationLevelScheme",
+      label: "Education Level Scheme",
+      topConcepts: [{ uri: "x", label: "Primary" }],
+    };
+    render(
+      <FilterDrawer
+        open={true}
+        schemes={[scheme]}
+        appliedFacets={[]}
+        onApply={noop}
+        onCancel={noop}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /^Education Level/ }),
+    ).toBeDefined();
+    expect(
+      screen.queryByRole("button", { name: /Scheme/ }),
+    ).toBeNull();
+  });
+
   test("opens with Show results disabled when nothing is selected", () => {
     render(
       <FilterDrawer

--- a/tests/components/filters/FilterDrawer.test.tsx
+++ b/tests/components/filters/FilterDrawer.test.tsx
@@ -58,7 +58,7 @@ describe("FilterDrawer", () => {
     ).toBeDefined();
   });
 
-  test("opens with Update Results disabled when nothing is selected", () => {
+  test("opens with Show results disabled when nothing is selected", () => {
     render(
       <FilterDrawer
         open={true}
@@ -68,11 +68,11 @@ describe("FilterDrawer", () => {
         onCancel={noop}
       />,
     );
-    const apply = screen.getByRole("button", { name: "Update Results" });
+    const apply = screen.getByRole("button", { name: "Show results" });
     expect((apply as HTMLButtonElement).disabled).toBe(true);
   });
 
-  test("toggling a concept enables Update Results", () => {
+  test("toggling a concept enables Show results", () => {
     render(
       <FilterDrawer
         open={true}
@@ -83,11 +83,11 @@ describe("FilterDrawer", () => {
       />,
     );
     fireEvent.click(screen.getByLabelText("Journal Article"));
-    const apply = screen.getByRole("button", { name: "Update Results" });
+    const apply = screen.getByRole("button", { name: "Show results" });
     expect((apply as HTMLButtonElement).disabled).toBe(false);
   });
 
-  test("Update Results fires onApply with one facet entry per non-empty scheme", () => {
+  test("Show results fires onApply with one facet entry per non-empty scheme", () => {
     const onApply = vi.fn();
     render(
       <FilterDrawer
@@ -100,7 +100,7 @@ describe("FilterDrawer", () => {
     );
     fireEvent.click(screen.getByLabelText("Journal Article"));
     fireEvent.click(screen.getByLabelText("Returns to Education"));
-    fireEvent.click(screen.getByRole("button", { name: "Update Results" }));
+    fireEvent.click(screen.getByRole("button", { name: "Show results" }));
 
     expect(onApply).toHaveBeenCalledTimes(1);
     const facets = onApply.mock.calls[0][0] as string[];
@@ -125,7 +125,7 @@ describe("FilterDrawer", () => {
       />,
     );
     fireEvent.click(screen.getByLabelText("Access to Education"));
-    fireEvent.click(screen.getByRole("button", { name: "Update Results" }));
+    fireEvent.click(screen.getByRole("button", { name: "Show results" }));
 
     const facet = (onApply.mock.calls[0][0] as string[])[0];
     expect(facet).toContain(URI_ACCESS);
@@ -149,23 +149,23 @@ describe("FilterDrawer", () => {
       (screen.getByLabelText("Journal Article") as HTMLInputElement).checked,
     ).toBe(true);
 
-    fireEvent.click(screen.getByRole("button", { name: "Reset" }));
+    fireEvent.click(screen.getByRole("button", { name: "Reset all" }));
 
     expect(
       (screen.getByLabelText("Journal Article") as HTMLInputElement).checked,
     ).toBe(false);
     // Update Results re-greys because the draft is back to equal-to-applied.
     expect(
-      (screen.getByRole("button", { name: "Update Results" }) as HTMLButtonElement)
+      (screen.getByRole("button", { name: "Show results" }) as HTMLButtonElement)
         .disabled,
     ).toBe(true);
     // And Reset does not bubble out to Cancel.
     expect(onCancel).not.toHaveBeenCalled();
   });
 
-  test("Cancel button fires onCancel", () => {
+  test("Cancel button lives in the drawer header and fires onCancel", () => {
     const onCancel = vi.fn();
-    render(
+    const { container } = render(
       <FilterDrawer
         open={true}
         schemes={TWO_SCHEMES}
@@ -174,7 +174,10 @@ describe("FilterDrawer", () => {
         onCancel={onCancel}
       />,
     );
-    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    const cancel = screen.getByRole("button", { name: "Cancel" });
+    expect(container.querySelector(".filter-drawer__header")?.contains(cancel))
+      .toBe(true);
+    fireEvent.click(cancel);
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 
@@ -302,7 +305,7 @@ describe("FilterDrawer", () => {
         .checked,
     ).toBe(true);
     expect(
-      (screen.getByRole("button", { name: "Update Results" }) as HTMLButtonElement)
+      (screen.getByRole("button", { name: "Show results" }) as HTMLButtonElement)
         .disabled,
     ).toBe(true);
   });
@@ -320,7 +323,7 @@ describe("FilterDrawer", () => {
     );
     fireEvent.click(screen.getByLabelText("Educational Outcomes and Learning"));
     expect(
-      (screen.getByRole("button", { name: "Update Results" }) as HTMLButtonElement)
+      (screen.getByRole("button", { name: "Show results" }) as HTMLButtonElement)
         .disabled,
     ).toBe(false);
   });

--- a/tests/components/filters/conceptSchemeFilterState.test.ts
+++ b/tests/components/filters/conceptSchemeFilterState.test.ts
@@ -11,6 +11,7 @@ import {
   summary,
   toggleConcept,
   toSearchFacet,
+  totalSelectedCount,
 } from "@/components/filters/conceptSchemeFilterState";
 import type {
   Concept,
@@ -529,5 +530,33 @@ describe("parseFacets", () => {
     expect([...selectedUris(state)].sort()).toEqual(
       [URI_ACCESS, URI_LEARNING].sort(),
     );
+  });
+});
+
+describe("totalSelectedCount", () => {
+  test("returns 0 when no facets are applied", () => {
+    expect(totalSelectedCount([], [OUTCOME_SCHEME_FIXTURE])).toBe(0);
+  });
+
+  test("sums individual concept counts across schemes", () => {
+    const outcomeFragment = toSearchFacet(
+      conceptSchemeStateFromUris([URI_LEARNING, URI_RETURNS]),
+      OUTCOME_SCHEME_FIXTURE,
+    );
+    const docFragment = toSearchFacet(
+      conceptSchemeStateFromUris([URI_JOURNAL_ARTICLE]),
+      SCHEME,
+    );
+    expect(
+      totalSelectedCount([outcomeFragment, docFragment], [OUTCOME_SCHEME_FIXTURE, SCHEME]),
+    ).toBe(3);
+  });
+
+  test("counts every selected URI in a subtree (parent + descendants)", () => {
+    const fragment = toSearchFacet(
+      conceptSchemeStateFromUris([URI_ACCESS, URI_EDUCATION_FINANCE, URI_ENROLMENT]),
+      OUTCOME_SCHEME_FIXTURE,
+    );
+    expect(totalSelectedCount([fragment], [OUTCOME_SCHEME_FIXTURE])).toBe(3);
   });
 });

--- a/tests/components/search/SortDropdown.test.tsx
+++ b/tests/components/search/SortDropdown.test.tsx
@@ -9,9 +9,9 @@ describe("SortDropdown", () => {
     const select = screen.getByLabelText(/sort/i) as HTMLSelectElement;
     const labels = Array.from(select.options).map((o) => o.textContent);
     expect(labels).toEqual([
-      "Relevance",
-      "Publication year (newest)",
-      "Publication year (oldest)",
+      "Sort: Relevance",
+      "Sort: Publication year (newest)",
+      "Sort: Publication year (oldest)",
     ]);
   });
 

--- a/tests/pages/SearchPage.test.tsx
+++ b/tests/pages/SearchPage.test.tsx
@@ -450,7 +450,7 @@ describe("SearchPage", () => {
 
       fireEvent.click(screen.getByRole("button", { name: /Refine/ }));
       fireEvent.click(screen.getByLabelText("Returns to Education"));
-      fireEvent.click(screen.getByRole("button", { name: "Update Results" }));
+      fireEvent.click(screen.getByRole("button", { name: "Show results" }));
 
       await waitFor(() => {
         const q = new URLSearchParams(window.location.search).get("q") ?? "";
@@ -469,7 +469,7 @@ describe("SearchPage", () => {
       fireEvent.click(refine);
 
       fireEvent.click(screen.getByLabelText("Returns to Education"));
-      fireEvent.click(screen.getByRole("button", { name: "Update Results" }));
+      fireEvent.click(screen.getByRole("button", { name: "Show results" }));
 
       await waitFor(() => {
         const q = new URLSearchParams(window.location.search).get("q") ?? "";
@@ -484,7 +484,7 @@ describe("SearchPage", () => {
 
       fireEvent.click(screen.getByRole("button", { name: /Refine/ }));
       fireEvent.click(screen.getByLabelText("Access to Education"));
-      fireEvent.click(screen.getByRole("button", { name: "Update Results" }));
+      fireEvent.click(screen.getByRole("button", { name: "Show results" }));
 
       await waitFor(() => {
         const q = new URLSearchParams(window.location.search).get("q") ?? "";
@@ -505,8 +505,8 @@ describe("SearchPage", () => {
       fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
       expect(window.location.search).toBe(before);
-      // Drawer is gone — no Update Results / Cancel button left in the DOM.
-      expect(screen.queryByRole("button", { name: "Update Results" })).toBeNull();
+      // Drawer is gone — no Show results / Cancel button left in the DOM.
+      expect(screen.queryByRole("button", { name: "Show results" })).toBeNull();
     });
 
     test("Refine is hidden when vocabulary has no schemes", async () => {


### PR DESCRIPTION
Polish pass on the Filtering UI: relocate the Refine entry point, integrate the drawer's section cards with the panel, tidy up the meta-bar controls, and trim a few vocabulary schemes from the visible filter list.

## UI / cosmetic
- Move the Refine button from the search bar's year-range row into the results meta bar next to Sort, with a new `FilterIcon`.
- Move the drawer's Cancel button into the header (top-right) and rename the title/footer copy ("Refine the evidence", "Reset all", "Show results");
- Drop the per-card border, background, radius and shadow on FilterCards so they read as in-place sections separated by single dividers.
- Replace the Unicode `▸`/`▾` expansion glyphs with `ChevronRightIcon` / `ChevronDownIcon` SVGs that size to `1em` and inherit `currentColor`.
- Trim a trailing ` Scheme` from FilterCard titles so e.g. "Document Type Scheme" reads as "Document Type".
- Switch the Refine/Sort/Export controls to `--color-bg-surface` so they pop as clickable against the inset meta bar, and bump padding-y on all three to a common 7px so their heights align.
- Prefix every Sort option with `Sort: ` so the closed dropdown self-describes next to Refine.

## Behaviour
- Keep the FilterCard summary (e.g. "1 selected") visible when the card is expanded, separated from the title by a `·`.
- Keep the results meta bar visible when a Refine trigger is offered, so the button stays reachable in browse mode before the first result loads.
- Hide `EstimateSourceScheme` and `esea:ImplementationDescriptionScheme` from the drawer alongside the existing `EffectSizeMetricScheme` exclusion.
- Shrink the Refine count badge so it sits within the text line box — the button no longer changes height when filters are applied.
- Refine badge now counts individual selected concepts across the whole drawer (sum of each scheme's `selectedCount`) instead of the number of schemes with any selection — selecting 5 outcomes plus 1 document type now reads `6`, not `2`.
