### PR TITLE
Lift suppression of evrepo: schemes from Refine drawer

### DIFF
--- a/src/services/communities.ts
+++ b/src/services/communities.ts
@@ -23,11 +23,7 @@ const COMMUNITIES: Community[] = [
       "VITE_ESEA_CONTEXT_URL",
       import.meta.env.VITE_ESEA_CONTEXT_URL,
     ),
-    filterExcludedSchemes: [
-      "evrepo:EffectSizeMetricScheme",
-      "evrepo:EstimateSourceScheme",
-      "esea:ImplementationDescriptionScheme",
-    ],
+    filterExcludedSchemes: ["esea:ImplementationDescriptionScheme"],
   },
 ];
 


### PR DESCRIPTION
PR #83 (Jack, 2026-05-25) suppressed `evrepo:EffectSizeMetricScheme`
and `evrepo:EstimateSourceScheme` from the Refine drawer as a stopgap.
The two schemes' concept URIs were missing from `linked_data_concepts`
in ES because `LinkedDataProjectionService` walked only
`evrepo:codedValue` triples and missed the bare-`@id` references on
`EffectEstimate`.

The backend fix landed in destiny-repository PR #711 (jaybe, merged
2026-05-27). The projection now does a second-pass walk over
`EffectEstimate.effectSizeMetric` and `EffectEstimate.estimateSource`.

This PR removes the two entries from `filterExcludedSchemes` so the
schemes reappear in the drawer with vocab-resolved labels and counts.

## DO NOT DEPLOY TO PROD UNTIL ES IS RE-INDEXED

The prod ES has not been re-indexed since DR #711 merged. Probed
2026-05-28: prod returns 0 results for
`linked_data_concepts:"https://vocab.evidence-repository.org/EffectSizeMetricScheme/hedgesG"`
while local DR (re-indexed against #711's code) returns 3,451. The
control query for a known-populated ESEA concept returns 10,000+, so
the prod-side 0 is real data absence, not a query syntax issue.

Deploying this PR before the prod reindex would surface empty Effect
Size Metric / Estimate Source facets with no counts and zero results,
recreating exactly the dead-end #83 was working around.

**Before merging and deploying:** re-run the same prod URL search probe.
The signal is non-zero, not a specific magnitude. Local validation
showed 3,451 for hedgesG, but the prod corpus has different
deduplication and dataset loading than the dev environment, so the
prod count will differ. Only deploy when the probe is non-zero.

## Validation performed

- Local DR (port 8000) returned ``total.count: 3451`` for the
  ``EffectSizeMetricScheme/hedgesG`` Lucene query, confirming DR #711's
  projection code produces the expected concept URIs when re-indexed.
- Live UI verification on ``localhost:3000/esea``: Refine drawer renders
  the Effect Size Metric scheme with vocab-resolved labels and
  per-concept counts (Hedges' g 3,451; Mean difference 2,309;
  Correlation (r) 11; Odds ratio 7; four other concepts blank).
  Estimate Source is unblocked by the same code path. Local counts
  reflect a dev corpus that differs from staging/prod in deduplication
  and dataset; the qualitative confirmation (schemes appear, labels
  resolve, counts wire through end-to-end) is what's verified, not the
  specific magnitudes.
- Prod search returned ``0 results`` for the same query, confirming the
  prod reindex has not yet run.
- Prod control query for ``DocumentTypeScheme/C00008`` (Journal Article)
  returned 10,000+ results, confirming Lucene field syntax is sound.
- ``npm run typecheck`` clean.
- ``npm test`` green (653 tests passing; communities tests unchanged;
  no new tests added since this is a config delta).

<img width="402" height="343" alt="image" src="https://github.com/user-attachments/assets/90c730e8-d702-4491-b856-a77965c7cecf" />