### PR TITLE
Naive facet counts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -466,7 +465,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -490,7 +488,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1545,7 +1542,6 @@
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1782,7 +1778,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2991,7 +2986,6 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -3368,7 +3362,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
       "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -3469,7 +3462,6 @@
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -3947,7 +3939,6 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -5087,7 +5078,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/src/components/filters/ConceptSchemeFilter.css
+++ b/src/components/filters/ConceptSchemeFilter.css
@@ -32,6 +32,19 @@
   outline: none;
 }
 
+.concept-scheme-filter__count {
+  margin-left: auto;
+  padding-left: var(--spacing-sm);
+  color: var(--color-text-tertiary);
+  font-variant-numeric: tabular-nums;
+  font-size: var(--font-size-small);
+  transition: opacity 150ms ease;
+}
+
+.concept-scheme-filter__count.is-updating {
+  opacity: 0.5;
+}
+
 .concept-scheme-filter__children {
   list-style: none;
   margin: 0;

--- a/src/components/filters/ConceptSchemeFilter.css
+++ b/src/components/filters/ConceptSchemeFilter.css
@@ -41,6 +41,13 @@
   transition: opacity 150ms ease;
 }
 
+.concept-scheme-filter__count--parent {
+  text-decoration: underline dotted;
+  text-underline-offset: 2px;
+  cursor: help;
+  outline: none;
+}
+
 .concept-scheme-filter__count.is-updating {
   opacity: 0.5;
 }

