### PR TITLE
Plumb in cross-facet api

### DIFF
--- a/src/hooks/useCrossFacets.ts
+++ b/src/hooks/useCrossFacets.ts
@@ -1,0 +1,89 @@
+import { useEffect, useState } from "preact/hooks";
+import { crossFacets } from "@/services/apiClient";
+import { useCommunity } from "@/community/CommunityContext";
+import { toTurtleUrl } from "@/services/vocabulary/vocabularyService";
+import {
+  axisPairToParams,
+  type CrossFacetAxisPair,
+} from "@/services/crossFacets";
+import type { SearchParams } from "@/services/searchParams";
+import type { ReferenceCrossFacetResult } from "@/types/models";
+
+function paramsKey(
+  params: SearchParams,
+  axes: CrossFacetAxisPair,
+  slug: string,
+  annotations: string[],
+): string {
+  return [
+    `q=${params.q}`,
+    `start=${params.startYear ?? ""}`,
+    `end=${params.endYear ?? ""}`,
+    `slug=${slug}`,
+    `ann=${JSON.stringify(annotations)}`,
+    `countries=${JSON.stringify(params.countryCodes)}`,
+    `concepts=${JSON.stringify(params.conceptFilters)}`,
+    `row=${JSON.stringify(axes.row)}`,
+    `column=${JSON.stringify(axes.column)}`,
+  ].join("&");
+}
+
+export function useCrossFacets(
+  params: SearchParams,
+  axes: CrossFacetAxisPair,
+): {
+  result: ReferenceCrossFacetResult | null;
+  loading: boolean;
+  error: Error | null;
+} {
+  const community = useCommunity();
+  const key = paramsKey(
+    params,
+    axes,
+    community?.slug ?? "",
+    community?.defaultAnnotations ?? [],
+  );
+  const [result, setResult] = useState<ReferenceCrossFacetResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!community) return;
+    let cancelled = false;
+
+    setError(null);
+    setLoading(true);
+
+    crossFacets(
+      params.q || undefined,
+      {
+        startYear: params.startYear,
+        endYear: params.endYear,
+        annotation: community.defaultAnnotations,
+        conceptFilters: params.conceptFilters,
+        countryCodes: params.countryCodes,
+      },
+      axisPairToParams(axes, toTurtleUrl(community.vocabularyUrl)),
+    )
+      .then((r) => {
+        if (!cancelled) setResult(r);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(e);
+        setResult(null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  if (!community) return { result: null, loading: false, error: null };
+
+  return { result, loading, error };
+}

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -98,11 +98,11 @@ export async function searchReferenceFacets(
 export async function crossFacets(
   query: string | undefined,
   filters: Pick<SearchFilters, SharedFilterFields>,
-  axes: { row: string; column: string; vocabularyUrl?: string },
+  axes: { axes: readonly [string, string]; vocabularyUrl?: string },
 ): Promise<ReferenceCrossFacetResult> {
   const params = buildSharedSearchParams(query, filters);
-  params.set("row", axes.row);
-  params.set("column", axes.column);
+  // Repeated `axes=` param, in order — the backend reads it as a 2-tuple.
+  for (const axis of axes.axes) params.append("axes", axis);
   if (axes.vocabularyUrl) params.set("vocabulary", axes.vocabularyUrl);
   return api.get<ReferenceCrossFacetResult>(
     `/v1/references/search/cross-facets/?${params.toString()}`,

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -1,6 +1,7 @@
 import { api } from "@/api/client";
 import type {
   Reference,
+  ReferenceCrossFacetResult,
   ReferenceFacetResult,
   SearchExportRead,
   SearchResult,
@@ -89,6 +90,22 @@ export async function searchReferenceFacets(
   }
   return api.get<ReferenceFacetResult>(
     `/v1/references/search/facets/?${params.toString()}`,
+  );
+}
+
+// Cross-tabulates two axes over the references matching the search, for evidence
+// maps. Same filters as searchReferences; build `axes` with axisPairToParams.
+export async function crossFacets(
+  query: string | undefined,
+  filters: Pick<SearchFilters, SharedFilterFields>,
+  axes: { row: string; column: string; vocabularyUrl?: string },
+): Promise<ReferenceCrossFacetResult> {
+  const params = buildSharedSearchParams(query, filters);
+  params.set("row", axes.row);
+  params.set("column", axes.column);
+  if (axes.vocabularyUrl) params.set("vocabulary", axes.vocabularyUrl);
+  return api.get<ReferenceCrossFacetResult>(
+    `/v1/references/search/cross-facets/?${params.toString()}`,
   );
 }
 

--- a/src/services/crossFacets.ts
+++ b/src/services/crossFacets.ts
@@ -13,8 +13,7 @@ export interface CrossFacetAxisPair {
 }
 
 export interface CrossFacetQueryAxes {
-  row: string;
-  column: string;
+  axes: [string, string];
   vocabularyUrl?: string;
 }
 
@@ -26,12 +25,11 @@ export function axisPairToParams(
   pair: CrossFacetAxisPair,
   vocabularyUrl: string,
 ): CrossFacetQueryAxes {
-  const axes: CrossFacetQueryAxes = {
-    row: axisToken(pair.row),
-    column: axisToken(pair.column),
+  const result: CrossFacetQueryAxes = {
+    axes: [axisToken(pair.row), axisToken(pair.column)],
   };
   if (pair.row.kind === "scheme" || pair.column.kind === "scheme") {
-    axes.vocabularyUrl = vocabularyUrl;
+    result.vocabularyUrl = vocabularyUrl;
   }
-  return axes;
+  return result;
 }

--- a/src/services/crossFacets.ts
+++ b/src/services/crossFacets.ts
@@ -1,0 +1,37 @@
+export const AXIS_COUNTRIES = "countries";
+export const AXIS_REGIONS = "country_wb_regions";
+
+export type LiteralAxisToken = typeof AXIS_COUNTRIES | typeof AXIS_REGIONS;
+
+export type CrossFacetAxis =
+  | { kind: "literal"; token: LiteralAxisToken }
+  | { kind: "scheme"; schemeUri: string };
+
+export interface CrossFacetAxisPair {
+  row: CrossFacetAxis;
+  column: CrossFacetAxis;
+}
+
+export interface CrossFacetQueryAxes {
+  row: string;
+  column: string;
+  vocabularyUrl?: string;
+}
+
+function axisToken(axis: CrossFacetAxis): string {
+  return axis.kind === "literal" ? axis.token : axis.schemeUri;
+}
+
+export function axisPairToParams(
+  pair: CrossFacetAxisPair,
+  vocabularyUrl: string,
+): CrossFacetQueryAxes {
+  const axes: CrossFacetQueryAxes = {
+    row: axisToken(pair.row),
+    column: axisToken(pair.column),
+  };
+  if (pair.row.kind === "scheme" || pair.column.kind === "scheme") {
+    axes.vocabularyUrl = vocabularyUrl;
+  }
+  return axes;
+}

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -74,6 +74,17 @@ export interface ReferenceFacetResult {
   countries?: CountryFacetCount[];
 }
 
+export interface CrossFacetCell {
+  row: string;
+  column: string;
+  count: number;
+}
+
+export interface ReferenceCrossFacetResult {
+  total: SearchResultTotal;
+  cells: CrossFacetCell[];
+}
+
 export interface ExternalIdentifier {
   identifier: string | number;
   identifier_type: string | null;

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -75,8 +75,7 @@ export interface ReferenceFacetResult {
 }
 
 export interface CrossFacetCell {
-  row: string;
-  column: string;
+  axes: [string, string];
   count: number;
 }
 

--- a/tests/hooks/useCrossFacets.test.tsx
+++ b/tests/hooks/useCrossFacets.test.tsx
@@ -42,7 +42,7 @@ function result(
 ): ReferenceCrossFacetResult {
   return {
     total: { count: 99, is_lower_bound: false },
-    cells: cells.map(([row, column, count]) => ({ row, column, count })),
+    cells: cells.map(([a0, a1, count]) => ({ axes: [a0, a1], count })),
   };
 }
 
@@ -62,7 +62,7 @@ describe("useCrossFacets", () => {
 
     expect(hook.current.result?.total.count).toBe(99);
     expect(hook.current.result?.cells).toEqual([
-      { row: "AFE", column: SCHEME, count: 7 },
+      { axes: ["AFE", SCHEME], count: 7 },
     ]);
     expect(mockCrossFacets).toHaveBeenCalledWith(
       "phonics",
@@ -71,8 +71,7 @@ describe("useCrossFacets", () => {
         conceptFilters: [],
       }),
       {
-        row: "country_wb_regions",
-        column: SCHEME,
+        axes: ["country_wb_regions", SCHEME],
         vocabularyUrl: expect.stringMatching(/\.ttl$/),
       },
     );

--- a/tests/hooks/useCrossFacets.test.tsx
+++ b/tests/hooks/useCrossFacets.test.tsx
@@ -1,0 +1,119 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/preact";
+import type { ComponentChildren } from "preact";
+import { useCrossFacets } from "@/hooks/useCrossFacets";
+import { CommunityProvider } from "@/community/CommunityContext";
+import {
+  AXIS_COUNTRIES,
+  AXIS_REGIONS,
+  type CrossFacetAxisPair,
+} from "@/services/crossFacets";
+import type { ReferenceCrossFacetResult } from "@/types/models";
+import { makeSearchParams } from "../fixtures";
+
+vi.mock("@/services/apiClient", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/services/apiClient")>();
+  return { ...actual, crossFacets: vi.fn() };
+});
+
+import { crossFacets } from "@/services/apiClient";
+const mockCrossFacets = vi.mocked(crossFacets);
+
+const baseParams = makeSearchParams({ q: "phonics" });
+const SCHEME = "https://vocab.example/scheme/Themes";
+const regionVsScheme: CrossFacetAxisPair = {
+  row: { kind: "literal", token: AXIS_REGIONS },
+  column: { kind: "scheme", schemeUri: SCHEME },
+};
+const regionVsCountry: CrossFacetAxisPair = {
+  row: { kind: "literal", token: AXIS_REGIONS },
+  column: { kind: "literal", token: AXIS_COUNTRIES },
+};
+
+function withCommunityPath(path: string) {
+  window.history.replaceState(null, "", path);
+  return ({ children }: { children: ComponentChildren }) => (
+    <CommunityProvider>{children}</CommunityProvider>
+  );
+}
+
+function result(
+  ...cells: [string, string, number][]
+): ReferenceCrossFacetResult {
+  return {
+    total: { count: 99, is_lower_bound: false },
+    cells: cells.map(([row, column, count]) => ({ row, column, count })),
+  };
+}
+
+beforeEach(() => {
+  mockCrossFacets.mockReset();
+  window.history.replaceState(null, "", "/");
+});
+
+describe("useCrossFacets", () => {
+  test("forwards filters, resolves axes against the Turtle vocab, returns cells + total", async () => {
+    mockCrossFacets.mockResolvedValue(result(["AFE", SCHEME, 7]));
+    const { result: hook } = renderHook(
+      () => useCrossFacets(baseParams, regionVsScheme),
+      { wrapper: withCommunityPath("/esea") },
+    );
+    await waitFor(() => expect(hook.current.loading).toBe(false));
+
+    expect(hook.current.result?.total.count).toBe(99);
+    expect(hook.current.result?.cells).toEqual([
+      { row: "AFE", column: SCHEME, count: 7 },
+    ]);
+    expect(mockCrossFacets).toHaveBeenCalledWith(
+      "phonics",
+      expect.objectContaining({
+        annotation: ["domain-inclusion/jacobs-education"],
+        conceptFilters: [],
+      }),
+      {
+        row: "country_wb_regions",
+        column: SCHEME,
+        vocabularyUrl: expect.stringMatching(/\.ttl$/),
+      },
+    );
+  });
+
+  test("refetches when the axis selection changes", async () => {
+    mockCrossFacets.mockResolvedValue(result());
+    const { rerender } = renderHook(
+      ({ axes }) => useCrossFacets(baseParams, axes),
+      {
+        wrapper: withCommunityPath("/esea"),
+        initialProps: { axes: regionVsScheme },
+      },
+    );
+    await waitFor(() => expect(mockCrossFacets).toHaveBeenCalledTimes(1));
+    rerender({ axes: regionVsCountry });
+    await waitFor(() => expect(mockCrossFacets).toHaveBeenCalledTimes(2));
+  });
+
+  test("clears result to null on settled error", async () => {
+    mockCrossFacets.mockRejectedValue(new Error("boom"));
+    const { result: hook } = renderHook(
+      () => useCrossFacets(baseParams, regionVsScheme),
+      { wrapper: withCommunityPath("/esea") },
+    );
+    await waitFor(() => {
+      expect(hook.current.error?.message).toBe("boom");
+      expect(hook.current.result).toBeNull();
+      expect(hook.current.loading).toBe(false);
+    });
+  });
+
+  test("idle (no fetch) when slug resolves to no community", () => {
+    mockCrossFacets.mockResolvedValue(result());
+    const { result: hook } = renderHook(
+      () => useCrossFacets(baseParams, regionVsScheme),
+      { wrapper: withCommunityPath("/banana") },
+    );
+    expect(hook.current.result).toBeNull();
+    expect(hook.current.loading).toBe(false);
+    expect(hook.current.error).toBeNull();
+    expect(mockCrossFacets).not.toHaveBeenCalled();
+  });
+});

--- a/tests/services/apiClient.test.ts
+++ b/tests/services/apiClient.test.ts
@@ -3,10 +3,12 @@ import { api } from "@/api/client";
 import {
   searchReferences,
   searchReferenceFacets,
+  crossFacets,
   getReference,
 } from "@/services/apiClient";
 import type {
   Reference,
+  ReferenceCrossFacetResult,
   ReferenceFacetResult,
   SearchResult,
 } from "@/types/models";
@@ -195,6 +197,64 @@ describe("searchReferenceFacets", () => {
     };
     mockedGet.mockResolvedValue(result);
     const res = await searchReferenceFacets("x", {}, ["concepts"]);
+    expect(res).toBe(result);
+  });
+});
+
+describe("crossFacets", () => {
+  const result: ReferenceCrossFacetResult = {
+    total: { count: 42, is_lower_bound: false },
+    cells: [{ row: "AFE", column: "ex:Theme", count: 7 }],
+  };
+
+  test("hits the /cross-facets/ endpoint with q, row and column", async () => {
+    mockedGet.mockResolvedValue(result);
+    await crossFacets("phonics", {}, {
+      row: "country_wb_regions",
+      column: "countries",
+    });
+    expect(mockedGet.mock.calls[0][0]).toMatch(
+      /^\/v1\/references\/search\/cross-facets\/\?/,
+    );
+    const params = new URLSearchParams(mockedGet.mock.calls[0][0].split("?")[1]);
+    expect(params.get("q")).toBe("phonics");
+    expect(params.get("row")).toBe("country_wb_regions");
+    expect(params.get("column")).toBe("countries");
+  });
+
+  test("appends vocabulary only when provided", async () => {
+    mockedGet.mockResolvedValue(result);
+    await crossFacets("x", {}, { row: "countries", column: "countries" });
+    expect(
+      new URLSearchParams(mockedGet.mock.calls[0][0].split("?")[1]).has("vocabulary"),
+    ).toBe(false);
+
+    await crossFacets("x", {}, {
+      row: "https://vocab.example/scheme/Themes",
+      column: "countries",
+      vocabularyUrl: "https://vocab.example/v1/vocabulary.ttl",
+    });
+    expect(
+      new URLSearchParams(mockedGet.mock.calls[1][0].split("?")[1]).get("vocabulary"),
+    ).toBe("https://vocab.example/v1/vocabulary.ttl");
+  });
+
+
+  test("forwards concept and country filters", async () => {
+    mockedGet.mockResolvedValue(result);
+    await crossFacets(
+      "phonics",
+      { conceptFilters: [["ex:A"], ["ex:B"]], countryCodes: ["DE", "FR"] },
+      { row: "countries", column: "country_wb_regions" },
+    );
+    const params = new URLSearchParams(mockedGet.mock.calls[0][0].split("?")[1]);
+    expect(params.getAll("concept")).toEqual(["ex:A", "ex:B"]);
+    expect(params.get("country")).toBe("DE,FR");
+  });
+
+  test("returns the result from api.get", async () => {
+    mockedGet.mockResolvedValue(result);
+    const res = await crossFacets("x", {}, { row: "countries", column: "countries" });
     expect(res).toBe(result);
   });
 });

--- a/tests/services/apiClient.test.ts
+++ b/tests/services/apiClient.test.ts
@@ -204,34 +204,31 @@ describe("searchReferenceFacets", () => {
 describe("crossFacets", () => {
   const result: ReferenceCrossFacetResult = {
     total: { count: 42, is_lower_bound: false },
-    cells: [{ row: "AFE", column: "ex:Theme", count: 7 }],
+    cells: [{ axes: ["AFE", "ex:Theme"], count: 7 }],
   };
 
-  test("hits the /cross-facets/ endpoint with q, row and column", async () => {
+  test("hits the /cross-facets/ endpoint with q and the ordered axes pair", async () => {
     mockedGet.mockResolvedValue(result);
     await crossFacets("phonics", {}, {
-      row: "country_wb_regions",
-      column: "countries",
+      axes: ["country_wb_regions", "countries"],
     });
     expect(mockedGet.mock.calls[0][0]).toMatch(
       /^\/v1\/references\/search\/cross-facets\/\?/,
     );
     const params = new URLSearchParams(mockedGet.mock.calls[0][0].split("?")[1]);
     expect(params.get("q")).toBe("phonics");
-    expect(params.get("row")).toBe("country_wb_regions");
-    expect(params.get("column")).toBe("countries");
+    expect(params.getAll("axes")).toEqual(["country_wb_regions", "countries"]);
   });
 
   test("appends vocabulary only when provided", async () => {
     mockedGet.mockResolvedValue(result);
-    await crossFacets("x", {}, { row: "countries", column: "countries" });
+    await crossFacets("x", {}, { axes: ["countries", "countries"] });
     expect(
       new URLSearchParams(mockedGet.mock.calls[0][0].split("?")[1]).has("vocabulary"),
     ).toBe(false);
 
     await crossFacets("x", {}, {
-      row: "https://vocab.example/scheme/Themes",
-      column: "countries",
+      axes: ["https://vocab.example/scheme/Themes", "countries"],
       vocabularyUrl: "https://vocab.example/v1/vocabulary.ttl",
     });
     expect(
@@ -239,13 +236,12 @@ describe("crossFacets", () => {
     ).toBe("https://vocab.example/v1/vocabulary.ttl");
   });
 
-
   test("forwards concept and country filters", async () => {
     mockedGet.mockResolvedValue(result);
     await crossFacets(
       "phonics",
       { conceptFilters: [["ex:A"], ["ex:B"]], countryCodes: ["DE", "FR"] },
-      { row: "countries", column: "country_wb_regions" },
+      { axes: ["countries", "country_wb_regions"] },
     );
     const params = new URLSearchParams(mockedGet.mock.calls[0][0].split("?")[1]);
     expect(params.getAll("concept")).toEqual(["ex:A", "ex:B"]);
@@ -254,7 +250,7 @@ describe("crossFacets", () => {
 
   test("returns the result from api.get", async () => {
     mockedGet.mockResolvedValue(result);
-    const res = await crossFacets("x", {}, { row: "countries", column: "countries" });
+    const res = await crossFacets("x", {}, { axes: ["countries", "countries"] });
     expect(res).toBe(result);
   });
 });

--- a/tests/services/crossFacets.test.ts
+++ b/tests/services/crossFacets.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect } from "vitest";
+import {
+  AXIS_COUNTRIES,
+  AXIS_REGIONS,
+  axisPairToParams,
+  type CrossFacetAxis,
+} from "@/services/crossFacets";
+
+const VOCAB = "https://vocab.example/v1/vocabulary.ttl";
+const SCHEME = "https://vocab.example/scheme/Themes";
+
+const countries: CrossFacetAxis = { kind: "literal", token: AXIS_COUNTRIES };
+const regions: CrossFacetAxis = { kind: "literal", token: AXIS_REGIONS };
+const scheme: CrossFacetAxis = { kind: "scheme", schemeUri: SCHEME };
+
+describe("axisPairToParams", () => {
+  // A literal axis resolves to its token, a scheme axis to its URI; vocabularyUrl
+  // is attached iff either axis is a scheme.
+  test.each([
+    {
+      label: "both literal",
+      row: regions,
+      column: countries,
+      expected: { row: "country_wb_regions", column: "countries" },
+    },
+    {
+      label: "row scheme",
+      row: scheme,
+      column: countries,
+      expected: { row: SCHEME, column: "countries", vocabularyUrl: VOCAB },
+    },
+    {
+      label: "column scheme",
+      row: regions,
+      column: scheme,
+      expected: {
+        row: "country_wb_regions",
+        column: SCHEME,
+        vocabularyUrl: VOCAB,
+      },
+    },
+    {
+      label: "both schemes",
+      row: scheme,
+      column: scheme,
+      expected: { row: SCHEME, column: SCHEME, vocabularyUrl: VOCAB },
+    },
+  ])("$label", ({ row, column, expected }) => {
+    expect(axisPairToParams({ row, column }, VOCAB)).toEqual(expected);
+  });
+});

--- a/tests/services/crossFacets.test.ts
+++ b/tests/services/crossFacets.test.ts
@@ -14,36 +14,32 @@ const regions: CrossFacetAxis = { kind: "literal", token: AXIS_REGIONS };
 const scheme: CrossFacetAxis = { kind: "scheme", schemeUri: SCHEME };
 
 describe("axisPairToParams", () => {
-  // A literal axis resolves to its token, a scheme axis to its URI; vocabularyUrl
-  // is attached iff either axis is a scheme.
+  // row→axes[0], column→axes[1]; a literal resolves to its token, a scheme to its
+  // URI; vocabularyUrl is attached iff either axis is a scheme.
   test.each([
     {
       label: "both literal",
       row: regions,
       column: countries,
-      expected: { row: "country_wb_regions", column: "countries" },
+      expected: { axes: ["country_wb_regions", "countries"] },
     },
     {
       label: "row scheme",
       row: scheme,
       column: countries,
-      expected: { row: SCHEME, column: "countries", vocabularyUrl: VOCAB },
+      expected: { axes: [SCHEME, "countries"], vocabularyUrl: VOCAB },
     },
     {
       label: "column scheme",
       row: regions,
       column: scheme,
-      expected: {
-        row: "country_wb_regions",
-        column: SCHEME,
-        vocabularyUrl: VOCAB,
-      },
+      expected: { axes: ["country_wb_regions", SCHEME], vocabularyUrl: VOCAB },
     },
     {
       label: "both schemes",
       row: scheme,
       column: scheme,
-      expected: { row: SCHEME, column: SCHEME, vocabularyUrl: VOCAB },
+      expected: { axes: [SCHEME, SCHEME], vocabularyUrl: VOCAB },
     },
   ])("$label", ({ row, column, expected }) => {
     expect(axisPairToParams({ row, column }, VOCAB)).toEqual(expected);


### PR DESCRIPTION
Closes #117 by adding the plumbing for the incoming `/cross-facets/` endpoint.

Cannot be merged until https://github.com/destiny-evidence/destiny-repository/pull/727.