### PR TITLE
Add HPV community

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,6 @@ VITE_KEYCLOAK_CLIENT_ID=evidence-repo-ui-client-development
 VITE_FEEDBACK_FORM_URL=https://forms.gle/zH9fsNZk8BApTaVj9
 VITE_ESEA_VOCABULARY_URL=https://vocab.staging.evidence-repository.org/published/019d40cf-2a63-77af-9828-c6a70647792c/1.1/vocabulary.jsonld
 VITE_ESEA_CONTEXT_URL=https://vocab.staging.evidence-repository.org/published/019d40cf-2a63-77af-9828-c6a70647792c/1.1/context.jsonld
-# HPV vocabulary is not yet published — these are placeholders; update once the
-# HPV JSON-LD source lands (#106 / #103).
+# HPV vocabulary is not yet published — these are placeholders
 VITE_HPV_VOCABULARY_URL=https://vocab.staging.evidence-repository.org/published/TODO-hpv/1.0/vocabulary.jsonld
 VITE_HPV_CONTEXT_URL=https://vocab.staging.evidence-repository.org/published/TODO-hpv/1.0/context.jsonld

--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,7 @@ VITE_KEYCLOAK_CLIENT_ID=evidence-repo-ui-client-development
 VITE_FEEDBACK_FORM_URL=https://forms.gle/zH9fsNZk8BApTaVj9
 VITE_ESEA_VOCABULARY_URL=https://vocab.staging.evidence-repository.org/published/019d40cf-2a63-77af-9828-c6a70647792c/1.1/vocabulary.jsonld
 VITE_ESEA_CONTEXT_URL=https://vocab.staging.evidence-repository.org/published/019d40cf-2a63-77af-9828-c6a70647792c/1.1/context.jsonld
+# HPV vocabulary is not yet published — these are placeholders; update once the
+# HPV JSON-LD source lands (#106 / #103).
+VITE_HPV_VOCABULARY_URL=https://vocab.staging.evidence-repository.org/published/TODO-hpv/1.0/vocabulary.jsonld
+VITE_HPV_CONTEXT_URL=https://vocab.staging.evidence-repository.org/published/TODO-hpv/1.0/context.jsonld

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,6 +55,8 @@ jobs:
           VITE_FEEDBACK_FORM_URL: ${{ vars.VITE_FEEDBACK_FORM_URL }}
           VITE_ESEA_VOCABULARY_URL: ${{ vars.VITE_ESEA_VOCABULARY_URL }}
           VITE_ESEA_CONTEXT_URL: ${{ vars.VITE_ESEA_CONTEXT_URL }}
+          VITE_HPV_VOCABULARY_URL: ${{ vars.VITE_HPV_VOCABULARY_URL }}
+          VITE_HPV_CONTEXT_URL: ${{ vars.VITE_HPV_CONTEXT_URL }}
         run: npm run build
 
       - name: Upload build artifacts

--- a/infra/app/github_actions.tf
+++ b/infra/app/github_actions.tf
@@ -137,6 +137,20 @@ resource "github_actions_environment_variable" "vite_esea_context_url" {
   value         = var.esea_context_url
 }
 
