### PR TITLE
Clearer UX when refining a draft search

### DIFF
--- a/src/components/filters/ConceptSchemeFilter.tsx
+++ b/src/components/filters/ConceptSchemeFilter.tsx
@@ -30,8 +30,6 @@ interface ConceptItemProps {
   onChange: (next: ConceptSchemeFilterState) => void;
 }
 
-// Locale-aware grouping (1234 → "1,234" in en-US, "1.234" in de-DE). Plain
-// Intl with no notation override; the browser picks the right separator.
 const countFormatter = new Intl.NumberFormat();
 
 function formatCount(n: number): string {
@@ -60,9 +58,6 @@ function ConceptItem({
   const countClass = `concept-scheme-filter__count${
     countsLoading ? " is-updating" : ""
   }${hasChildren ? " concept-scheme-filter__count--parent" : ""}`;
-  // Parent rows expose only the count for the parent URI itself (not a
-  // rollup of descendants), which can confuse readers since clicking the
-  // parent cascades into its subtree. Surface that semantic via a tooltip.
   const countTooltip = hasChildren
     ? "Count shows investigations tagged with this concept. Select to also include narrower concepts."
     : undefined;

--- a/src/components/filters/FilterDrawer.css
+++ b/src/components/filters/FilterDrawer.css
@@ -34,11 +34,33 @@
   border-bottom: 1px solid var(--color-border);
 }
 
+.filter-drawer__heading {
+  /* Stack title + subtitle vertically; the heading is one flex item in the
+     header row, so Cancel stays anchored on the right regardless of whether
+     the subtitle renders. min-width:0 lets the subtitle truncate cleanly. */
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
 .filter-drawer__title {
   margin: 0;
   font-size: var(--font-size-xl);
   font-weight: 600;
   color: var(--color-text-primary);
+}
+
+.filter-drawer__subtitle {
+  margin: 0;
+  font-size: var(--font-size-small);
+  color: var(--color-text-tertiary);
+  /* Long queries wrap so the user always sees what they searched for; the
+     drawer body scrolls, so a taller header is recoverable. word-break
+     covers degenerate inputs (pasted URLs, no spaces) that would otherwise
+     overflow the panel horizontally. */
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .filter-drawer__panel:focus {

--- a/src/components/filters/FilterDrawer.css
+++ b/src/components/filters/FilterDrawer.css
@@ -35,9 +35,6 @@
 }
 
 .filter-drawer__heading {
-  /* Stack title + subtitle vertically; the heading is one flex item in the
-     header row, so Cancel stays anchored on the right regardless of whether
-     the subtitle renders. min-width:0 lets the subtitle truncate cleanly. */
   display: flex;
   flex-direction: column;
   gap: 2px;
@@ -55,10 +52,7 @@
   margin: 0;
   font-size: var(--font-size-small);
   color: var(--color-text-tertiary);
-  /* Long queries wrap so the user always sees what they searched for; the
-     drawer body scrolls, so a taller header is recoverable. word-break
-     covers degenerate inputs (pasted URLs, no spaces) that would otherwise
-     overflow the panel horizontally. */
+  /* Break unbroken strings (pasted URLs) so they don't overflow the panel. */
   overflow-wrap: anywhere;
   word-break: break-word;
 }

--- a/src/components/filters/FilterDrawer.tsx
+++ b/src/components/filters/FilterDrawer.tsx
@@ -167,9 +167,15 @@ function FilterDrawerPanel({
         tabIndex={-1}
       >
         <header class="filter-drawer__header">
-          <h2 id={titleId} class="filter-drawer__title">
-            Refine the evidence
-          </h2>
+          <div class="filter-drawer__heading">
+            <h2 id={titleId} class="filter-drawer__title">
+              Refine the evidence
+            </h2>
+            {/* "*" is the browse-mode sentinel — don't echo it as a query. */}
+            {params.q !== "" && params.q !== "*" && (
+              <p class="filter-drawer__subtitle">Searching for “{params.q}”</p>
+            )}
+          </div>
           <button
             type="button"
             class="filter-drawer__btn filter-drawer__btn--cancel"

--- a/src/components/filters/FilterDrawer.tsx
+++ b/src/components/filters/FilterDrawer.tsx
@@ -58,10 +58,7 @@ function schemeDisplayLabel(label: string): string {
   return label.replace(/\s+Scheme$/i, "");
 }
 
-// Thin wrapper that gates rendering — and therefore hook execution — on
-// `open`. Keeping the hooks inside FilterDrawerPanel means we don't fire the
-// facet-count fetch (or any of the effects) until the drawer is actually
-// opened, so users who never refine don't pay the network cost.
+// Gates hook execution on `open` — users who never refine don't fetch facets.
 export function FilterDrawer({ open, ...rest }: FilterDrawerProps) {
   if (!open) return null;
   return <FilterDrawerPanel {...rest} />;
@@ -80,14 +77,9 @@ function FilterDrawerPanel({
     parseFacets(appliedFacets, schemes),
   );
   const panelRef = useRef<HTMLElement>(null);
-  // Captured at mount (= drawer open). useRef's initial value runs once on
-  // mount, so this snapshots the focused element at the moment the user
-  // triggered open.
   const previousFocusRef = useRef<Element | null>(document.activeElement);
   const titleId = useId();
 
-  // Eager facet counts: every toggle changes `draft`, which retriggers the
-  // fetch via the hook's cache key.
   const draftFacets = useMemo(
     () => draftToFacets(draft, schemes),
     [draft, schemes],
@@ -102,7 +94,6 @@ function FilterDrawerPanel({
     error: facetError,
   } = useSearchFacets(facetParams);
 
-  // Lock body scroll while mounted; restore on unmount.
   useEffect(() => {
     const previous = document.body.style.overflow;
     document.body.style.overflow = "hidden";
@@ -111,8 +102,6 @@ function FilterDrawerPanel({
     };
   }, []);
 
-  // Focus the dialog panel itself on mount (it carries tabindex=-1).
-  // Restore focus to wherever it was on unmount.
   useEffect(() => {
     panelRef.current?.focus();
     return () => {
@@ -121,7 +110,6 @@ function FilterDrawerPanel({
     };
   }, []);
 
-  // Escape dismisses the drawer (treated as Cancel).
   useEffect(() => {
     function handleKey(e: KeyboardEvent) {
       if (e.key === "Escape") {
@@ -193,10 +181,8 @@ function FilterDrawerPanel({
           )}
           {schemes.map((scheme) => {
             const state = draft.get(scheme.uri) ?? emptyConceptSchemeState();
-            // Per-scheme suppression: once any concept in this scheme is
-            // selected, the facet endpoint's counts become co-occurrence with
-            // that selection (siblings show ~0). Hide counts for the scheme
-            // until the user clears the selection.
+            // Counts intersect with selected concepts, so siblings of a
+            // selection drop to ~0; hide per-scheme once anything's picked.
             const showCounts = state.size === 0 && facetCounts !== null;
             return (
               <FilterCard

--- a/src/hooks/useSearchFacets.ts
+++ b/src/hooks/useSearchFacets.ts
@@ -4,9 +4,7 @@ import { buildFacetedQuery } from "@/services/searchParams";
 import { useCommunity } from "@/community/CommunityContext";
 import type { SearchParams } from "@/services/searchParams";
 
-// Cache key for the facets request. Mirrors useSearch's paramsKey but omits
-// `page` and `sort` — facet counts are invariant under both, so paging or
-// re-sorting must not retrigger the fetch.
+// Omits `page` and `sort` — facet counts are invariant under both.
 function paramsKey(
   params: SearchParams,
   slug: string,
@@ -41,8 +39,7 @@ export function useSearchFacets(params: SearchParams): {
     if (!community) return;
     let cancelled = false;
 
-    // Mirror useSearch's dim-while-updating: keep prior counts visible while
-    // a new fetch is in flight so the drawer doesn't flicker on every search.
+    // Keep prior counts visible while refetching (dim-while-updating).
     setError(null);
     setLoading(true);
 

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -155,10 +155,29 @@ function SearchPageInner({ community }: { community: Community }) {
     [vocab.schemes, community.filterExcludedSchemes],
   );
 
+  // Treat clicking Refine like submitting the search bar: commit any
+  // pending q / year edits before opening the drawer, so facet counts
+  // and the post-Apply navigation reflect what the user has typed.
+  // Validation errors short-circuit and keep the drawer closed.
+  function handleOpenDrawer() {
+    const committed = draft.commitDraft();
+    if (!committed) return;
+    const changed =
+      params.q !== committed.q ||
+      params.startYear !== committed.startYear ||
+      params.endYear !== committed.endYear;
+    if (changed) {
+      navigate(
+        buildSearchUrl(community.slug, { ...params, ...committed, page: 1 }),
+      );
+    }
+    setDrawerOpen(true);
+  }
+
   const refine = buildRefineConfig(
     vocab,
     totalSelectedCount(params.searchFacets, filterableSchemes),
-    () => setDrawerOpen(true),
+    handleOpenDrawer,
   );
 
   function handleApplyFacets(nextFacets: string[]) {

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -22,8 +22,6 @@ function isPositiveSafeInt(n: number | undefined): n is number {
   return n !== undefined && Number.isSafeInteger(n) && n >= 1;
 }
 
-// Shared with the facets endpoint, which accepts the same q/year/annotation
-// filters but no page or sort. Browse-mode shim mirrors searchReferences.
 function buildSharedSearchParams(
   query: string | undefined,
   filters: Pick<SearchFilters, "startYear" | "endYear" | "annotation">,

--- a/tests/components/filters/FilterDrawer.test.tsx
+++ b/tests/components/filters/FilterDrawer.test.tsx
@@ -91,6 +91,50 @@ describe("FilterDrawer", () => {
     ).toBeDefined();
   });
 
+  test("shows a subtitle nudge with the current query when params.q is set", () => {
+    const { container } = render(
+      <FilterDrawer
+        open={true}
+        schemes={TWO_SCHEMES}
+        appliedFacets={[]}
+        params={makeSearchParams({ q: "phonics" })}
+        onApply={noop}
+        onCancel={noop}
+      />,
+    );
+    // Bind on the class and the query value, not the surrounding wording —
+    // the prose around the query is expected to iterate.
+    const subtitle = container.querySelector(".filter-drawer__subtitle");
+    expect(subtitle).not.toBeNull();
+    expect(subtitle?.textContent).toContain("phonics");
+  });
+
+  test("hides the subtitle nudge in browse mode (empty q or '*')", () => {
+    const { rerender, container } = render(
+      <FilterDrawer
+        open={true}
+        schemes={TWO_SCHEMES}
+        appliedFacets={[]}
+        params={defaultParams}
+        onApply={noop}
+        onCancel={noop}
+      />,
+    );
+    expect(container.querySelector(".filter-drawer__subtitle")).toBeNull();
+
+    rerender(
+      <FilterDrawer
+        open={true}
+        schemes={TWO_SCHEMES}
+        appliedFacets={[]}
+        params={makeSearchParams({ q: "*" })}
+        onApply={noop}
+        onCancel={noop}
+      />,
+    );
+    expect(container.querySelector(".filter-drawer__subtitle")).toBeNull();
+  });
+
   test("strips a trailing ' Scheme' from the scheme label", () => {
     const scheme: ConceptScheme = {
       uri: "https://vocab.esea.education/EducationLevelScheme",

--- a/tests/pages/SearchPage.test.tsx
+++ b/tests/pages/SearchPage.test.tsx
@@ -418,6 +418,46 @@ describe("SearchPage", () => {
       mockVocab.mockReturnValue(vocabWith([OUTCOME_SCHEME_FIXTURE]));
     });
 
+    test("clicking Refine commits the search bar draft (q + years) to the URL before opening", async () => {
+      mockBoth({ results: makeResult(120, ["r1"]) });
+      renderSearchPage();
+      await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
+
+      // Type into the search bar but don't press Enter.
+      fireEvent.input(screen.getByRole("searchbox"), {
+        target: { value: "phonics" },
+      });
+      // URL hasn't changed yet — draft is still uncommitted.
+      expect(new URLSearchParams(window.location.search).get("q")).toBeNull();
+
+      fireEvent.click(screen.getByRole("button", { name: /Refine/ }));
+
+      // Refine commits the draft, navigating to the searched URL, then opens
+      // the drawer (Show results button is the visible witness).
+      await waitFor(() => {
+        expect(new URLSearchParams(window.location.search).get("q")).toBe(
+          "phonics",
+        );
+      });
+      expect(screen.getByRole("button", { name: "Show results" })).toBeDefined();
+    });
+
+    test("clicking Refine with an invalid year range does NOT open the drawer", async () => {
+      mockBoth({ results: makeResult(120, ["r1"]) });
+      renderSearchPage();
+      await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());
+
+      // Start year after end year — commitDraft returns null.
+      const [startInput, endInput] = screen.getAllByPlaceholderText("YYYY");
+      fireEvent.input(startInput, { target: { value: "2020" } });
+      fireEvent.input(endInput, { target: { value: "2010" } });
+
+      fireEvent.click(screen.getByRole("button", { name: /Refine/ }));
+
+      // Drawer didn't open — no Show results button in the DOM.
+      expect(screen.queryByRole("button", { name: "Show results" })).toBeNull();
+    });
+
     test("URL with one facet → Refine shows count 1 and drawer opens with concept pre-checked", async () => {
       const startQ = `* AND (linked_data_concepts:"${URI_LEARNING}")`;
       history.replaceState(null, "", `/esea?q=${encodeURIComponent(startQ)}`);


### PR DESCRIPTION
Fast follow on #73:
- Apply search draft to facet counts to reflect what the refining will actually do
- Show search draft in the drawer to nudge users toward what is happening

<img width="1250" height="892" alt="image" src="https://github.com/user-attachments/assets/da34486e-efde-411f-a106-1fbca1224b7e" />