--- a/src/components/filters/ConceptSchemeFilter.tsx
+++ b/src/components/filters/ConceptSchemeFilter.tsx
@@ -64,7 +64,7 @@ function ConceptItem({
   // rollup of descendants), which can confuse readers since clicking the
   // parent cascades into its subtree. Surface that semantic via a tooltip.
   const countTooltip = hasChildren
-    ? "Investigations tagged with this concept. Select to also include narrower concepts."
+    ? "Count shows investigations tagged with this concept. Select to also include narrower concepts."
     : undefined;
   const countNode = count !== undefined && (
     <span

--- a/src/components/filters/ConceptSchemeFilter.tsx
+++ b/src/components/filters/ConceptSchemeFilter.tsx
@@ -30,15 +30,12 @@ interface ConceptItemProps {
   onChange: (next: ConceptSchemeFilterState) => void;
 }
 
-// Compact-locale notation (1234 → "1.2K", 1_500_000 → "1.5M"). Honours the
-// browser locale via Intl rather than rolling our own k/M suffixes.
-const compactFormatter = new Intl.NumberFormat(undefined, {
-  notation: "compact",
-  maximumFractionDigits: 1,
-});
+// Locale-aware grouping (1234 → "1,234" in en-US, "1.234" in de-DE). Plain
+// Intl with no notation override; the browser picks the right separator.
+const countFormatter = new Intl.NumberFormat();
 
 function formatCount(n: number): string {
-  return compactFormatter.format(n);
+  return countFormatter.format(n);
 }
 
 function ConceptItem({
@@ -72,7 +69,7 @@ function ConceptItem({
   const countNode = count !== undefined && (
     <span
       class={countClass}
-      aria-label={`${count} references`}
+      aria-label={`${formatCount(count)} investigations`}
       tabIndex={hasChildren ? 0 : undefined}
     >
       {formatCount(count)}

--- a/src/components/filters/ConceptSchemeFilter.tsx
+++ b/src/components/filters/ConceptSchemeFilter.tsx
@@ -67,7 +67,7 @@ function ConceptItem({
   // rollup of descendants), which can confuse readers since clicking the
   // parent cascades into its subtree. Surface that semantic via a tooltip.
   const countTooltip = hasChildren
-    ? "References tagged with this concept. Select to also include narrower concepts."
+    ? "Investigations tagged with this concept. Select to also include narrower concepts."
     : undefined;
   const countNode = count !== undefined && (
     <span

--- a/src/components/filters/ConceptSchemeFilter.tsx
+++ b/src/components/filters/ConceptSchemeFilter.tsx
@@ -62,7 +62,22 @@ function ConceptItem({
   const count = counts?.get(concept.uri);
   const countClass = `concept-scheme-filter__count${
     countsLoading ? " is-updating" : ""
-  }`;
+  }${hasChildren ? " concept-scheme-filter__count--parent" : ""}`;
+  // Parent rows expose only the count for the parent URI itself (not a
+  // rollup of descendants), which can confuse readers since clicking the
+  // parent cascades into its subtree. Surface that semantic via a tooltip.
+  const countTooltip = hasChildren
+    ? "References tagged with this concept. Select to also include narrower concepts."
+    : undefined;
+  const countNode = count !== undefined && (
+    <span
+      class={countClass}
+      aria-label={`${count} references`}
+      tabIndex={hasChildren ? 0 : undefined}
+    >
+      {formatCount(count)}
+    </span>
+  );
   return (
     <li class="concept-scheme-filter__item">
       <label class="concept-scheme-filter__row">
@@ -77,11 +92,12 @@ function ConceptItem({
         ) : (
           labelNode
         )}
-        {count !== undefined && (
-          <span class={countClass} aria-label={`${count} references`}>
-            {formatCount(count)}
-          </span>
-        )}
+        {countNode &&
+          (countTooltip ? (
+            <Tooltip text={countTooltip}>{countNode}</Tooltip>
+          ) : (
+            countNode
+          ))}
       </label>
       {hasChildren && (
         <ul class="concept-scheme-filter__children">

--- a/src/components/filters/ConceptSchemeFilter.tsx
+++ b/src/components/filters/ConceptSchemeFilter.tsx
@@ -16,6 +16,8 @@ import "./ConceptSchemeFilter.css";
 interface ConceptSchemeFilterProps {
   scheme: ConceptScheme;
   state: ConceptSchemeFilterState;
+  counts?: ReadonlyMap<string, number> | null;
+  countsLoading?: boolean;
   onChange: (next: ConceptSchemeFilterState) => void;
 }
 
@@ -23,10 +25,30 @@ interface ConceptItemProps {
   concept: Concept;
   state: ConceptSchemeFilterState;
   index: ConceptIndex;
+  counts: ReadonlyMap<string, number> | null;
+  countsLoading: boolean;
   onChange: (next: ConceptSchemeFilterState) => void;
 }
 
-function ConceptItem({ concept, state, index, onChange }: ConceptItemProps) {
+// Compact-locale notation (1234 → "1.2K", 1_500_000 → "1.5M"). Honours the
+// browser locale via Intl rather than rolling our own k/M suffixes.
+const compactFormatter = new Intl.NumberFormat(undefined, {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+
+function formatCount(n: number): string {
+  return compactFormatter.format(n);
+}
+
+function ConceptItem({
+  concept,
+  state,
+  index,
+  counts,
+  countsLoading,
+  onChange,
+}: ConceptItemProps) {
   const hasDefinition = !!concept.definition;
   const labelClass = hasDefinition
     ? "concept-scheme-filter__label concept-scheme-filter__label--has-tooltip"
@@ -37,6 +59,10 @@ function ConceptItem({ concept, state, index, onChange }: ConceptItemProps) {
     </span>
   );
   const hasChildren = !!concept.narrower && concept.narrower.length > 0;
+  const count = counts?.get(concept.uri);
+  const countClass = `concept-scheme-filter__count${
+    countsLoading ? " is-updating" : ""
+  }`;
   return (
     <li class="concept-scheme-filter__item">
       <label class="concept-scheme-filter__row">
@@ -51,6 +77,11 @@ function ConceptItem({ concept, state, index, onChange }: ConceptItemProps) {
         ) : (
           labelNode
         )}
+        {count !== undefined && (
+          <span class={countClass} aria-label={`${count} references`}>
+            {formatCount(count)}
+          </span>
+        )}
       </label>
       {hasChildren && (
         <ul class="concept-scheme-filter__children">
@@ -60,6 +91,8 @@ function ConceptItem({ concept, state, index, onChange }: ConceptItemProps) {
               concept={child}
               state={state}
               index={index}
+              counts={counts}
+              countsLoading={countsLoading}
               onChange={onChange}
             />
           ))}
@@ -72,6 +105,8 @@ function ConceptItem({ concept, state, index, onChange }: ConceptItemProps) {
 export function ConceptSchemeFilter({
   scheme,
   state,
+  counts = null,
+  countsLoading = false,
   onChange,
 }: ConceptSchemeFilterProps) {
   const index = useMemo(() => buildConceptIndex(scheme), [scheme]);
@@ -83,6 +118,8 @@ export function ConceptSchemeFilter({
           concept={concept}
           state={state}
           index={index}
+          counts={counts}
+          countsLoading={countsLoading}
           onChange={onChange}
         />
       ))}

--- a/src/components/filters/FilterDrawer.css
+++ b/src/components/filters/FilterDrawer.css
@@ -53,6 +53,16 @@
   flex-direction: column;
 }
 
+.filter-drawer__notice {
+  margin: var(--spacing-xs) 0 var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-inset);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-small);
+}
+
 .filter-drawer__footer {
   display: flex;
   align-items: center;

--- a/src/components/filters/FilterDrawer.tsx
+++ b/src/components/filters/FilterDrawer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef, useState } from "preact/hooks";
+import { useEffect, useId, useMemo, useRef, useState } from "preact/hooks";
 import { FilterCard } from "./FilterCard";
 import { ConceptSchemeFilter } from "./ConceptSchemeFilter";
 import {
@@ -8,6 +8,8 @@ import {
   toSearchFacet,
   type ConceptSchemeFilterState,
 } from "./conceptSchemeFilterState";
+import { useSearchFacets } from "@/hooks/useSearchFacets";
+import type { SearchParams } from "@/services/searchParams";
 import type { ConceptScheme } from "@/services/vocabulary/vocabularyService";
 import "./FilterDrawer.css";
 
@@ -15,10 +17,9 @@ interface FilterDrawerProps {
   open: boolean;
   schemes: ConceptScheme[];
   appliedFacets: string[];
-  // null encodes "no facet data available yet" (initial load, error, or
-  // suppressed by parent). Drawer renders without counts in that case.
-  facetCounts?: ReadonlyMap<string, number> | null;
-  facetCountsLoading?: boolean;
+  // Drives the facet-count fetch alongside the draft. Owned by SearchPage as
+  // the source of truth for q / years / annotations.
+  params: SearchParams;
   onApply: (next: string[]) => void;
   onCancel: () => void;
 }
@@ -64,8 +65,7 @@ export function FilterDrawer({
   open,
   schemes,
   appliedFacets,
-  facetCounts = null,
-  facetCountsLoading = false,
+  params,
   onApply,
   onCancel,
 }: FilterDrawerProps) {
@@ -75,6 +75,20 @@ export function FilterDrawer({
   const panelRef = useRef<HTMLElement>(null);
   const previousFocusRef = useRef<Element | null>(null);
   const titleId = useId();
+
+  // Eager facet counts: every toggle changes `draft`, which retriggers the
+  // fetch via the hook's cache key. When closed, key off the URL state so
+  // mid-edit cancellations don't keep refetching from stale draft.
+  const draftFacets = useMemo(
+    () => draftToFacets(draft, schemes),
+    [draft, schemes],
+  );
+  const facetParams: SearchParams = {
+    ...params,
+    searchFacets: open ? draftFacets : appliedFacets,
+  };
+  const { counts: facetCounts, loading: facetCountsLoading } =
+    useSearchFacets(facetParams);
 
   // Reset draft from URL on each FilterDrawer open and capture pre-open focus.
   useEffect(() => {

--- a/src/components/filters/FilterDrawer.tsx
+++ b/src/components/filters/FilterDrawer.tsx
@@ -15,6 +15,10 @@ interface FilterDrawerProps {
   open: boolean;
   schemes: ConceptScheme[];
   appliedFacets: string[];
+  // null encodes "no facet data available yet" (initial load, error, or
+  // suppressed by parent). Drawer renders without counts in that case.
+  facetCounts?: ReadonlyMap<string, number> | null;
+  facetCountsLoading?: boolean;
   onApply: (next: string[]) => void;
   onCancel: () => void;
 }
@@ -60,6 +64,8 @@ export function FilterDrawer({
   open,
   schemes,
   appliedFacets,
+  facetCounts = null,
+  facetCountsLoading = false,
   onApply,
   onCancel,
 }: FilterDrawerProps) {
@@ -170,6 +176,11 @@ export function FilterDrawer({
             )
             .map((scheme) => {
             const state = draft.get(scheme.uri) ?? emptyConceptSchemeState();
+            // Per-scheme suppression: once any concept in this scheme is
+            // selected, the facet endpoint's counts become co-occurrence with
+            // that selection (siblings show ~0). Hide counts for the scheme
+            // until the user clears the selection.
+            const showCounts = state.size === 0 && facetCounts !== null;
             return (
               <FilterCard
                 key={scheme.uri}
@@ -179,6 +190,8 @@ export function FilterDrawer({
                 <ConceptSchemeFilter
                   scheme={scheme}
                   state={state}
+                  counts={showCounts ? facetCounts : null}
+                  countsLoading={facetCountsLoading}
                   onChange={(next) => onSchemeChange(scheme, next)}
                 />
               </FilterCard>

--- a/src/components/filters/FilterDrawer.tsx
+++ b/src/components/filters/FilterDrawer.tsx
@@ -29,10 +29,7 @@ type Draft = Map<string, ConceptSchemeFilterState>;
 // Serialise the drawer's per-scheme draft back into the wire format expected
 // by SearchParams.searchFacets — one entry per scheme that has at least one
 // concept selected.
-function draftToFacets(
-  draft: Draft,
-  schemes: ConceptScheme[],
-): string[] {
+function draftToFacets(draft: Draft, schemes: ConceptScheme[]): string[] {
   const facets: string[] = [];
   for (const scheme of schemes) {
     const state = draft.get(scheme.uri);
@@ -61,67 +58,71 @@ function schemeDisplayLabel(label: string): string {
   return label.replace(/\s+Scheme$/i, "");
 }
 
-export function FilterDrawer({
-  open,
+// Thin wrapper that gates rendering — and therefore hook execution — on
+// `open`. Keeping the hooks inside FilterDrawerPanel means we don't fire the
+// facet-count fetch (or any of the effects) until the drawer is actually
+// opened, so users who never refine don't pay the network cost.
+export function FilterDrawer({ open, ...rest }: FilterDrawerProps) {
+  if (!open) return null;
+  return <FilterDrawerPanel {...rest} />;
+}
+
+type FilterDrawerPanelProps = Omit<FilterDrawerProps, "open">;
+
+function FilterDrawerPanel({
   schemes,
   appliedFacets,
   params,
   onApply,
   onCancel,
-}: FilterDrawerProps) {
+}: FilterDrawerPanelProps) {
   const [draft, setDraft] = useState<Draft>(() =>
     parseFacets(appliedFacets, schemes),
   );
   const panelRef = useRef<HTMLElement>(null);
-  const previousFocusRef = useRef<Element | null>(null);
+  // Captured at mount (= drawer open). useRef's initial value runs once on
+  // mount, so this snapshots the focused element at the moment the user
+  // triggered open.
+  const previousFocusRef = useRef<Element | null>(document.activeElement);
   const titleId = useId();
 
   // Eager facet counts: every toggle changes `draft`, which retriggers the
-  // fetch via the hook's cache key. When closed, key off the URL state so
-  // mid-edit cancellations don't keep refetching from stale draft.
+  // fetch via the hook's cache key.
   const draftFacets = useMemo(
     () => draftToFacets(draft, schemes),
     [draft, schemes],
   );
   const facetParams: SearchParams = {
     ...params,
-    searchFacets: open ? draftFacets : appliedFacets,
+    searchFacets: draftFacets,
   };
-  const { counts: facetCounts, loading: facetCountsLoading } =
-    useSearchFacets(facetParams);
+  const {
+    counts: facetCounts,
+    loading: facetCountsLoading,
+    error: facetError,
+  } = useSearchFacets(facetParams);
 
-  // Reset draft from URL on each FilterDrawer open and capture pre-open focus.
+  // Lock body scroll while mounted; restore on unmount.
   useEffect(() => {
-    if (!open) return;
-    previousFocusRef.current = document.activeElement;
-    setDraft(parseFacets(appliedFacets, schemes));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open]);
-
-  // Lock body scroll while the modal is up;
-  useEffect(() => {
-    if (!open) return;
     const previous = document.body.style.overflow;
     document.body.style.overflow = "hidden";
     return () => {
       document.body.style.overflow = previous;
     };
-  }, [open]);
+  }, []);
 
-  // Focus the dialog panel itself on open (it carries tabindex=-1)
-  // Restore focus to wherever it was on close.
+  // Focus the dialog panel itself on mount (it carries tabindex=-1).
+  // Restore focus to wherever it was on unmount.
   useEffect(() => {
-    if (!open) return;
     panelRef.current?.focus();
     return () => {
       const target = previousFocusRef.current;
       if (target instanceof HTMLElement) target.focus();
     };
-  }, [open]);
+  }, []);
 
   // Escape dismisses the drawer (treated as Cancel).
   useEffect(() => {
-    if (!open) return;
     function handleKey(e: KeyboardEvent) {
       if (e.key === "Escape") {
         e.preventDefault();
@@ -130,9 +131,7 @@ export function FilterDrawer({
     }
     window.addEventListener("keydown", handleKey);
     return () => window.removeEventListener("keydown", handleKey);
-  }, [open, onCancel]);
-
-  if (!open) return null;
+  }, [onCancel]);
 
   function onSchemeChange(
     scheme: ConceptScheme,
@@ -181,6 +180,11 @@ export function FilterDrawer({
         </header>
 
         <div class="filter-drawer__body">
+          {facetError && (
+            <div class="filter-drawer__notice" role="status">
+              Investigation counts unavailable.
+            </div>
+          )}
           {schemes.map((scheme) => {
             const state = draft.get(scheme.uri) ?? emptyConceptSchemeState();
             // Per-scheme suppression: once any concept in this scheme is

--- a/src/hooks/useSearchFacets.ts
+++ b/src/hooks/useSearchFacets.ts
@@ -1,0 +1,81 @@
+import { useEffect, useState } from "preact/hooks";
+import { searchReferenceFacets } from "@/services/apiClient";
+import { buildFacetedQuery } from "@/services/searchParams";
+import { useCommunity } from "@/community/CommunityContext";
+import type { SearchParams } from "@/services/searchParams";
+
+// Cache key for the facets request. Mirrors useSearch's paramsKey but omits
+// `page` and `sort` — facet counts are invariant under both, so paging or
+// re-sorting must not retrigger the fetch.
+function paramsKey(
+  params: SearchParams,
+  slug: string,
+  annotations: string[],
+): string {
+  return [
+    `q=${params.q}`,
+    `start=${params.startYear ?? ""}`,
+    `end=${params.endYear ?? ""}`,
+    `slug=${slug}`,
+    `ann=${JSON.stringify(annotations)}`,
+    `facets=${JSON.stringify(params.searchFacets)}`,
+  ].join("&");
+}
+
+export function useSearchFacets(params: SearchParams): {
+  counts: ReadonlyMap<string, number> | null;
+  loading: boolean;
+  error: Error | null;
+} {
+  const community = useCommunity();
+  const key = paramsKey(
+    params,
+    community?.slug ?? "",
+    community?.defaultAnnotations ?? [],
+  );
+  const [counts, setCounts] = useState<ReadonlyMap<string, number> | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!community) return;
+    let cancelled = false;
+
+    // Mirror useSearch's dim-while-updating: keep prior counts visible while
+    // a new fetch is in flight so the drawer doesn't flicker on every search.
+    setError(null);
+    setLoading(true);
+
+    const wireQuery = buildFacetedQuery(params.q, params.searchFacets);
+    searchReferenceFacets(
+      wireQuery || undefined,
+      {
+        startYear: params.startYear,
+        endYear: params.endYear,
+        annotation: community.defaultAnnotations,
+      },
+      ["concepts"],
+    )
+      .then((r) => {
+        if (cancelled) return;
+        const map = new Map<string, number>();
+        for (const { concept, count } of r.concepts ?? []) {
+          map.set(concept, count);
+        }
+        setCounts(map);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(e);
+        setCounts(null);
+      })
+      .finally(() => { if (!cancelled) setLoading(false); });
+
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  if (!community) return { counts: null, loading: false, error: null };
+
+  return { counts, loading, error };
+}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -12,6 +12,7 @@ import { navigate } from "@/services/navigation";
 import { useUrlParams } from "@/hooks/useUrlParams";
 import { useCorpusTotal } from "@/hooks/useCorpusTotal";
 import { useSearch } from "@/hooks/useSearch";
+import { useSearchFacets } from "@/hooks/useSearchFacets";
 import { useSearchDraft } from "@/hooks/useSearchDraft";
 import { useSearchExport, type ExportStatus } from "@/hooks/useSearchExport";
 import { useVocabulary } from "@/hooks/useVocabulary";
@@ -135,6 +136,7 @@ function SearchPageInner({ community }: { community: Community }) {
 
   const corpus = useCorpusTotal();
   const results = useSearch(params);
+  const facets = useSearchFacets(params);
   const exportJob = useSearchExport();
 
   // Kick off the vocabulary fetch on page mount (not on drawer open) via the
@@ -387,6 +389,8 @@ function SearchPageInner({ community }: { community: Community }) {
           open={drawerOpen}
           schemes={vocab.schemes}
           appliedFacets={params.searchFacets}
+          facetCounts={facets.counts}
+          facetCountsLoading={facets.loading}
           onApply={handleApplyFacets}
           onCancel={() => setDrawerOpen(false)}
         />

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -12,7 +12,6 @@ import { navigate } from "@/services/navigation";
 import { useUrlParams } from "@/hooks/useUrlParams";
 import { useCorpusTotal } from "@/hooks/useCorpusTotal";
 import { useSearch } from "@/hooks/useSearch";
-import { useSearchFacets } from "@/hooks/useSearchFacets";
 import { useSearchDraft } from "@/hooks/useSearchDraft";
 import { useSearchExport, type ExportStatus } from "@/hooks/useSearchExport";
 import { useVocabulary } from "@/hooks/useVocabulary";
@@ -136,7 +135,6 @@ function SearchPageInner({ community }: { community: Community }) {
 
   const corpus = useCorpusTotal();
   const results = useSearch(params);
-  const facets = useSearchFacets(params);
   const exportJob = useSearchExport();
 
   // Kick off the vocabulary fetch on page mount (not on drawer open) via the
@@ -389,8 +387,7 @@ function SearchPageInner({ community }: { community: Community }) {
           open={drawerOpen}
           schemes={vocab.schemes}
           appliedFacets={params.searchFacets}
-          facetCounts={facets.counts}
-          facetCountsLoading={facets.loading}
+          params={params}
           onApply={handleApplyFacets}
           onCancel={() => setDrawerOpen(false)}
         />

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -1,5 +1,12 @@
 import { api } from "@/api/client";
-import type { Reference, SearchExportRead, SearchResult } from "@/types/models";
+import type {
+  Reference,
+  ReferenceFacetResult,
+  SearchExportRead,
+  SearchResult,
+} from "@/types/models";
+
+export type FacetType = "concepts";
 
 export interface SearchFilters {
   page?: number;
@@ -15,10 +22,12 @@ function isPositiveSafeInt(n: number | undefined): n is number {
   return n !== undefined && Number.isSafeInteger(n) && n >= 1;
 }
 
-export async function searchReferences(
+// Shared with the facets endpoint, which accepts the same q/year/annotation
+// filters but no page or sort. Browse-mode shim mirrors searchReferences.
+function buildSharedSearchParams(
   query: string | undefined,
-  filters: SearchFilters = {},
-): Promise<SearchResult> {
+  filters: Pick<SearchFilters, "startYear" | "endYear" | "annotation">,
+): URLSearchParams {
   const normalizedQuery = query?.trim();
   // Browse-mode shim: empty q would produce "(q) AND ..." on the backend,
   // which is an invalid Lucene query. "*" is match-anything.
@@ -27,12 +36,32 @@ export async function searchReferences(
 
   const params = new URLSearchParams();
   params.set("q", effectiveQuery);
-  if (isPositiveSafeInt(filters.page)) params.set("page", String(filters.page));
   if (isPositiveSafeInt(filters.startYear)) params.set("start_year", String(filters.startYear));
   if (isPositiveSafeInt(filters.endYear)) params.set("end_year", String(filters.endYear));
   for (const a of filters.annotation ?? []) params.append("annotation", a);
+  return params;
+}
+
+export async function searchReferences(
+  query: string | undefined,
+  filters: SearchFilters = {},
+): Promise<SearchResult> {
+  const params = buildSharedSearchParams(query, filters);
+  if (isPositiveSafeInt(filters.page)) params.set("page", String(filters.page));
   for (const s of filters.sort ?? []) params.append("sort", s);
   return api.get<SearchResult>(`/v1/references/search/?${params.toString()}`);
+}
+
+export async function searchReferenceFacets(
+  query: string | undefined,
+  filters: Pick<SearchFilters, "startYear" | "endYear" | "annotation">,
+  facets: FacetType[],
+): Promise<ReferenceFacetResult> {
+  const params = buildSharedSearchParams(query, filters);
+  for (const f of facets) params.append("facet", f);
+  return api.get<ReferenceFacetResult>(
+    `/v1/references/search/facets/?${params.toString()}`,
+  );
 }
 
 // Unlike searchReferences, no empty-q → "*" shim: the export endpoint is

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -24,6 +24,15 @@ export interface SearchResult {
   references: Reference[];
 }
 
+export interface ConceptFacetCount {
+  concept: string;
+  count: number;
+}
+
+export interface ReferenceFacetResult {
+  concepts?: ConceptFacetCount[];
+}
+
 export interface ExternalIdentifier {
   identifier: string | number;
   identifier_type: string | null;

--- a/tests/components/filters/ConceptSchemeFilter.test.tsx
+++ b/tests/components/filters/ConceptSchemeFilter.test.tsx
@@ -265,6 +265,38 @@ describe("ConceptSchemeFilter (hierarchical)", () => {
     ).toBeNull();
   });
 
+  test("wraps a parent concept's count in a Tooltip explaining the parent semantics", () => {
+    const counts = new Map<string, number>([
+      [URI_ACCESS, 774],
+      [URI_EDUCATION_FINANCE, 264],
+    ]);
+    const { container } = render(
+      <ConceptSchemeFilter
+        scheme={OUTCOME_SCHEME_FIXTURE}
+        state={emptyConceptSchemeState()}
+        counts={counts}
+        countsLoading={false}
+        onChange={vi.fn()}
+      />,
+    );
+    // Parent ("Access to Education") has children → count wrapped in Tooltip.
+    const parentCount = container.querySelector(
+      ".concept-scheme-filter__count--parent",
+    );
+    expect(parentCount).not.toBeNull();
+    expect(parentCount?.closest("[data-tooltip]")).not.toBeNull();
+
+    // Leaf ("Education Finance") has no children → bare count, no tooltip.
+    const counts2 = container.querySelectorAll(
+      ".concept-scheme-filter__count",
+    );
+    const leafCount = Array.from(counts2).find(
+      (n) => !n.classList.contains("concept-scheme-filter__count--parent"),
+    );
+    expect(leafCount).toBeDefined();
+    expect(leafCount?.closest('[data-tooltip]')).toBeNull();
+  });
+
   test("applies the is-updating class to counts while loading", () => {
     const counts = new Map<string, number>([[URI_ACCESS, 7]]);
     const { container } = render(

--- a/tests/components/filters/ConceptSchemeFilter.test.tsx
+++ b/tests/components/filters/ConceptSchemeFilter.test.tsx
@@ -207,7 +207,7 @@ describe("ConceptSchemeFilter (hierarchical)", () => {
     ).toBe(false);
   });
 
-  test("renders compact-formatted counts next to concepts when counts are provided", () => {
+  test("renders locale-grouped counts next to concepts when counts are provided", () => {
     const counts = new Map<string, number>([
       [URI_ACCESS, 12],
       [URI_EDUCATION_FINANCE, 1234],
@@ -221,6 +221,9 @@ describe("ConceptSchemeFilter (hierarchical)", () => {
         onChange={vi.fn()}
       />,
     );
+    // Compute the expected separator at test time so this passes regardless
+    // of the test runner's locale (en-US → "1,234", de-DE → "1.234").
+    const expected1234 = new Intl.NumberFormat().format(1234);
     // Count's aria-label augments the input's accessible name (deliberate, so
     // screen readers announce it) — match with a regex on the visible label.
     const accessRow = screen
@@ -230,7 +233,7 @@ describe("ConceptSchemeFilter (hierarchical)", () => {
     const financeRow = screen
       .getByLabelText(/^Education Finance/)
       .closest("label")!;
-    expect(financeRow.textContent).toMatch(/1\.2K/i);
+    expect(financeRow.textContent).toContain(expected1234);
   });
 
   test("omits the count when the URI is missing from the counts map", () => {

--- a/tests/components/filters/ConceptSchemeFilter.test.tsx
+++ b/tests/components/filters/ConceptSchemeFilter.test.tsx
@@ -207,6 +207,82 @@ describe("ConceptSchemeFilter (hierarchical)", () => {
     ).toBe(false);
   });
 
+  test("renders compact-formatted counts next to concepts when counts are provided", () => {
+    const counts = new Map<string, number>([
+      [URI_ACCESS, 12],
+      [URI_EDUCATION_FINANCE, 1234],
+    ]);
+    render(
+      <ConceptSchemeFilter
+        scheme={OUTCOME_SCHEME_FIXTURE}
+        state={emptyConceptSchemeState()}
+        counts={counts}
+        countsLoading={false}
+        onChange={vi.fn()}
+      />,
+    );
+    // Count's aria-label augments the input's accessible name (deliberate, so
+    // screen readers announce it) — match with a regex on the visible label.
+    const accessRow = screen
+      .getByLabelText(/^Access to Education/)
+      .closest("label")!;
+    expect(accessRow.textContent).toContain("12");
+    const financeRow = screen
+      .getByLabelText(/^Education Finance/)
+      .closest("label")!;
+    expect(financeRow.textContent).toMatch(/1\.2K/i);
+  });
+
+  test("omits the count when the URI is missing from the counts map", () => {
+    // Map has Access only; the others should render with no count node.
+    const counts = new Map<string, number>([[URI_ACCESS, 7]]);
+    const { container } = render(
+      <ConceptSchemeFilter
+        scheme={OUTCOME_SCHEME_FIXTURE}
+        state={emptyConceptSchemeState()}
+        counts={counts}
+        countsLoading={false}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(
+      container.querySelectorAll(".concept-scheme-filter__count"),
+    ).toHaveLength(1);
+  });
+
+  test("renders no count nodes when counts prop is null", () => {
+    const { container } = render(
+      <ConceptSchemeFilter
+        scheme={OUTCOME_SCHEME_FIXTURE}
+        state={emptyConceptSchemeState()}
+        counts={null}
+        countsLoading={false}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(
+      container.querySelector(".concept-scheme-filter__count"),
+    ).toBeNull();
+  });
+
+  test("applies the is-updating class to counts while loading", () => {
+    const counts = new Map<string, number>([[URI_ACCESS, 7]]);
+    const { container } = render(
+      <ConceptSchemeFilter
+        scheme={OUTCOME_SCHEME_FIXTURE}
+        state={emptyConceptSchemeState()}
+        counts={counts}
+        countsLoading={true}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(
+      container.querySelector(
+        ".concept-scheme-filter__count.is-updating",
+      ),
+    ).not.toBeNull();
+  });
+
   test("a nested concept's definition is surfaced via its own Tooltip", () => {
     const { container } = render(
       <ConceptSchemeFilter

--- a/tests/components/filters/FilterDrawer.test.tsx
+++ b/tests/components/filters/FilterDrawer.test.tsx
@@ -351,6 +351,116 @@ describe("FilterDrawer", () => {
     ).toBe(false);
   });
 
+  test("renders facet counts on schemes that have no selection", () => {
+    const counts = new Map<string, number>([[URI_JOURNAL, 42]]);
+    const { container } = render(
+      <FilterDrawer
+        open={true}
+        schemes={TWO_SCHEMES}
+        appliedFacets={[]}
+        facetCounts={counts}
+        facetCountsLoading={false}
+        onApply={noop}
+        onCancel={noop}
+      />,
+    );
+    expect(
+      container.querySelector(".concept-scheme-filter__count")?.textContent,
+    ).toBe("42");
+  });
+
+  // Per-scheme count nodes — querying the DOM directly because the count
+  // span's aria-label augments the input's accessible name in some
+  // testing-library versions but not others, making getByLabelText brittle.
+  function countNodesInSchemeContaining(
+    container: Element,
+    conceptLabel: string,
+  ): NodeListOf<Element> {
+    // Each FilterCard wraps one scheme. Find the card whose body contains
+    // the named concept, then return its count nodes.
+    const cards = container.querySelectorAll(".filter-card");
+    for (const card of cards) {
+      const labels = card.querySelectorAll(".concept-scheme-filter__label");
+      for (const label of labels) {
+        if (label.textContent === conceptLabel) {
+          return card.querySelectorAll(".concept-scheme-filter__count");
+        }
+      }
+    }
+    return container.querySelectorAll(":not(*)");
+  }
+
+  test("hides facet counts for a scheme once any concept in it is selected", () => {
+    // Hydrate the OutcomeScheme with one selection; counts for Outcome's
+    // concepts should disappear, but counts in the other scheme stay.
+    const appliedFacets = [`linked_data_concepts:"${URI_LEARNING}"`];
+    const counts = new Map<string, number>([
+      [URI_LEARNING, 100],
+      [URI_ACCESS, 50],
+      [URI_JOURNAL, 7],
+    ]);
+    const { container } = render(
+      <FilterDrawer
+        open={true}
+        schemes={TWO_SCHEMES}
+        appliedFacets={appliedFacets}
+        facetCounts={counts}
+        facetCountsLoading={false}
+        onApply={noop}
+        onCancel={noop}
+      />,
+    );
+    expect(
+      countNodesInSchemeContaining(container, "Access to Education").length,
+    ).toBe(0);
+    const journalCounts = countNodesInSchemeContaining(
+      container,
+      "Journal Article",
+    );
+    expect(journalCounts.length).toBe(1);
+    expect(journalCounts[0].textContent).toBe("7");
+  });
+
+  test("toggling a concept in a scheme suppresses that scheme's counts immediately", () => {
+    const counts = new Map<string, number>([
+      [URI_ACCESS, 50],
+      [URI_LEARNING, 100],
+      [URI_JOURNAL, 7],
+    ]);
+    const { container } = render(
+      <FilterDrawer
+        open={true}
+        schemes={TWO_SCHEMES}
+        appliedFacets={[]}
+        facetCounts={counts}
+        facetCountsLoading={false}
+        onApply={noop}
+        onCancel={noop}
+      />,
+    );
+    // Before: both schemes show their respective counts.
+    expect(
+      countNodesInSchemeContaining(container, "Access to Education").length,
+    ).toBeGreaterThan(0);
+    expect(
+      countNodesInSchemeContaining(container, "Journal Article").length,
+    ).toBe(1);
+
+    // Count's aria-label augments the input's accessible name, so an exact
+    // string match no longer hits — match a prefix.
+    fireEvent.click(
+      screen.getByLabelText(/^Educational Outcomes and Learning/),
+    );
+
+    // OutcomeScheme counts disappear; DocumentType scheme's count survives.
+    expect(
+      countNodesInSchemeContaining(container, "Access to Education").length,
+    ).toBe(0);
+    expect(
+      countNodesInSchemeContaining(container, "Journal Article").length,
+    ).toBe(1);
+  });
+
   test("re-hydrates when reopened after appliedFacets change", () => {
     const initial = [`linked_data_concepts:"${URI_LEARNING}"`];
     const { rerender } = render(

--- a/tests/components/filters/FilterDrawer.test.tsx
+++ b/tests/components/filters/FilterDrawer.test.tsx
@@ -1,7 +1,20 @@
-import { describe, test, expect, vi } from "vitest";
+import { describe, test, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, cleanup } from "@testing-library/preact";
+
+// Module-level mock so FilterDrawer's internal facet-count fetch is inert
+// across the suite; individual tests set the return when they care.
+vi.mock("@/hooks/useSearchFacets", () => ({
+  useSearchFacets: vi.fn(() => ({
+    counts: null,
+    loading: false,
+    error: null,
+  })),
+}));
+
 import { FilterDrawer } from "@/components/filters/FilterDrawer";
+import { useSearchFacets } from "@/hooks/useSearchFacets";
 import type { ConceptScheme } from "@/services/vocabulary/vocabularyService";
+import { makeSearchParams } from "../../fixtures";
 import {
   OUTCOME_SCHEME_FIXTURE,
   URI_ACCESS,
@@ -9,6 +22,24 @@ import {
   URI_ENROLMENT,
   URI_LEARNING,
 } from "./fixtures";
+
+const mockUseSearchFacets = vi.mocked(useSearchFacets);
+
+const defaultParams = makeSearchParams();
+
+function setCounts(counts: ReadonlyMap<string, number> | null, loading = false) {
+  mockUseSearchFacets.mockReturnValue({ counts, loading, error: null });
+}
+
+beforeEach(() => {
+  mockUseSearchFacets.mockReset();
+  // Default: no counts. Tests that need counts override via setCounts().
+  mockUseSearchFacets.mockReturnValue({
+    counts: null,
+    loading: false,
+    error: null,
+  });
+});
 
 // A second scheme exercises the multi-scheme rendering and the per-scheme
 // draft Map.
@@ -33,6 +64,7 @@ describe("FilterDrawer", () => {
         open={false}
         schemes={TWO_SCHEMES}
         appliedFacets={[]}
+        params={defaultParams}
         onApply={noop}
         onCancel={noop}
       />,
@@ -46,6 +78,7 @@ describe("FilterDrawer", () => {
         open={true}
         schemes={TWO_SCHEMES}
         appliedFacets={[]}
+        params={defaultParams}
         onApply={noop}
         onCancel={noop}
       />,
@@ -69,6 +102,7 @@ describe("FilterDrawer", () => {
         open={true}
         schemes={[scheme]}
         appliedFacets={[]}
+        params={defaultParams}
         onApply={noop}
         onCancel={noop}
       />,
@@ -87,6 +121,7 @@ describe("FilterDrawer", () => {
         open={true}
         schemes={TWO_SCHEMES}
         appliedFacets={[]}
+        params={defaultParams}
         onApply={noop}
         onCancel={noop}
       />,
@@ -101,6 +136,7 @@ describe("FilterDrawer", () => {
         open={true}
         schemes={TWO_SCHEMES}
         appliedFacets={[]}
+        params={defaultParams}
         onApply={noop}
         onCancel={noop}
       />,
@@ -117,6 +153,7 @@ describe("FilterDrawer", () => {
         open={true}
         schemes={TWO_SCHEMES}
         appliedFacets={[]}
+        params={defaultParams}
         onApply={onApply}
         onCancel={noop}
       />,
@@ -143,6 +180,7 @@ describe("FilterDrawer", () => {
         open={true}
         schemes={[OUTCOME_SCHEME_FIXTURE]}
         appliedFacets={[]}
+        params={defaultParams}
         onApply={onApply}
         onCancel={noop}
       />,
@@ -163,6 +201,7 @@ describe("FilterDrawer", () => {
         open={true}
         schemes={TWO_SCHEMES}
         appliedFacets={[]}
+        params={defaultParams}
         onApply={noop}
         onCancel={onCancel}
       />,
@@ -193,6 +232,7 @@ describe("FilterDrawer", () => {
         open={true}
         schemes={TWO_SCHEMES}
         appliedFacets={[]}
+        params={defaultParams}
         onApply={noop}
         onCancel={onCancel}
       />,
@@ -211,6 +251,7 @@ describe("FilterDrawer", () => {
         open={true}
         schemes={TWO_SCHEMES}
         appliedFacets={[]}
+        params={defaultParams}
         onApply={noop}
         onCancel={onCancel}
       />,
@@ -226,6 +267,7 @@ describe("FilterDrawer", () => {
         open={true}
         schemes={TWO_SCHEMES}
         appliedFacets={[]}
+        params={defaultParams}
         onApply={noop}
         onCancel={onCancel}
       />,
@@ -242,6 +284,7 @@ describe("FilterDrawer", () => {
         open={true}
         schemes={TWO_SCHEMES}
         appliedFacets={[]}
+        params={defaultParams}
         onApply={noop}
         onCancel={noop}
       />,
@@ -262,6 +305,7 @@ describe("FilterDrawer", () => {
         open={true}
         schemes={TWO_SCHEMES}
         appliedFacets={[]}
+        params={defaultParams}
         onApply={noop}
         onCancel={noop}
       />,
@@ -273,6 +317,7 @@ describe("FilterDrawer", () => {
         open={false}
         schemes={TWO_SCHEMES}
         appliedFacets={[]}
+        params={defaultParams}
         onApply={noop}
         onCancel={noop}
       />,
@@ -291,6 +336,7 @@ describe("FilterDrawer", () => {
         open={true}
         schemes={TWO_SCHEMES}
         appliedFacets={[]}
+        params={defaultParams}
         onApply={noop}
         onCancel={noop}
       />,
@@ -302,6 +348,7 @@ describe("FilterDrawer", () => {
         open={false}
         schemes={TWO_SCHEMES}
         appliedFacets={[]}
+        params={defaultParams}
         onApply={noop}
         onCancel={noop}
       />,
@@ -319,6 +366,7 @@ describe("FilterDrawer", () => {
         open={true}
         schemes={[OUTCOME_SCHEME_FIXTURE]}
         appliedFacets={appliedFacets}
+        params={defaultParams}
         onApply={noop}
         onCancel={noop}
       />,
@@ -340,6 +388,7 @@ describe("FilterDrawer", () => {
         open={true}
         schemes={[OUTCOME_SCHEME_FIXTURE]}
         appliedFacets={appliedFacets}
+        params={defaultParams}
         onApply={noop}
         onCancel={noop}
       />,
@@ -352,14 +401,13 @@ describe("FilterDrawer", () => {
   });
 
   test("renders facet counts on schemes that have no selection", () => {
-    const counts = new Map<string, number>([[URI_JOURNAL, 42]]);
+    setCounts(new Map<string, number>([[URI_JOURNAL, 42]]));
     const { container } = render(
       <FilterDrawer
         open={true}
         schemes={TWO_SCHEMES}
         appliedFacets={[]}
-        facetCounts={counts}
-        facetCountsLoading={false}
+        params={defaultParams}
         onApply={noop}
         onCancel={noop}
       />,
@@ -394,18 +442,17 @@ describe("FilterDrawer", () => {
     // Hydrate the OutcomeScheme with one selection; counts for Outcome's
     // concepts should disappear, but counts in the other scheme stay.
     const appliedFacets = [`linked_data_concepts:"${URI_LEARNING}"`];
-    const counts = new Map<string, number>([
+    setCounts(new Map<string, number>([
       [URI_LEARNING, 100],
       [URI_ACCESS, 50],
       [URI_JOURNAL, 7],
-    ]);
+    ]));
     const { container } = render(
       <FilterDrawer
         open={true}
         schemes={TWO_SCHEMES}
         appliedFacets={appliedFacets}
-        facetCounts={counts}
-        facetCountsLoading={false}
+        params={defaultParams}
         onApply={noop}
         onCancel={noop}
       />,
@@ -422,18 +469,17 @@ describe("FilterDrawer", () => {
   });
 
   test("toggling a concept in a scheme suppresses that scheme's counts immediately", () => {
-    const counts = new Map<string, number>([
+    setCounts(new Map<string, number>([
       [URI_ACCESS, 50],
       [URI_LEARNING, 100],
       [URI_JOURNAL, 7],
-    ]);
+    ]));
     const { container } = render(
       <FilterDrawer
         open={true}
         schemes={TWO_SCHEMES}
         appliedFacets={[]}
-        facetCounts={counts}
-        facetCountsLoading={false}
+        params={defaultParams}
         onApply={noop}
         onCancel={noop}
       />,
@@ -468,6 +514,7 @@ describe("FilterDrawer", () => {
         open={true}
         schemes={[OUTCOME_SCHEME_FIXTURE]}
         appliedFacets={initial}
+        params={defaultParams}
         onApply={noop}
         onCancel={noop}
       />,
@@ -484,6 +531,7 @@ describe("FilterDrawer", () => {
         open={false}
         schemes={[OUTCOME_SCHEME_FIXTURE]}
         appliedFacets={next}
+        params={defaultParams}
         onApply={noop}
         onCancel={noop}
       />,
@@ -493,6 +541,7 @@ describe("FilterDrawer", () => {
         open={true}
         schemes={[OUTCOME_SCHEME_FIXTURE]}
         appliedFacets={next}
+        params={defaultParams}
         onApply={noop}
         onCancel={noop}
       />,
@@ -506,5 +555,30 @@ describe("FilterDrawer", () => {
       (screen.getByLabelText("Educational Outcomes and Learning") as HTMLInputElement)
         .checked,
     ).toBe(false);
+  });
+
+  test("eager loading: toggling a concept re-keys the facet hook with the new draft", () => {
+    render(
+      <FilterDrawer
+        open={true}
+        schemes={TWO_SCHEMES}
+        appliedFacets={[]}
+        params={makeSearchParams({ q: "phonics" })}
+        onApply={noop}
+        onCancel={noop}
+      />,
+    );
+    // Pre-toggle: hook fired with empty facets.
+    const before = mockUseSearchFacets.mock.calls.at(-1)?.[0];
+    expect(before?.searchFacets).toEqual([]);
+    expect(before?.q).toBe("phonics");
+
+    fireEvent.click(screen.getByLabelText("Journal Article"));
+
+    // Post-toggle: the most recent call carries the freshly-drafted facet.
+    const after = mockUseSearchFacets.mock.calls.at(-1)?.[0];
+    expect(after?.searchFacets?.length).toBe(1);
+    expect(after?.searchFacets?.[0]).toContain(URI_JOURNAL);
+    expect(after?.q).toBe("phonics");
   });
 });

--- a/tests/hooks/useSearchFacets.test.tsx
+++ b/tests/hooks/useSearchFacets.test.tsx
@@ -1,0 +1,170 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/preact";
+import type { ComponentChildren } from "preact";
+import { useSearchFacets } from "@/hooks/useSearchFacets";
+import { CommunityProvider } from "@/community/CommunityContext";
+import type { ReferenceFacetResult } from "@/types/models";
+import { makeSearchParams } from "../fixtures";
+
+vi.mock("@/services/apiClient", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/services/apiClient")>();
+  return { ...actual, searchReferenceFacets: vi.fn() };
+});
+
+import { searchReferenceFacets } from "@/services/apiClient";
+const mockFacets = vi.mocked(searchReferenceFacets);
+
+const baseParams = makeSearchParams({ q: "phonics" });
+
+function withCommunityPath(path: string) {
+  window.history.replaceState(null, "", path);
+  return ({ children }: { children: ComponentChildren }) => (
+    <CommunityProvider>{children}</CommunityProvider>
+  );
+}
+
+function result(...pairs: [string, number][]): ReferenceFacetResult {
+  return { concepts: pairs.map(([concept, count]) => ({ concept, count })) };
+}
+
+beforeEach(() => {
+  mockFacets.mockReset();
+  window.history.replaceState(null, "", "/");
+});
+
+describe("useSearchFacets", () => {
+  test("fetches on mount with q + community annotations", async () => {
+    mockFacets.mockResolvedValue(result(["ex:A", 12]));
+    const { result: hook } = renderHook(() => useSearchFacets(baseParams), {
+      wrapper: withCommunityPath("/esea"),
+    });
+    await waitFor(() => expect(hook.current.loading).toBe(false));
+    expect(hook.current.counts?.get("ex:A")).toBe(12);
+    expect(mockFacets).toHaveBeenCalledWith(
+      "phonics",
+      expect.objectContaining({
+        annotation: ["domain-inclusion/jacobs-education"],
+      }),
+      ["concepts"],
+    );
+  });
+
+  test("converts the SDK response array to a Map keyed by concept URI", async () => {
+    mockFacets.mockResolvedValue(result(["ex:A", 1], ["ex:B", 2]));
+    const { result: hook } = renderHook(() => useSearchFacets(baseParams), {
+      wrapper: withCommunityPath("/esea"),
+    });
+    await waitFor(() => expect(hook.current.counts).not.toBeNull());
+    expect(hook.current.counts?.size).toBe(2);
+    expect(hook.current.counts?.get("ex:A")).toBe(1);
+    expect(hook.current.counts?.get("ex:B")).toBe(2);
+  });
+
+  test("handles a response with no concepts field as an empty Map", async () => {
+    mockFacets.mockResolvedValue({});
+    const { result: hook } = renderHook(() => useSearchFacets(baseParams), {
+      wrapper: withCommunityPath("/esea"),
+    });
+    await waitFor(() => expect(hook.current.loading).toBe(false));
+    expect(hook.current.counts).not.toBeNull();
+    expect(hook.current.counts?.size).toBe(0);
+  });
+
+  test("does NOT refetch when only page changes", async () => {
+    mockFacets.mockResolvedValue(result());
+    const { rerender } = renderHook(({ p }) => useSearchFacets(p), {
+      wrapper: withCommunityPath("/esea"),
+      initialProps: { p: baseParams },
+    });
+    await waitFor(() => expect(mockFacets).toHaveBeenCalledTimes(1));
+    rerender({ p: { ...baseParams, page: 5 } });
+    rerender({ p: { ...baseParams, page: 9 } });
+    expect(mockFacets).toHaveBeenCalledTimes(1);
+  });
+
+  test("does NOT refetch when only sort changes", async () => {
+    mockFacets.mockResolvedValue(result());
+    const { rerender } = renderHook(({ p }) => useSearchFacets(p), {
+      wrapper: withCommunityPath("/esea"),
+      initialProps: { p: baseParams },
+    });
+    await waitFor(() => expect(mockFacets).toHaveBeenCalledTimes(1));
+    rerender({ p: { ...baseParams, sort: "newest" as const } });
+    rerender({ p: { ...baseParams, sort: "oldest" as const } });
+    expect(mockFacets).toHaveBeenCalledTimes(1);
+  });
+
+  test("refetches when q changes", async () => {
+    mockFacets.mockResolvedValue(result());
+    const { rerender } = renderHook(({ p }) => useSearchFacets(p), {
+      wrapper: withCommunityPath("/esea"),
+      initialProps: { p: baseParams },
+    });
+    await waitFor(() => expect(mockFacets).toHaveBeenCalledTimes(1));
+    rerender({ p: { ...baseParams, q: "synthetic phonics" } });
+    await waitFor(() => expect(mockFacets).toHaveBeenCalledTimes(2));
+  });
+
+  test("refetches when facets change (counts are intersection-with-selection)", async () => {
+    mockFacets.mockResolvedValue(result());
+    const { rerender } = renderHook(({ p }) => useSearchFacets(p), {
+      wrapper: withCommunityPath("/esea"),
+      initialProps: { p: baseParams },
+    });
+    await waitFor(() => expect(mockFacets).toHaveBeenCalledTimes(1));
+    rerender({
+      p: {
+        ...baseParams,
+        searchFacets: ['linked_data_concepts:"ex:A"'],
+      },
+    });
+    await waitFor(() => expect(mockFacets).toHaveBeenCalledTimes(2));
+  });
+
+  test("preserves prior counts while a new fetch is in flight (dim-while-updating)", async () => {
+    const resolvers: ((v: ReferenceFacetResult) => void)[] = [];
+    mockFacets.mockImplementation(
+      () => new Promise<ReferenceFacetResult>((r) => { resolvers.push(r); }),
+    );
+
+    const { result: hook, rerender } = renderHook(
+      ({ p }) => useSearchFacets(p),
+      {
+        wrapper: withCommunityPath("/esea"),
+        initialProps: { p: baseParams },
+      },
+    );
+    resolvers[0](result(["ex:A", 10]));
+    await waitFor(() => expect(hook.current.counts?.get("ex:A")).toBe(10));
+
+    rerender({ p: { ...baseParams, q: "next" } });
+    expect(hook.current.counts?.get("ex:A")).toBe(10);
+    expect(hook.current.loading).toBe(true);
+
+    resolvers[1](result(["ex:A", 20]));
+    await waitFor(() => expect(hook.current.counts?.get("ex:A")).toBe(20));
+  });
+
+  test("clears counts to null on settled error", async () => {
+    mockFacets.mockRejectedValue(new Error("boom"));
+    const { result: hook } = renderHook(() => useSearchFacets(baseParams), {
+      wrapper: withCommunityPath("/esea"),
+    });
+    await waitFor(() => {
+      expect(hook.current.error?.message).toBe("boom");
+      expect(hook.current.counts).toBeNull();
+      expect(hook.current.loading).toBe(false);
+    });
+  });
+
+  test("idle (no fetch) when slug resolves to no community", () => {
+    mockFacets.mockResolvedValue(result());
+    const { result: hook } = renderHook(() => useSearchFacets(baseParams), {
+      wrapper: withCommunityPath("/banana"),
+    });
+    expect(hook.current.counts).toBeNull();
+    expect(hook.current.loading).toBe(false);
+    expect(hook.current.error).toBeNull();
+    expect(mockFacets).not.toHaveBeenCalled();
+  });
+});

--- a/tests/services/apiClient.test.ts
+++ b/tests/services/apiClient.test.ts
@@ -1,7 +1,15 @@
 import { vi } from "vitest";
 import { api } from "@/api/client";
-import { searchReferences, getReference } from "@/services/apiClient";
-import type { Reference, SearchResult } from "@/types/models";
+import {
+  searchReferences,
+  searchReferenceFacets,
+  getReference,
+} from "@/services/apiClient";
+import type {
+  Reference,
+  ReferenceFacetResult,
+  SearchResult,
+} from "@/types/models";
 
 vi.mock("@/api/client", () => ({
   api: {
@@ -134,6 +142,60 @@ describe("searchReferences", () => {
       "relevance",
       "-year",
     ]);
+  });
+});
+
+describe("searchReferenceFacets", () => {
+  const emptyResult: ReferenceFacetResult = { concepts: [] };
+
+  test("hits the /facets/ endpoint with q and one facet param", async () => {
+    mockedGet.mockResolvedValue(emptyResult);
+    await searchReferenceFacets("phonics", {}, ["concepts"]);
+    expect(mockedGet).toHaveBeenCalledWith(
+      "/v1/references/search/facets/?q=phonics&facet=concepts",
+    );
+  });
+
+  test("empty/whitespace query becomes browse-mode q=*", async () => {
+    mockedGet.mockResolvedValue(emptyResult);
+    await searchReferenceFacets("   ", {}, ["concepts"]);
+    const url = mockedGet.mock.calls[0][0];
+    expect(new URLSearchParams(url.split("?")[1]).get("q")).toBe("*");
+  });
+
+  test("forwards year and annotation filters; never sends page or sort", async () => {
+    mockedGet.mockResolvedValue(emptyResult);
+    await searchReferenceFacets(
+      "phonics",
+      { startYear: 2010, endYear: 2020, annotation: ["a", "b"] },
+      ["concepts"],
+    );
+    const url = mockedGet.mock.calls[0][0];
+    const params = new URLSearchParams(url.split("?")[1]);
+    expect(params.get("start_year")).toBe("2010");
+    expect(params.get("end_year")).toBe("2020");
+    expect(params.getAll("annotation")).toEqual(["a", "b"]);
+    expect(params.has("page")).toBe(false);
+    expect(params.has("sort")).toBe(false);
+  });
+
+  test("appends one facet param per requested facet", async () => {
+    mockedGet.mockResolvedValue(emptyResult);
+    await searchReferenceFacets("x", {}, ["concepts", "concepts"]);
+    const url = mockedGet.mock.calls[0][0];
+    expect(new URLSearchParams(url.split("?")[1]).getAll("facet")).toEqual([
+      "concepts",
+      "concepts",
+    ]);
+  });
+
+  test("returns the result from api.get", async () => {
+    const result: ReferenceFacetResult = {
+      concepts: [{ concept: "ex:A", count: 5 }],
+    };
+    mockedGet.mockResolvedValue(result);
+    const res = await searchReferenceFacets("x", {}, ["concepts"]);
+    expect(res).toBe(result);
   });
 });
 


### PR DESCRIPTION
Closes #73 

Adds the naive facet counts from https://github.com/destiny-evidence/destiny-repository/pull/705 to the UI drawer.

Fast follow of https://github.com/destiny-evidence/destiny-repository/issues/703 will vastly improve the UX, but this provides a solid base for initial exploration.