### PR TITLE
Construct sibling groups from entire concept schemes, specific to depth

### DIFF
--- a/src/components/filters/ConceptSchemeFilter.tsx
+++ b/src/components/filters/ConceptSchemeFilter.tsx
@@ -69,8 +69,10 @@ function ConceptItem({
   const countClass = `concept-scheme-filter__count${
     countsLoading ? " is-updating" : ""
   }${hasChildren ? " concept-scheme-filter__count--parent" : ""}`;
+  // Parent counts are a toggle preview for that concept alone — they don't roll
+  // up children — which is non-obvious enough to spell out on hover.
   const countTooltip = hasChildren
-    ? "Results you'd see if you toggled this concept. Selecting a parent includes all narrower concepts."
+    ? "Results you'd see if you toggled this concept."
     : undefined;
   const countNode = showCountBadge && (
     <span

--- a/src/components/filters/conceptSchemeFilterState.ts
+++ b/src/components/filters/conceptSchemeFilterState.ts
@@ -47,29 +47,6 @@ export function summary(state: ConceptSchemeFilterState): string {
   return state.size === 0 ? "" : `${state.size} selected`;
 }
 
-// Lookup maps for one scheme, derived from its tree. `byUri` resolves any
-// concept (so we can read a parent's `narrower` to check sibling state);
-// `broader` maps a concept URI to its parent's URI, terminating at top
-// concepts which have no entry.
-export interface ConceptIndex {
-  byUri: ReadonlyMap<string, Concept>;
-  broader: ReadonlyMap<string, string>;
-}
-
-export function buildConceptIndex(scheme: ConceptScheme): ConceptIndex {
-  const byUri = new Map<string, Concept>();
-  const broader = new Map<string, string>();
-  const walk = (concept: Concept, parentUri?: string) => {
-    byUri.set(concept.uri, concept);
-    if (parentUri) broader.set(concept.uri, parentUri);
-    if (concept.narrower) {
-      for (const child of concept.narrower) walk(child, concept.uri);
-    }
-  };
-  for (const top of scheme.topConcepts) walk(top);
-  return { byUri, broader };
-}
-
 export function toggleConcept(
   state: ConceptSchemeFilterState,
   concept: Concept,
@@ -89,29 +66,19 @@ function walkConcepts(concepts: Concept[]): Concept[] {
   return all;
 }
 
-// Buckets selections into sibling-set groups for the backend's `concept=`
-// param: one group per common broader URI, with top concepts keyed by the
-// scheme URI so they share a synthetic root. Auto-rollup can leave a parent
-// + every descendant selected; they land in separate groups (disjoint sibling
-// sets), which is what the backend validates.
+// All of a scheme's selected concepts OR-join into one `concept=` group — the
+// backend treats a whole scheme as one sibling set.
+// Returned in scheme preorder; URIs not in the tree are dropped (stale URLs).
 export function toConceptFilterGroups(
   state: ConceptSchemeFilterState,
   scheme: ConceptScheme,
 ): string[][] {
   if (state.size === 0) return [];
-  const index = buildConceptIndex(scheme);
-  const groups = new Map<string, string[]>();
+  const group: string[] = [];
   for (const concept of walkConcepts(scheme.topConcepts)) {
-    if (!state.has(concept.uri)) continue;
-    const groupKey = index.broader.get(concept.uri) ?? scheme.uri;
-    let group = groups.get(groupKey);
-    if (!group) {
-      group = [];
-      groups.set(groupKey, group);
-    }
-    group.push(concept.uri);
+    if (state.has(concept.uri)) group.push(concept.uri);
   }
-  return Array.from(groups.values());
+  return group.length > 0 ? [group] : [];
 }
 
 function indexConceptUrisByScheme(

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -15,7 +15,7 @@ export interface SearchFilters {
   annotation?: string[];
   sort?: string[];
   // One `concept=` URL param per inner array; URIs in an array are OR'd
-  // (must share a sibling set in the vocab), arrays are AND'd.
+  // (one scheme's selected concepts), arrays are AND'd (across schemes).
   conceptFilters?: readonly (readonly string[])[];
   // ISO-3166 alpha-2 codes; comma-joined into a single `country=` param. The
   // facet endpoint accepts only one OR'd country filter, which this satisfies.
@@ -29,8 +29,8 @@ function isPositiveSafeInt(n: number | undefined): n is number {
 }
 
 // concept and country are always serialised together — one `concept=` per
-// sibling group, one `country=` for the OR'd codes. Extend here when the
-// backend grows another structured filter (e.g. `country_wb_region=`).
+// scheme, one `country=` for the OR'd codes. Extend here when the backend
+// grows another structured filter (e.g. `country_wb_region=`).
 function appendStructuredFilters(
   params: URLSearchParams,
   filters: Pick<SearchFilters, "conceptFilters" | "countryCodes">,

--- a/src/services/searchParams.ts
+++ b/src/services/searchParams.ts
@@ -16,7 +16,7 @@ export interface SearchParams {
   endYear: number | undefined;
   sort: SortOption | undefined;
   // One `concept=` URL param per inner array; URIs in an array are OR'd
-  // (must share a sibling set), arrays are AND'd.
+  // (one scheme's selected concepts), arrays are AND'd (across schemes).
   conceptFilters: readonly (readonly string[])[];
   countryCodes: readonly string[];
 }

--- a/tests/components/filters/ConceptSchemeFilter.test.tsx
+++ b/tests/components/filters/ConceptSchemeFilter.test.tsx
@@ -268,7 +268,7 @@ describe("ConceptSchemeFilter (hierarchical)", () => {
     ).toBeNull();
   });
 
-  test("wraps a parent concept's count in a Tooltip explaining the parent semantics", () => {
+  test("wraps a parent concept's count in a Tooltip clarifying it's a toggle preview", () => {
     const counts = new Map<string, number>([
       [URI_ACCESS, 774],
       [URI_EDUCATION_FINANCE, 264],
@@ -282,22 +282,26 @@ describe("ConceptSchemeFilter (hierarchical)", () => {
         onChange={vi.fn()}
       />,
     );
-    // Parent ("Access to Education") has children → count wrapped in Tooltip.
+    // Parent ("Access to Education") has children → count wrapped in Tooltip,
+    // and the text no longer claims selecting it rolls up its children.
     const parentCount = container.querySelector(
       ".concept-scheme-filter__count--parent",
     );
     expect(parentCount).not.toBeNull();
-    expect(parentCount?.closest("[data-tooltip]")).not.toBeNull();
+    const tooltip = parentCount?.closest("[data-tooltip]");
+    expect(tooltip).not.toBeNull();
+    expect(tooltip?.getAttribute("data-tooltip")).toBe(
+      "Results you'd see if you toggled this concept.",
+    );
 
     // Leaf ("Education Finance") has no children → bare count, no tooltip.
-    const counts2 = container.querySelectorAll(
-      ".concept-scheme-filter__count",
-    );
-    const leafCount = Array.from(counts2).find(
+    const leafCount = Array.from(
+      container.querySelectorAll(".concept-scheme-filter__count"),
+    ).find(
       (n) => !n.classList.contains("concept-scheme-filter__count--parent"),
     );
     expect(leafCount).toBeDefined();
-    expect(leafCount?.closest('[data-tooltip]')).toBeNull();
+    expect(leafCount?.closest("[data-tooltip]")).toBeNull();
   });
 
   test("applies the is-updating class to counts while loading", () => {
@@ -334,8 +338,8 @@ describe("ConceptSchemeFilter (hierarchical)", () => {
   });
 
   test("clicking an unselected parent selects only the parent URI", () => {
-    // Cascade removed: clicking parent matches docs tagged with the parent
-    // URI literally, not its subtree. See destiny-repository#655.
+    // Clicking a parent adds only the parent URI — no cascade into
+    // descendants; it matches docs tagged with that URI literally.
     const onChange = vi.fn();
     render(
       <ConceptSchemeFilter

--- a/tests/components/filters/FilterDrawer.test.tsx
+++ b/tests/components/filters/FilterDrawer.test.tsx
@@ -152,7 +152,7 @@ describe("FilterDrawer", () => {
     expect((apply as HTMLButtonElement).disabled).toBe(false);
   });
 
-  test("Show results fires onApply with one sibling-set group per selection", () => {
+  test("Show results fires onApply with one OR-group per scheme", () => {
     const onApply = vi.fn();
     renderDrawer({ onApply });
     fireEvent.click(screen.getByLabelText("Journal Article"));
@@ -162,8 +162,8 @@ describe("FilterDrawer", () => {
     expect(onApply).toHaveBeenCalledTimes(1);
     const applied = onApply.mock.calls[0][0] as AppliedFilters;
     expect(applied.countryCodes).toEqual([]);
-    // Concepts from different schemes → separate sibling-set groups, in
-    // scheme order (Outcome first per TWO_SCHEMES).
+    // Concepts from different schemes → separate groups (AND'd across schemes),
+    // in scheme order (Outcome first per TWO_SCHEMES).
     expect(applied.conceptFilters).toEqual([
       ["https://vocab.esea.education/OutcomeScheme/C00130"],
       [URI_JOURNAL],

--- a/tests/components/filters/FilterDrawer.test.tsx
+++ b/tests/components/filters/FilterDrawer.test.tsx
@@ -171,8 +171,8 @@ describe("FilterDrawer", () => {
   });
 
   test("toggling parent concept emits only the parent URI (no cascade)", () => {
-    // Cascade removed: see destiny-repository#655. Children must be clicked
-    // individually until the backend matches narrower concepts implicitly.
+    // Toggling a parent adds only the parent URI — no cascade — so children
+    // must be clicked individually.
     const onApply = vi.fn();
     renderDrawer({ schemes: [OUTCOME_SCHEME_FIXTURE], onApply });
     fireEvent.click(screen.getByLabelText("Access to Education"));

--- a/tests/components/filters/conceptSchemeFilter.integration.test.tsx
+++ b/tests/components/filters/conceptSchemeFilter.integration.test.tsx
@@ -49,8 +49,8 @@ describe("FilterCard + ConceptSchemeFilter integration", () => {
     expect(screen.getByTestId("groups").textContent).toBe("[]");
 
     fireEvent.click(header);
-    // Click a parent and one of its children individually (cascade was removed,
-    // destiny-repository#655) — both should OR-join into the one scheme group.
+    // Click a parent and one of its children individually — both should
+    // OR-join into the one scheme group.
     fireEvent.click(screen.getByLabelText("Access to Education"));
     fireEvent.click(screen.getByLabelText("Education Finance"));
     fireEvent.click(header);

--- a/tests/components/filters/conceptSchemeFilter.integration.test.tsx
+++ b/tests/components/filters/conceptSchemeFilter.integration.test.tsx
@@ -49,26 +49,25 @@ describe("FilterCard + ConceptSchemeFilter integration", () => {
     expect(screen.getByTestId("groups").textContent).toBe("[]");
 
     fireEvent.click(header);
-    // Cascade was removed (destiny-repository#655) — click the parent and a
-    // child individually to exercise the multi-group emission.
+    // Click a parent and one of its children individually (cascade was removed,
+    // destiny-repository#655) — both should OR-join into the one scheme group.
     fireEvent.click(screen.getByLabelText("Access to Education"));
     fireEvent.click(screen.getByLabelText("Education Finance"));
     fireEvent.click(header);
 
     expect(header.getAttribute("aria-expanded")).toBe("false");
     expect(screen.getByText("2 selected")).toBeDefined();
-    // Parent + child sit in disjoint sibling-set groups (parent's broader is
-    // the scheme root; child's broader is the parent).
+    // The whole scheme is one sibling set, so parent + child OR-join into a
+    // single group (preorder: Access before its child Education Finance).
     const groups: string[][] = JSON.parse(
       screen.getByTestId("groups").textContent ?? "[]",
     );
     expect(groups).toEqual([
-      [URI_ACCESS],
-      [URI_EDUCATION_FINANCE],
+      [URI_ACCESS, URI_EDUCATION_FINANCE],
     ]);
 
     // Round-trip through the URL — a missing comma-join would split each URI
-    // into its own concept= param and trip the backend's sibling-set rule.
+    // into its own concept= param and AND them instead of OR'ing the scheme.
     const params = makeSearchParams({ conceptFilters: groups });
     const url = "?" + toQueryString(params);
     expect(parseSearchParams(url).conceptFilters).toEqual(groups);

--- a/tests/components/filters/conceptSchemeFilterState.test.ts
+++ b/tests/components/filters/conceptSchemeFilterState.test.ts
@@ -114,8 +114,8 @@ describe("toggleConcept", () => {
   });
 
   test("on a parent only adds the parent URI; descendants are not cascaded in", () => {
-    // Cascade was removed: selecting the parent matches docs tagged with the
-    // parent URI literally, not its subtree. See destiny-repository#655.
+    // Toggling a parent adds only the parent URI — no cascade into
+    // descendants; it matches docs tagged with that URI literally.
     const result = toggleConcept(emptyConceptSchemeState(), ACCESS_SUBTREE);
     expect(isSelected(result, URI_ACCESS)).toBe(true);
     expect(isSelected(result, URI_EDUCATION_FINANCE)).toBe(false);
@@ -218,7 +218,7 @@ describe("toConceptFilterGroups", () => {
   });
 
   // The whole scheme is one sibling set, so a parent and its descendants
-  // OR-join into a single group rather than AND'ing across depth levels.
+  // OR-join into a single group.
   test("a parent and its descendants collapse into one whole-scheme group", () => {
     const state = conceptSchemeStateFromUris([
       URI_ACCESS,

--- a/tests/components/filters/conceptSchemeFilterState.test.ts
+++ b/tests/components/filters/conceptSchemeFilterState.test.ts
@@ -1,6 +1,5 @@
 import { describe, test, expect } from "vitest";
 import {
-  buildConceptIndex,
   conceptSchemeStateFromUris,
   emptyConceptSchemeState,
   isEmpty,
@@ -174,30 +173,6 @@ describe("toggleConcept", () => {
   });
 });
 
-describe("buildConceptIndex", () => {
-  test("indexes every concept in the scheme by URI", () => {
-    const idx = buildConceptIndex(OUTCOME_SCHEME_FIXTURE);
-    expect(idx.byUri.get(URI_ACCESS)?.label).toBe("Access to Education");
-    expect(idx.byUri.get(URI_EDUCATION_FINANCE)?.label).toBe(
-      "Education Finance",
-    );
-    expect(idx.byUri.get(URI_ENROLMENT)?.label).toBe("Enrolment and Attendance");
-    expect(idx.byUri.get(URI_LEARNING)?.label).toBe(
-      "Educational Outcomes and Learning",
-    );
-    expect(idx.byUri.get(URI_RETURNS)?.label).toBe("Returns to Education");
-  });
-
-  test("maps each non-top concept to its parent and omits top concepts", () => {
-    const idx = buildConceptIndex(OUTCOME_SCHEME_FIXTURE);
-    expect(idx.broader.get(URI_EDUCATION_FINANCE)).toBe(URI_ACCESS);
-    expect(idx.broader.get(URI_ENROLMENT)).toBe(URI_ACCESS);
-    expect(idx.broader.has(URI_ACCESS)).toBe(false);
-    expect(idx.broader.has(URI_LEARNING)).toBe(false);
-    expect(idx.broader.has(URI_RETURNS)).toBe(false);
-  });
-});
-
 describe("toConceptFilterGroups", () => {
   test("returns no groups when state is empty", () => {
     expect(toConceptFilterGroups(emptyConceptSchemeState(), SCHEME)).toEqual([]);
@@ -235,28 +210,27 @@ describe("toConceptFilterGroups", () => {
     ]);
   });
 
-  test("a single narrower concept lands in one group keyed by its parent", () => {
+  test("a single narrower concept lands in one group", () => {
     const state = conceptSchemeStateFromUris([URI_EDUCATION_FINANCE]);
     expect(toConceptFilterGroups(state, OUTCOME_SCHEME_FIXTURE)).toEqual([
       [URI_EDUCATION_FINANCE],
     ]);
   });
 
-  // Parent + descendants can coexist in the state via URL hydration; they
-  // must split into disjoint sibling-set groups or the backend 400s on overlap.
-  test("a fully-selected subtree splits into separate sibling-set groups (parent vs descendants)", () => {
+  // The whole scheme is one sibling set, so a parent and its descendants
+  // OR-join into a single group rather than AND'ing across depth levels.
+  test("a parent and its descendants collapse into one whole-scheme group", () => {
     const state = conceptSchemeStateFromUris([
       URI_ACCESS,
       URI_EDUCATION_FINANCE,
       URI_ENROLMENT,
     ]);
     expect(toConceptFilterGroups(state, OUTCOME_SCHEME_FIXTURE)).toEqual([
-      [URI_ACCESS],
-      [URI_EDUCATION_FINANCE, URI_ENROLMENT],
+      [URI_ACCESS, URI_EDUCATION_FINANCE, URI_ENROLMENT],
     ]);
   });
 
-  test("top-level siblings under different parents do NOT mix with the same scheme's children", () => {
+  test("concepts at different depths all OR-join into one preorder group", () => {
     const state = conceptSchemeStateFromUris([
       URI_LEARNING,
       URI_RETURNS,
@@ -264,8 +238,7 @@ describe("toConceptFilterGroups", () => {
     ]);
     // Preorder: Education_Finance (under Access) comes before Learning/Returns.
     expect(toConceptFilterGroups(state, OUTCOME_SCHEME_FIXTURE)).toEqual([
-      [URI_EDUCATION_FINANCE],
-      [URI_LEARNING, URI_RETURNS],
+      [URI_EDUCATION_FINANCE, URI_LEARNING, URI_RETURNS],
     ]);
   });
 });

--- a/tests/pages/SearchPage.test.tsx
+++ b/tests/pages/SearchPage.test.tsx
@@ -475,8 +475,8 @@ describe("SearchPage", () => {
     });
 
     test("selecting a parent concept applies only the parent URI (no cascade)", async () => {
-      // Cascade removed: see destiny-repository#655. Selecting parent matches
-      // docs tagged with the parent URI literally, not its subtree.
+      // Selecting a parent applies only the parent URI — no cascade — matching
+      // docs tagged with it literally, not its subtree.
       mockBoth({ results: makeResult(120, ["r1"]) });
       renderSearchPage();
       await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());


### PR DESCRIPTION
Closes #113 

Fixes hierarchical query construction by OR-ing across entire concept schemes, not just those with a shared parent.

To be released in lockstep with https://github.com/destiny-evidence/destiny-repository/pull/729.