+resource "github_actions_environment_variable" "vite_hpv_vocabulary_url" {
+  repository    = github_repository_environment.environment.repository
+  environment   = github_repository_environment.environment.environment
+  variable_name = "VITE_HPV_VOCABULARY_URL"
+  value         = var.hpv_vocabulary_url
+}
+
+resource "github_actions_environment_variable" "vite_hpv_context_url" {
+  repository    = github_repository_environment.environment.repository
+  environment   = github_repository_environment.environment.environment
+  variable_name = "VITE_HPV_CONTEXT_URL"
+  value         = var.hpv_context_url
+}
+
 resource "github_actions_environment_variable" "frontdoor_resource_group" {
   repository    = github_repository_environment.environment.repository
   environment   = github_repository_environment.environment.environment

--- a/infra/app/variables.tf
+++ b/infra/app/variables.tf
@@ -118,3 +118,17 @@ variable "esea_context_url" {
   default     = "https://vocab.evidence-repository.org/published/019d9463-2780-7243-b4de-e547386f2a90/1.1/context.jsonld"
 }
 
+# TODO: the HPV vocabulary is not yet published — these defaults are
+# placeholders so the build doesn't fail; update once the JSON-LD source lands.
+variable "hpv_vocabulary_url" {
+  description = "URL of the HPV community's published SKOS vocabulary (.jsonld) — placeholder until the HPV vocabulary is published"
+  type        = string
+  default     = "https://vocab.evidence-repository.org/published/TODO-hpv/1.0/vocabulary.jsonld"
+}
+
+variable "hpv_context_url" {
+  description = "URL of the HPV community's JSON-LD @context (.jsonld) — placeholder until the HPV vocabulary is published"
+  type        = string
+  default     = "https://vocab.evidence-repository.org/published/TODO-hpv/1.0/context.jsonld"
+}
+

--- a/src/components/filters/ConceptSchemeFilter.tsx
+++ b/src/components/filters/ConceptSchemeFilter.tsx
@@ -15,6 +15,7 @@ interface ConceptSchemeFilterProps {
   state: ConceptSchemeFilterState;
   counts?: ReadonlyMap<string, number> | null;
   countsLoading?: boolean;
+  countNoun?: string;
   onChange: (next: ConceptSchemeFilterState) => void;
 }
 
@@ -23,6 +24,7 @@ interface ConceptItemProps {
   state: ConceptSchemeFilterState;
   counts: ReadonlyMap<string, number> | null;
   countsLoading: boolean;
+  countNoun: string;
   onChange: (next: ConceptSchemeFilterState) => void;
 }
 
@@ -37,6 +39,7 @@ function ConceptItem({
   state,
   counts,
   countsLoading,
+  countNoun,
   onChange,
 }: ConceptItemProps) {
   const hasDefinition = !!concept.definition;
@@ -72,7 +75,7 @@ function ConceptItem({
   const countNode = showCountBadge && (
     <span
       class={countClass}
-      aria-label={`${formatCount(count)} investigations`}
+      aria-label={`${formatCount(count)} ${countNoun}`}
       tabIndex={hasChildren ? 0 : undefined}
     >
       {formatCount(count)}
@@ -109,6 +112,7 @@ function ConceptItem({
               state={state}
               counts={counts}
               countsLoading={countsLoading}
+              countNoun={countNoun}
               onChange={onChange}
             />
           ))}
@@ -123,6 +127,7 @@ export function ConceptSchemeFilter({
   state,
   counts = null,
   countsLoading = false,
+  countNoun = "results",
   onChange,
 }: ConceptSchemeFilterProps) {
   return (
@@ -134,6 +139,7 @@ export function ConceptSchemeFilter({
           state={state}
           counts={counts}
           countsLoading={countsLoading}
+          countNoun={countNoun}
           onChange={onChange}
         />
       ))}

--- a/src/components/filters/CountryFilter.tsx
+++ b/src/components/filters/CountryFilter.tsx
@@ -12,6 +12,7 @@ interface CountryFilterProps {
   state: CountryFilterState;
   counts?: ReadonlyMap<string, number> | null;
   countsLoading?: boolean;
+  countNoun?: string;
   onChange: (next: CountryFilterState) => void;
 }
 
@@ -35,6 +36,7 @@ export function CountryFilter({
   state,
   counts = null,
   countsLoading = false,
+  countNoun = "results",
   onChange,
 }: CountryFilterProps) {
   const [query, setQuery] = useState("");
@@ -96,7 +98,7 @@ export function CountryFilter({
                 {showCountBadge && (
                   <span
                     class={countClass}
-                    aria-label={`${formatCount(count)} investigations`}
+                    aria-label={`${formatCount(count)} ${countNoun}`}
                   >
                     {formatCount(count)}
                   </span>
@@ -111,7 +113,7 @@ export function CountryFilter({
               ? "Loading countries…"
               : query.trim() === ""
                 ? "No countries match the current filters."
-                : `No references for “${query.trim()}”.`}
+                : `No ${countNoun} for “${query.trim()}”.`}
           </li>
         )}
       </ul>

--- a/src/components/filters/FilterDrawer.tsx
+++ b/src/components/filters/FilterDrawer.tsx
@@ -40,6 +40,8 @@ export interface AppliedFilters {
 
 interface FilterDrawerProps {
   open: boolean;
+  title?: string;
+  countNoun?: string;
   schemes: ConceptScheme[];
   appliedConceptFilters: readonly (readonly string[])[];
   appliedCountryCodes: readonly string[];
@@ -106,6 +108,8 @@ export function FilterDrawer({ open, ...rest }: FilterDrawerProps) {
 type FilterDrawerPanelProps = Omit<FilterDrawerProps, "open">;
 
 function FilterDrawerPanel({
+  title = "Refine the evidence",
+  countNoun = "results",
   schemes,
   appliedConceptFilters,
   appliedCountryCodes,
@@ -232,7 +236,7 @@ function FilterDrawerPanel({
         <header class="filter-drawer__header">
           <div class="filter-drawer__heading">
             <h2 id={titleId} class="filter-drawer__title">
-              Refine the evidence
+              {title}
             </h2>
             {/* "*" is the browse-mode sentinel — don't echo it as a query. */}
             {params.q !== "" && params.q !== "*" && (
@@ -251,7 +255,7 @@ function FilterDrawerPanel({
         <div class="filter-drawer__body">
           {facetError && (
             <div class="filter-drawer__notice" role="status">
-              Investigation counts unavailable.
+              Filter counts unavailable.
             </div>
           )}
           <FilterCard
@@ -270,6 +274,7 @@ function FilterDrawerPanel({
               state={countryDraft}
               counts={facetCounts?.countries ?? null}
               countsLoading={facetCountsLoading}
+              countNoun={countNoun}
               onChange={setCountryDraft}
             />
           </FilterCard>
@@ -286,6 +291,7 @@ function FilterDrawerPanel({
                   state={state}
                   counts={facetCounts?.concepts ?? null}
                   countsLoading={facetCountsLoading}
+                  countNoun={countNoun}
                   onChange={(next) => onSchemeChange(scheme, next)}
                 />
               </FilterCard>

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,6 +1,7 @@
 import type { ComponentChildren } from "preact";
 import { useAuth } from "@/auth/AuthContext";
 import { useCommunity } from "@/community/CommunityContext";
+import { DEFAULT_COMMUNITY_SLUG } from "@/services/communities";
 import { FeedbackFAB } from "@/components/feedback/FeedbackFAB";
 import "./AppShell.css";
 
@@ -8,18 +9,16 @@ interface AppShellProps {
   children: ComponentChildren;
 }
 
-// Brand link target: there's no real "/" landing page yet — the router only
-// matches /:community/* — so point at the lone live community root. Revisit
-// when a multi-community switcher or a true root page lands.
-const BRAND_HREF = "/esea";
-
 export function AppShell({ children }: AppShellProps) {
   const { username, logout } = useAuth();
   const community = useCommunity();
+  // No "/" landing page yet (router only matches /:community/*), so point at
+  // the current community root, falling back to the default off a community route.
+  const brandHref = `/${community?.slug ?? DEFAULT_COMMUNITY_SLUG}`;
   return (
     <div class="app-shell">
       <header class="app-header">
-        <a href={BRAND_HREF} class="app-header__brand">
+        <a href={brandHref} class="app-header__brand">
           <span class="app-header__logo-mark" aria-hidden="true">E</span>
           <span class="app-header__brand-text">
             <span class="app-header__brand-name">Evidence Repository</span>

--- a/src/components/search/ResultRow.tsx
+++ b/src/components/search/ResultRow.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "preact/hooks";
-import type { Reference } from "@/types/models";
+import type { CodingInstitutionConfig, Reference } from "@/types/models";
 import type {
   CodedAnnotation,
   InvestigationData,
@@ -13,7 +13,6 @@ import {
   extractLinkedData,
   formatPagination,
 } from "@/services/referenceUtils";
-import { extractReferenceCodingInstitution } from "@/services/codingInstitution";
 import { parseInvestigation } from "@/services/investigationParser";
 import { conceptsToTags } from "@/services/conceptLabels";
 import { useVocabulary } from "@/hooks/useVocabulary";
@@ -24,6 +23,7 @@ import "./ResultRow.css";
 interface ResultRowProps {
   communitySlug: string;
   reference: Reference;
+  codingInstitution?: CodingInstitutionConfig;
 }
 
 const MAX_AUTHORS_SHOWN = 3;
@@ -66,7 +66,11 @@ function aggregatePillConcepts(
   return out;
 }
 
-export function ResultRow({ communitySlug, reference }: ResultRowProps) {
+export function ResultRow({
+  communitySlug,
+  reference,
+  codingInstitution: codingConfig,
+}: ResultRowProps) {
   const bib = extractBibliographic(reference);
   const doi = extractDoi(reference.identifiers);
   const abstract = extractAbstract(reference)?.abstract ?? null;
@@ -104,7 +108,7 @@ export function ResultRow({ communitySlug, reference }: ResultRowProps) {
   const year = bib?.publication_year !== null && bib?.publication_year !== undefined
     ? String(bib.publication_year)
     : "";
-  const codingInstitution = extractReferenceCodingInstitution(reference);
+  const codingInstitution = codingConfig?.fromReference(reference) ?? null;
 
   const findingsLabel = counts ? String(counts.findings) : "—";
   const estimatesLabel = counts ? String(counts.estimates) : "—";

--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -5,6 +5,7 @@ interface SearchBarProps {
   draftQ: string;
   onDraftQChange: (q: string) => void;
   onSubmit: () => void;
+  placeholder?: string;
   disabled?: boolean;
 }
 
@@ -12,6 +13,7 @@ export function SearchBar({
   draftQ,
   onDraftQChange,
   onSubmit,
+  placeholder = "Search the evidence",
   disabled = false,
 }: SearchBarProps) {
   function handleSubmit(e?: Event) {
@@ -29,7 +31,7 @@ export function SearchBar({
           <input
             type="search"
             aria-label="Search query"
-            placeholder="Search the evidence"
+            placeholder={placeholder}
             value={draftQ}
             onInput={(e) => onDraftQChange((e.target as HTMLInputElement).value)}
             disabled={disabled}

--- a/src/hooks/useSearchExport.ts
+++ b/src/hooks/useSearchExport.ts
@@ -6,7 +6,7 @@ import {
   type SearchFilters,
 } from "@/services/apiClient";
 import { exportReferencesToExcel } from "@/services/export/export";
-import type { SearchExportRead } from "@/types/models";
+import type { CodingInstitutionConfig, SearchExportRead } from "@/types/models";
 
 export type ExportStatus =
   | "idle"
@@ -22,6 +22,7 @@ export interface StartExportOptions {
   filename: string;
   vocabularyUrl: string;
   contextUrl: string;
+  codingInstitution?: CodingInstitutionConfig;
 }
 
 export interface UseSearchExportResult {
@@ -75,6 +76,7 @@ export function useSearchExport(): UseSearchExportResult {
       filename,
       vocabularyUrl,
       contextUrl,
+      codingInstitution,
     }: StartExportOptions) => {
       runIdRef.current += 1;
       const runId = runIdRef.current;
@@ -106,6 +108,7 @@ export function useSearchExport(): UseSearchExportResult {
             vocabularyUrl,
             contextUrl,
             filename,
+            codingInstitution,
           );
         } catch (err) {
           fail(

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,3 +1,4 @@
+import { DEFAULT_COMMUNITY_SLUG } from "@/services/communities";
 import "./NotFoundPage.css";
 
 interface NotFoundPageProps {
@@ -11,7 +12,7 @@ export function NotFoundPage(_props: NotFoundPageProps) {
       <h1>Page not found</h1>
       <p>
         The page you're looking for doesn't exist.{" "}
-        <a href="/esea">Go to search</a>.
+        <a href={`/${DEFAULT_COMMUNITY_SLUG}`}>Go to search</a>.
       </p>
     </div>
   );

--- a/src/pages/RecordDetailPage.tsx
+++ b/src/pages/RecordDetailPage.tsx
@@ -7,7 +7,6 @@ import {
   extractLinkedDataEnhancement,
   extractDoi,
 } from "@/services/referenceUtils";
-import { extractLinkedDataCodingInstitution } from "@/services/codingInstitution";
 import {
   parseInvestigation,
   extractIsRetracted,
@@ -94,7 +93,7 @@ export function RecordDetailPage({ id }: RecordDetailPageProps) {
   const doi = extractDoi(reference.identifiers);
   const lde = extractLinkedDataEnhancement(reference);
   const codingInstitution = lde
-    ? extractLinkedDataCodingInstitution(reference, lde)
+    ? (community.codingInstitution?.fromLinkedData(reference, lde) ?? null)
     : null;
   const abstract = extractAbstract(reference);
 

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -255,6 +255,7 @@ function SearchPageInner({ community }: { community: Community }) {
       filename: formatExportFilename(community.slug),
       vocabularyUrl: community.vocabularyUrl,
       contextUrl: community.contextUrl,
+      codingInstitution: community.codingInstitution,
     });
   }
 
@@ -382,7 +383,12 @@ function SearchPageInner({ community }: { community: Community }) {
           )}
 
           {results.results?.references.map((ref) => (
-            <ResultRow key={ref.id} communitySlug={community.slug} reference={ref} />
+            <ResultRow
+              key={ref.id}
+              communitySlug={community.slug}
+              reference={ref}
+              codingInstitution={community.codingInstitution}
+            />
           ))}
         </div>
 

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -274,7 +274,7 @@ function SearchPageInner({ community }: { community: Community }) {
         <h1 class="search-hero__title">Search the evidence</h1>
         <p class="search-hero__subtitle">
           {corpus.total
-            ? `${formatTotal(corpus.total)} investigations across ${community.name.toLowerCase()} research`
+            ? `${formatTotal(corpus.total)} ${community.copy.countNoun} across ${community.copy.corpusDescriptor}`
             : corpus.loading
               ? <span class="search-hero__subtitle--placeholder">Loading…</span>
               : community.name}
@@ -283,6 +283,7 @@ function SearchPageInner({ community }: { community: Community }) {
           draftQ={draft.draftQ}
           onDraftQChange={draft.setDraftQ}
           onSubmit={handleSubmit}
+          placeholder={community.copy.searchPlaceholder}
           disabled={results.loading && results.results !== null}
         />
       </section>
@@ -398,6 +399,8 @@ function SearchPageInner({ community }: { community: Community }) {
       {filterableSchemes.length > 0 && (
         <FilterDrawer
           open={drawerOpen}
+          title={community.copy.drawerTitle}
+          countNoun={community.copy.countNoun}
           schemes={filterableSchemes}
           appliedConceptFilters={params.conceptFilters}
           appliedCountryCodes={params.countryCodes}

--- a/src/services/codingInstitution.ts
+++ b/src/services/codingInstitution.ts
@@ -1,46 +1,44 @@
-import type { Enhancement, OtherEnhancement, Reference } from "@/types/models";
+import type {
+  CodingInstitutionConfig,
+  Enhancement,
+  OtherEnhancement,
+  Reference,
+} from "@/types/models";
 import { extractLatestEnhancement } from "@/services/referenceUtils";
 
-// Match institution tokens with non-letter boundaries: real source values are
-// more convoluted (e.g. "eef-eppi-review", "ad_hoc_ingestors.iiie_ingestor@1.0").
-const INSTITUTION_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
-  [/(^|[^a-z])eef([^a-z]|$)/, "EEF"],
-  [/(^|[^a-z])iiie([^a-z]|$)/, "IIIE"],
-  [/(^|[^a-z])essa([^a-z]|$)/, "ESSA"],
-  [/(^|[^a-z])wwhge([^a-z]|$)/, "WWHGE"],
-];
-
-export function resolveCodingInstitution(
-  source: string | null | undefined,
-): string | null {
-  if (!source) return null;
-  const lower = source.toLowerCase();
-  for (const [pattern, label] of INSTITUTION_PATTERNS) {
-    if (pattern.test(lower)) return label;
+// Derives the coder label by matching tokens (first match wins) in a
+// reference's raw-enhancement `source`. Patterns use non-letter boundaries
+// because real values are convoluted, e.g. "ad_hoc_ingestors.iiie_ingestor@1.0".
+export function rawSourcePatterns(
+  patterns: ReadonlyArray<readonly [RegExp, string]>,
+): CodingInstitutionConfig {
+  function resolve(source: string | null | undefined): string | null {
+    if (!source) return null;
+    const lower = source.toLowerCase();
+    for (const [pattern, label] of patterns) {
+      if (pattern.test(lower)) return label;
+    }
+    return null;
   }
-  return null;
-}
 
-// Temporary: roll back once references are deduplicated.
-export function extractReferenceCodingInstitution(
-  reference: Reference,
-): string | null {
-  const raw = extractLatestEnhancement<OtherEnhancement>(reference, "raw");
-  return resolveCodingInstitution(raw?.source);
-}
+  return {
+    // Temporary: roll back once references are deduplicated.
+    fromReference(reference: Reference): string | null {
+      const raw = extractLatestEnhancement<OtherEnhancement>(reference, "raw");
+      return resolve(raw?.source);
+    },
 
-export function extractLinkedDataCodingInstitution(
-  reference: Reference,
-  lde: Enhancement,
-): string | null {
-  if (!lde.derived_from?.length) return null;
-  if (!reference.enhancements) return null;
-  const derivedIds = new Set(lde.derived_from);
-  const raw = reference.enhancements.find(
-    (e) =>
-      e.content.enhancement_type === "raw" &&
-      e.id !== null &&
-      derivedIds.has(e.id),
-  );
-  return resolveCodingInstitution(raw?.source);
+    fromLinkedData(reference: Reference, lde: Enhancement): string | null {
+      if (!lde.derived_from?.length) return null;
+      if (!reference.enhancements) return null;
+      const derivedIds = new Set(lde.derived_from);
+      const raw = reference.enhancements.find(
+        (e) =>
+          e.content.enhancement_type === "raw" &&
+          e.id !== null &&
+          derivedIds.has(e.id),
+      );
+      return resolve(raw?.source);
+    },
+  };
 }

--- a/src/services/communities.ts
+++ b/src/services/communities.ts
@@ -3,6 +3,7 @@ import type {
   CommunityCopy,
   CommunityFeatures,
 } from "@/types/models";
+import { rawSourcePatterns } from "@/services/codingInstitution";
 
 function requireEnv(name: string, value: string | undefined): string {
   if (typeof value !== "string" || value === "") {
@@ -45,6 +46,12 @@ const COMMUNITIES: Community[] = [
     filterExcludedSchemes: ["esea:ImplementationDescriptionScheme"],
     features: { ...DEFAULT_FEATURES },
     copy: buildCopy("Education", { countNoun: "investigations" }),
+    codingInstitution: rawSourcePatterns([
+      [/(^|[^a-z])eef([^a-z]|$)/, "EEF"],
+      [/(^|[^a-z])iiie([^a-z]|$)/, "IIIE"],
+      [/(^|[^a-z])essa([^a-z]|$)/, "ESSA"],
+      [/(^|[^a-z])wwhge([^a-z]|$)/, "WWHGE"],
+    ]),
   },
   {
     slug: "hpv",

--- a/src/services/communities.ts
+++ b/src/services/communities.ts
@@ -20,7 +20,10 @@ const DEFAULT_FEATURES: CommunityFeatures = {
 };
 
 // Shared copy fallbacks; a community overrides only what diverges.
-function buildCopy(name: string, overrides: Partial<CommunityCopy>): CommunityCopy {
+function buildCopy(
+  name: string,
+  overrides: Partial<CommunityCopy>,
+): CommunityCopy {
   return {
     searchPlaceholder: "Search the evidence",
     drawerTitle: "Refine the evidence",
@@ -56,7 +59,7 @@ const COMMUNITIES: Community[] = [
   {
     slug: "hpv",
     name: "HPV Vaccine Delivery",
-    // TODO(#106): placeholder annotation, pending the backend's HPV domain inclusion.
+    // TODO: placeholder annotation, pending the backend's HPV domain inclusion.
     defaultAnnotations: ["domain-inclusion/hpv"],
     vocabularyUrl: requireEnv(
       "VITE_HPV_VOCABULARY_URL",

--- a/src/services/communities.ts
+++ b/src/services/communities.ts
@@ -1,4 +1,8 @@
-import type { Community } from "@/types/models";
+import type {
+  Community,
+  CommunityCopy,
+  CommunityFeatures,
+} from "@/types/models";
 
 function requireEnv(name: string, value: string | undefined): string {
   if (typeof value !== "string" || value === "") {
@@ -8,6 +12,21 @@ function requireEnv(name: string, value: string | undefined): string {
     );
   }
   return value;
+}
+
+const DEFAULT_FEATURES: CommunityFeatures = {
+  evidenceMap: false,
+};
+
+// Shared copy fallbacks; a community overrides only what diverges.
+function buildCopy(name: string, overrides: Partial<CommunityCopy>): CommunityCopy {
+  return {
+    searchPlaceholder: "Search the evidence",
+    drawerTitle: "Refine the evidence",
+    countNoun: "results",
+    corpusDescriptor: `${name.toLowerCase()} research`,
+    ...overrides,
+  };
 }
 
 const COMMUNITIES: Community[] = [
@@ -24,8 +43,34 @@ const COMMUNITIES: Community[] = [
       import.meta.env.VITE_ESEA_CONTEXT_URL,
     ),
     filterExcludedSchemes: ["esea:ImplementationDescriptionScheme"],
+    features: { ...DEFAULT_FEATURES },
+    copy: buildCopy("Education", { countNoun: "investigations" }),
+  },
+  {
+    slug: "hpv",
+    name: "HPV Vaccine Delivery",
+    // TODO(#106): placeholder annotation, pending the backend's HPV domain inclusion.
+    defaultAnnotations: ["domain-inclusion/hpv"],
+    vocabularyUrl: requireEnv(
+      "VITE_HPV_VOCABULARY_URL",
+      import.meta.env.VITE_HPV_VOCABULARY_URL,
+    ),
+    contextUrl: requireEnv(
+      "VITE_HPV_CONTEXT_URL",
+      import.meta.env.VITE_HPV_CONTEXT_URL,
+    ),
+    filterExcludedSchemes: [],
+    features: { ...DEFAULT_FEATURES, evidenceMap: true },
+    copy: buildCopy("HPV Vaccine Delivery", {
+      countNoun: "references",
+      corpusDescriptor: "HPV vaccine delivery research",
+    }),
   },
 ];
+
+// Brand link / not-found fallback target while there's no true "/" landing
+// page — the router only matches /:community/*.
+export const DEFAULT_COMMUNITY_SLUG = COMMUNITIES[0].slug;
 
 export function findCommunity(slug: string): Community | undefined {
   return COMMUNITIES.find((c) => c.slug === slug);

--- a/src/services/export/buildRows.ts
+++ b/src/services/export/buildRows.ts
@@ -3,7 +3,6 @@
  * structures; field accesses use snake_case to match the wire format.
  */
 
-import { extractLinkedDataCodingInstitution } from "@/services/codingInstitution";
 import {
   extractDoi,
   extractOpenAlexId,
@@ -12,6 +11,7 @@ import {
 import { expandCompactUri } from "@/services/vocabulary";
 import type {
   BibliographicMetadataEnhancement,
+  CodingInstitutionConfig,
   Enhancement,
   LinkedDataEnhancement,
   Reference,
@@ -330,6 +330,7 @@ export function buildInvestigationRow(
   linked: Enhancement & { content: LinkedDataEnhancement },
   investigation: Investigation,
   vocab: ConceptResolver,
+  codingInstitution?: CodingInstitutionConfig,
 ): InvestigationRow {
   const docType = investigation.documentType ?? {};
   const authors = bibliographic?.authorship
@@ -337,7 +338,7 @@ export function buildInvestigationRow(
     : null;
   return {
     reference_id: String(reference.id),
-    source: extractLinkedDataCodingInstitution(reference, linked),
+    source: codingInstitution?.fromLinkedData(reference, linked) ?? null,
     title: bibliographic?.title ?? null,
     authors: authors || null,
     publication_year: bibliographic?.publication_year ?? null,

--- a/src/services/export/export.ts
+++ b/src/services/export/export.ts
@@ -11,6 +11,7 @@ import {
   getCachedContext,
   getCachedVocabulary,
 } from "@/services/vocabulary";
+import type { CodingInstitutionConfig } from "@/types/models";
 
 import { generateWorkbook, workbookToArrayBuffer } from "./generate.ts";
 import { streamJsonlFromUrl } from "./jsonlStream.ts";
@@ -46,15 +47,20 @@ export async function exportReferencesToExcel(
   vocabularyUrl: string,
   contextUrl: string,
   filename: string,
+  codingInstitution?: CodingInstitutionConfig,
 ): Promise<void> {
   const references = streamJsonlFromUrl(jsonlUrl);
   const [vocab, context] = await Promise.all([
     getCachedVocabulary(vocabularyUrl),
     getCachedContext(contextUrl),
   ]);
-  const wb = await generateWorkbook(references, {
-    prefixes: context.prefixes,
-    labels: vocab.labels,
-  });
+  const wb = await generateWorkbook(
+    references,
+    {
+      prefixes: context.prefixes,
+      labels: vocab.labels,
+    },
+    codingInstitution,
+  );
   triggerDownload(workbookToArrayBuffer(wb), filename);
 }

--- a/src/services/export/generate.ts
+++ b/src/services/export/generate.ts
@@ -19,7 +19,7 @@ import {
   extractLinkedDataEnhancement,
   isDict,
 } from "@/services/referenceUtils";
-import type { Reference } from "@/types/models";
+import type { CodingInstitutionConfig, Reference } from "@/types/models";
 
 import type {
   ArmRow,
@@ -113,6 +113,7 @@ function appendSheet<R extends AnyRow>(
 export async function buildAllRows(
   references: ReferenceSource,
   vocab: ConceptResolver,
+  codingInstitution?: CodingInstitutionConfig,
 ): Promise<BuiltRows> {
   const investigation: InvestigationRow[] = [];
   const arms: ArmRow[] = [];
@@ -127,7 +128,14 @@ export async function buildAllRows(
     const findings = (Array.isArray(inv["hasFinding"]) ? inv["hasFinding"] : []) as Finding[];
     const armIds = assignArmIds(findings);
     investigation.push(
-      buildInvestigationRow(reference, bibliographic, linked, inv, vocab),
+      buildInvestigationRow(
+        reference,
+        bibliographic,
+        linked,
+        inv,
+        vocab,
+        codingInstitution,
+      ),
     );
     arms.push(...buildFindingRows(referenceId, findings, armIds, vocab));
     outcomes.push(...buildOutcomeRows(referenceId, findings, armIds, vocab));
@@ -150,8 +158,9 @@ export async function buildAllRows(
 export async function generateWorkbook(
   references: ReferenceSource,
   vocab: ConceptResolver,
+  codingInstitution?: CodingInstitutionConfig,
 ): Promise<XLSX.WorkBook> {
-  const rows = await buildAllRows(references, vocab);
+  const rows = await buildAllRows(references, vocab, codingInstitution);
   const wb = XLSX.utils.book_new();
   appendSheet(wb, SHEET_NAMES.investigation, SHEET_HEADERS.investigation, rows.investigation);
   appendSheet(wb, SHEET_NAMES.arms, SHEET_HEADERS.arms, rows.arms);

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -1,3 +1,18 @@
+export interface CommunityFeatures {
+  // No UI yet; reserved so the evidence map can ship behind a flag (#103).
+  evidenceMap: boolean;
+}
+
+// See buildCopy() in services/communities.ts for the shared fallbacks.
+export interface CommunityCopy {
+  searchPlaceholder: string;
+  drawerTitle: string;
+  // Plural noun for a count of evidence items: "investigations" / "references".
+  countNoun: string;
+  // Completes "{N} {countNoun} across {corpusDescriptor}", e.g. "education research".
+  corpusDescriptor: string;
+}
+
 export interface Community {
   slug: string;
   name: string;
@@ -5,6 +20,8 @@ export interface Community {
   vocabularyUrl: string;
   contextUrl: string;
   filterExcludedSchemes: string[];
+  features: CommunityFeatures;
+  copy: CommunityCopy;
 }
 
 export type Visibility = "public" | "restricted" | "hidden";

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -13,6 +13,14 @@ export interface CommunityCopy {
   corpusDescriptor: string;
 }
 
+// Two entry points because the coder is read from different shapes: result rows
+// carry the raw enhancement inline; the detail page and export resolve it via a
+// linked-data enhancement's derived_from chain. See rawSourcePatterns().
+export interface CodingInstitutionConfig {
+  fromReference(reference: Reference): string | null;
+  fromLinkedData(reference: Reference, lde: Enhancement): string | null;
+}
+
 export interface Community {
   slug: string;
   name: string;
@@ -22,6 +30,8 @@ export interface Community {
   filterExcludedSchemes: string[];
   features: CommunityFeatures;
   copy: CommunityCopy;
+  // Absent ⇒ no coder concept; the "Coded by" pill and export source are hidden.
+  codingInstitution?: CodingInstitutionConfig;
 }
 
 export type Visibility = "public" | "restricted" | "hidden";

--- a/tests/community/CommunityContext.test.tsx
+++ b/tests/community/CommunityContext.test.tsx
@@ -29,6 +29,18 @@ describe("useCommunity", () => {
     expect(screen.getByTestId("community")).toHaveTextContent("Education");
   });
 
+  test("resolves the hpv community from /hpv", () => {
+    setPath("/hpv");
+    render(
+      <CommunityProvider>
+        <TestConsumer />
+      </CommunityProvider>,
+    );
+    expect(screen.getByTestId("community")).toHaveTextContent(
+      "HPV Vaccine Delivery",
+    );
+  });
+
   test("updates when the browser fires popstate", () => {
     setPath("/");
     render(

--- a/tests/components/filters/CountryFilter.test.tsx
+++ b/tests/components/filters/CountryFilter.test.tsx
@@ -111,11 +111,12 @@ describe("CountryFilter", () => {
     expect(franceRow.querySelector(".country-filter__count")).toBeNull();
   });
 
-  test("search with no matches in the aggregation → \"No references for [query]\" message", () => {
+  test("search with no matches in the aggregation → \"No {countNoun} for [query]\" message", () => {
     render(
       <CountryFilter
         state={emptyCountryState()}
         counts={new Map([["DE", 1]])}
+        countNoun="references"
         onChange={vi.fn()}
       />,
     );

--- a/tests/components/search/ResultRow.test.tsx
+++ b/tests/components/search/ResultRow.test.tsx
@@ -1,11 +1,14 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/preact";
 import { PILL_CAP, ResultRow } from "@/components/search/ResultRow";
+import { rawSourcePatterns } from "@/services/codingInstitution";
 import {
   abstractEnh,
   bibliographicEnh,
   makeReference,
 } from "../../fixtures";
+
+const CODING = rawSourcePatterns([[/(^|[^a-z])eef([^a-z]|$)/, "EEF"]]);
 
 const vocabState = {
   labels: null as Map<string, string> | null,
@@ -252,7 +255,32 @@ describe("ResultRow", () => {
   });
 
   test("does not render coding institution when no raw enhancement is present", () => {
-    render(<ResultRow communitySlug="esea" reference={makeRef()} />);
+    render(
+      <ResultRow
+        communitySlug="esea"
+        reference={makeRef()}
+        codingInstitution={CODING}
+      />,
+    );
+    expect(screen.queryByTestId("coder-text")).toBeNull();
+  });
+
+  test("does not render coding institution when the community has no config", () => {
+    const ref = makeRef({
+      enhancements: [
+        {
+          id: "raw-1",
+          reference_id: "ref-1",
+          source: "eef-eppi-review",
+          visibility: "public",
+          robot_version: null,
+          derived_from: null,
+          created_at: "2024-01-01",
+          content: { enhancement_type: "raw" },
+        },
+      ],
+    });
+    render(<ResultRow communitySlug="hpv" reference={ref} />);
     expect(screen.queryByTestId("coder-text")).toBeNull();
   });
 
@@ -272,7 +300,11 @@ describe("ResultRow", () => {
       ],
     });
     const { container } = render(
-      <ResultRow communitySlug="esea" reference={ref} />,
+      <ResultRow
+        communitySlug="esea"
+        reference={ref}
+        codingInstitution={CODING}
+      />,
     );
     const coder = screen.getByTestId("coder-text");
     expect(coder).toHaveTextContent("EEF");

--- a/tests/hooks/useSearchExport.test.tsx
+++ b/tests/hooks/useSearchExport.test.tsx
@@ -106,6 +106,7 @@ describe("useSearchExport", () => {
       VOCAB_URL,
       CONTEXT_URL,
       "file.xlsx",
+      undefined,
     );
     expect(mockRequest).toHaveBeenCalledWith("phonics", { annotation: ["x"] });
   });

--- a/tests/services/codingInstitution.test.ts
+++ b/tests/services/codingInstitution.test.ts
@@ -1,13 +1,23 @@
 import { describe, test, expect } from "vitest";
-import {
-  resolveCodingInstitution,
-  extractReferenceCodingInstitution,
-  extractLinkedDataCodingInstitution,
-} from "@/services/codingInstitution";
+import { rawSourcePatterns } from "@/services/codingInstitution";
 import type { Enhancement, Reference } from "@/types/models";
 import { linkedDataEnh, makeReference, rawEnh } from "../fixtures";
 
-describe("resolveCodingInstitution", () => {
+// esea-style patterns; the factory itself is community-agnostic.
+const coding = rawSourcePatterns([
+  [/(^|[^a-z])eef([^a-z]|$)/, "EEF"],
+  [/(^|[^a-z])iiie([^a-z]|$)/, "IIIE"],
+  [/(^|[^a-z])essa([^a-z]|$)/, "ESSA"],
+  [/(^|[^a-z])wwhge([^a-z]|$)/, "WWHGE"],
+]);
+
+function refWithRawSource(source: string): Reference {
+  return makeReference({
+    enhancements: [rawEnh("ref-1", { id: "a", source, createdAt: "2024-01-01" })],
+  });
+}
+
+describe("rawSourcePatterns source matching", () => {
   test.each([
     ["eef-eppi-review", "EEF"],
     ["ad_hoc_ingestors.iiie_ingestor@1.0", "IIIE"],
@@ -15,37 +25,25 @@ describe("resolveCodingInstitution", () => {
     ["wwhge-internal", "WWHGE"],
     ["EEF-EPPI-REVIEW", "EEF"],
   ])("maps %s to %s", (input, expected) => {
-    expect(resolveCodingInstitution(input)).toBe(expected);
+    expect(coding.fromReference(refWithRawSource(input))).toBe(expected);
   });
 
   test("returns null for unknown sources", () => {
-    expect(resolveCodingInstitution("openalex")).toBeNull();
-    expect(resolveCodingInstitution("robot")).toBeNull();
+    expect(coding.fromReference(refWithRawSource("openalex"))).toBeNull();
+    expect(coding.fromReference(refWithRawSource("robot"))).toBeNull();
   });
 
   test("does not match patterns embedded in larger words", () => {
-    // "beef" should not match "eef"; "messa" should not match "essa"; etc.
-    expect(resolveCodingInstitution("beef")).toBeNull();
-    expect(resolveCodingInstitution("messaging")).toBeNull();
-  });
-
-  test("returns null for empty/null/undefined", () => {
-    expect(resolveCodingInstitution("")).toBeNull();
-    expect(resolveCodingInstitution(null)).toBeNull();
-    expect(resolveCodingInstitution(undefined)).toBeNull();
+    // "beef" should not match "eef"; "messaging" should not match "essa".
+    expect(coding.fromReference(refWithRawSource("beef"))).toBeNull();
+    expect(coding.fromReference(refWithRawSource("messaging"))).toBeNull();
   });
 });
 
-describe("extractReferenceCodingInstitution", () => {
-  test("returns null when enhancements is null", () => {
-    expect(
-      extractReferenceCodingInstitution(makeReference({ enhancements: [] })),
-    ).toBeNull();
-  });
-
+describe("fromReference", () => {
   test("returns null when no raw enhancement exists", () => {
     expect(
-      extractReferenceCodingInstitution(makeReference({ enhancements: [] })),
+      coding.fromReference(makeReference({ enhancements: [] })),
     ).toBeNull();
   });
 
@@ -64,24 +62,11 @@ describe("extractReferenceCodingInstitution", () => {
         }),
       ],
     });
-    expect(extractReferenceCodingInstitution(ref)).toBe("IIIE");
-  });
-
-  test("returns null when raw source is unknown", () => {
-    const ref = makeReference({
-      enhancements: [
-        rawEnh("ref-1", {
-          id: "a",
-          source: "openalex",
-          createdAt: "2024-01-01",
-        }),
-      ],
-    });
-    expect(extractReferenceCodingInstitution(ref)).toBeNull();
+    expect(coding.fromReference(ref)).toBe("IIIE");
   });
 });
 
-describe("extractLinkedDataCodingInstitution", () => {
+describe("fromLinkedData", () => {
   test("returns null when reference has no enhancements", () => {
     const lde = linkedDataEnh("ref-1", { id: "lde-1", derivedFrom: ["raw-1"] });
     const ref: Reference = {
@@ -90,7 +75,7 @@ describe("extractLinkedDataCodingInstitution", () => {
       identifiers: null,
       enhancements: null,
     };
-    expect(extractLinkedDataCodingInstitution(ref, lde)).toBeNull();
+    expect(coding.fromLinkedData(ref, lde)).toBeNull();
   });
 
   test("returns null when LDE has no derived_from", () => {
@@ -101,7 +86,7 @@ describe("extractLinkedDataCodingInstitution", () => {
         lde,
       ],
     });
-    expect(extractLinkedDataCodingInstitution(ref, lde)).toBeNull();
+    expect(coding.fromLinkedData(ref, lde)).toBeNull();
   });
 
   test("resolves source on raw enhancement matched by derived_from", () => {
@@ -113,7 +98,7 @@ describe("extractLinkedDataCodingInstitution", () => {
         lde,
       ],
     });
-    expect(extractLinkedDataCodingInstitution(ref, lde)).toBe("EEF");
+    expect(coding.fromLinkedData(ref, lde)).toBe("EEF");
   });
 
   test("resolves the provenance of the specific LDE passed in", () => {
@@ -136,8 +121,8 @@ describe("extractLinkedDataCodingInstitution", () => {
         ldeB,
       ],
     });
-    expect(extractLinkedDataCodingInstitution(ref, ldeA)).toBe("EEF");
-    expect(extractLinkedDataCodingInstitution(ref, ldeB)).toBe("IIIE");
+    expect(coding.fromLinkedData(ref, ldeA)).toBe("EEF");
+    expect(coding.fromLinkedData(ref, ldeB)).toBe("IIIE");
   });
 
   test("returns null when derived_from points to a missing enhancement", () => {
@@ -151,7 +136,7 @@ describe("extractLinkedDataCodingInstitution", () => {
         lde,
       ],
     });
-    expect(extractLinkedDataCodingInstitution(ref, lde)).toBeNull();
+    expect(coding.fromLinkedData(ref, lde)).toBeNull();
   });
 
   test("ignores non-raw enhancements with matching id in derived_from", () => {
@@ -179,6 +164,6 @@ describe("extractLinkedDataCodingInstitution", () => {
     };
     const lde = linkedDataEnh("ref-1", { id: "lde-1", derivedFrom: ["bib-1"] });
     const ref = makeReference({ enhancements: [bibEnh, lde] });
-    expect(extractLinkedDataCodingInstitution(ref, lde)).toBeNull();
+    expect(coding.fromLinkedData(ref, lde)).toBeNull();
   });
 });

--- a/tests/services/communities.test.ts
+++ b/tests/services/communities.test.ts
@@ -1,42 +1,51 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+function stubValidEnv() {
+  vi.stubEnv("VITE_ESEA_VOCABULARY_URL", "https://vocab.example/v1");
+  vi.stubEnv("VITE_ESEA_CONTEXT_URL", "https://vocab.example/ctx");
+  vi.stubEnv("VITE_HPV_VOCABULARY_URL", "https://vocab.example/hpv-v1");
+  vi.stubEnv("VITE_HPV_CONTEXT_URL", "https://vocab.example/hpv-ctx");
+}
 
 // Each test re-evaluates communities.ts against fresh env stubs, so the module
 // registry must be cleared before every dynamic import.
-describe("communities env validation", () => {
+describe("communities", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    stubValidEnv();
+  });
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.resetModules();
   });
 
-  it("throws when VITE_ESEA_VOCABULARY_URL is missing", async () => {
-    vi.resetModules();
-    vi.stubEnv("VITE_ESEA_VOCABULARY_URL", "");
-    vi.stubEnv("VITE_ESEA_CONTEXT_URL", "https://test.example/context");
-
-    await expect(import("@/services/communities")).rejects.toThrow(
-      /VITE_ESEA_VOCABULARY_URL/,
-    );
+  it.each([
+    "VITE_ESEA_VOCABULARY_URL",
+    "VITE_ESEA_CONTEXT_URL",
+    "VITE_HPV_VOCABULARY_URL",
+    "VITE_HPV_CONTEXT_URL",
+  ])("throws when %s is missing", async (name) => {
+    vi.stubEnv(name, "");
+    await expect(import("@/services/communities")).rejects.toThrow(name);
   });
 
-  it("throws when VITE_ESEA_CONTEXT_URL is missing", async () => {
-    vi.resetModules();
-    vi.stubEnv("VITE_ESEA_VOCABULARY_URL", "https://test.example/vocab");
-    vi.stubEnv("VITE_ESEA_CONTEXT_URL", "");
-
-    await expect(import("@/services/communities")).rejects.toThrow(
-      /VITE_ESEA_CONTEXT_URL/,
-    );
-  });
-
-  it("attaches the configured URLs to the esea community", async () => {
-    vi.resetModules();
-    vi.stubEnv("VITE_ESEA_VOCABULARY_URL", "https://vocab.example/v1");
-    vi.stubEnv("VITE_ESEA_CONTEXT_URL", "https://vocab.example/ctx");
-
+  it("resolves each community with its URLs, copy, and features", async () => {
     const { findCommunity } = await import("@/services/communities");
     const esea = findCommunity("esea");
+    const hpv = findCommunity("hpv");
 
     expect(esea?.vocabularyUrl).toBe("https://vocab.example/v1");
     expect(esea?.contextUrl).toBe("https://vocab.example/ctx");
+    // copy: overridden noun, name-derived corpusDescriptor, shared defaults.
+    expect(esea?.copy.countNoun).toBe("investigations");
+    expect(esea?.copy.corpusDescriptor).toBe("education research");
+    expect(esea?.copy.searchPlaceholder).toBe("Search the evidence");
+    expect(esea?.features.evidenceMap).toBe(false);
+
+    expect(hpv?.name).toBe("HPV Vaccine Delivery");
+    expect(hpv?.vocabularyUrl).toBe("https://vocab.example/hpv-v1");
+    expect(hpv?.copy.countNoun).toBe("references");
+    expect(hpv?.copy.corpusDescriptor).toBe("HPV vaccine delivery research");
+    expect(hpv?.features.evidenceMap).toBe(true);
   });
 });

--- a/tests/services/communities.test.ts
+++ b/tests/services/communities.test.ts
@@ -47,5 +47,6 @@ describe("communities", () => {
     expect(hpv?.copy.countNoun).toBe("references");
     expect(hpv?.copy.corpusDescriptor).toBe("HPV vaccine delivery research");
     expect(hpv?.features.evidenceMap).toBe(true);
+    expect(hpv?.codingInstitution).toBeUndefined();
   });
 });

--- a/tests/services/export/buildRows.test.ts
+++ b/tests/services/export/buildRows.test.ts
@@ -6,6 +6,7 @@ import {
   buildInvestigationRow,
   buildOutcomeRows,
 } from "@/services/export/buildRows.ts";
+import { rawSourcePatterns } from "@/services/codingInstitution";
 import type {
   ConceptResolver,
   Finding,
@@ -203,19 +204,20 @@ describe("buildInvestigationRow", () => {
     expect(row.vocabulary).toBe("https://vocab.esea.education/v1");
   });
 
-  // Token-by-token resolver behaviour and edge cases (null derived_from,
-  // unknown sources, non-raw upstream filter) live in
-  // tests/services/codingInstitution.test.ts. Here we just smoke-test
-  // that buildInvestigationRow plumbs the resolved value into row.source.
-  test("source reflects extractLinkedDataCodingInstitution of the linked enhancement", () => {
+  // Resolver behaviour and edge cases live in
+  // tests/services/codingInstitution.test.ts; here we just check the plumbing
+  // into row.source — populated with a config, null without one.
+  test("source reflects the coding-institution config (null when absent)", () => {
     const raw = makeEnh(
       { enhancement_type: "raw" },
       { id: "raw-1", source: "eef-eppi-review" },
     );
     const linked = linkedEnh({});
     const ref = makeRef({ enhancements: [raw, linked] });
-    const row = buildInvestigationRow(ref, null, linked, {}, VOCAB);
-    expect(row.source).toBe("EEF");
+    const coding = rawSourcePatterns([[/(^|[^a-z])eef([^a-z]|$)/, "EEF"]]);
+
+    expect(buildInvestigationRow(ref, null, linked, {}, VOCAB, coding).source).toBe("EEF");
+    expect(buildInvestigationRow(ref, null, linked, {}, VOCAB).source).toBeNull();
   });
 });
 

--- a/tests/services/export/export.test.ts
+++ b/tests/services/export/export.test.ts
@@ -6,8 +6,18 @@ import { fileURLToPath } from "node:url";
 import * as XLSX from "xlsx";
 
 import { exportReferencesToExcel } from "@/services/export/export.ts";
+import { rawSourcePatterns } from "@/services/codingInstitution";
 import { _resetContextCache } from "@/services/vocabulary/contextService";
 import { _resetVocabularyCache } from "@/services/vocabulary/vocabularyService";
+
+// esea config: the fixtures are education data, so the source column resolves
+// to coder labels (EEF, ESSA, …) in the snapshots.
+const CODING = rawSourcePatterns([
+  [/(^|[^a-z])eef([^a-z]|$)/, "EEF"],
+  [/(^|[^a-z])iiie([^a-z]|$)/, "IIIE"],
+  [/(^|[^a-z])essa([^a-z]|$)/, "ESSA"],
+  [/(^|[^a-z])wwhge([^a-z]|$)/, "WWHGE"],
+]);
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const FIXTURES = resolve(HERE, "fixtures");
@@ -339,6 +349,7 @@ describe.each([
       VOCAB_URL,
       CONTEXT_URL,
       `${stem}.xlsx`,
+      CODING,
     );
 
     expect(captured.blobBytes).not.toBeNull();

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -4,6 +4,8 @@ import "@testing-library/jest-dom/vitest";
 
 vi.stubEnv("VITE_ESEA_VOCABULARY_URL", "https://test.example/vocab");
 vi.stubEnv("VITE_ESEA_CONTEXT_URL", "https://test.example/context");
+vi.stubEnv("VITE_HPV_VOCABULARY_URL", "https://test.example/hpv-vocab");
+vi.stubEnv("VITE_HPV_CONTEXT_URL", "https://test.example/hpv-context");
 
 const defaultTokenParsed = () => ({
   name: "Test User",


### PR DESCRIPTION
Closes #106 

- Generalises and parameterises UI copy (community short/long name, name of references/investigations)
- Generalises the coding source detection
- Adds `evidenceMap` feature flag
- Adds `HPV` community (with placeholder annotation and vocab values)