### PR TITLE
Visualise<->Search navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,8 +10,8 @@ import { URL_CHANGE_EVENT } from "./services/navigation";
 
 // preact-router intercepts internal <a href="/..."> clicks and updates the
 // URL via history.pushState without firing popstate or our URL_CHANGE_EVENT.
-// Bridging Router onChange into URL_CHANGE_EVENT keeps subscribers
-// (CommunityProvider, useUrlParams) in sync with router-driven navigation.
+// Bridging Router onChange into URL_CHANGE_EVENT keeps our URL subscribers
+// in sync with router-driven navigation.
 function emitUrlChange() {
   window.dispatchEvent(new Event(URL_CHANGE_EVENT));
 }

--- a/src/components/common/Tooltip.css
+++ b/src/components/common/Tooltip.css
@@ -32,7 +32,9 @@
   line-height: 1.4;
   width: max-content;
   max-width: 280px;
-  white-space: normal;
+  /* pre-line honours explicit "\n" in `text` (multi-line tooltips) while still
+     wrapping/collapsing other whitespace; single-line tooltips are unaffected. */
+  white-space: pre-line;
   text-align: left;
   z-index: 10;
   pointer-events: none;

--- a/src/components/common/Tooltip.css
+++ b/src/components/common/Tooltip.css
@@ -10,6 +10,16 @@
  *   so it fits inside the available space (see ConceptSchemeFilter.css).
  */
 
+/* Bubble appearance, shared with bespoke tooltips that can't reuse the pseudo
+   (e.g. the evidence map's fixed-positioned header tooltip). */
+:root {
+  --tooltip-bg: #161b22;
+  --tooltip-color: #fff;
+  --tooltip-padding: 12px 14px;
+  --tooltip-line-height: 1.4;
+  --tooltip-max-width: 280px;
+}
+
 .tooltip {
   position: relative;
   display: inline-flex;
@@ -23,15 +33,15 @@
   bottom: calc(100% + 8px);
   left: 50%;
   transform: translateX(-50%);
-  background: #161b22;
-  color: #fff;
-  padding: 12px 14px;
+  background: var(--tooltip-bg);
+  color: var(--tooltip-color);
+  padding: var(--tooltip-padding);
   border-radius: var(--radius-lg);
   font-size: 14px;
   font-weight: 400;
-  line-height: 1.4;
+  line-height: var(--tooltip-line-height);
   width: max-content;
-  max-width: 280px;
+  max-width: var(--tooltip-max-width);
   /* pre-line honours explicit "\n" in `text` (multi-line tooltips) while still
      wrapping/collapsing other whitespace; single-line tooltips are unaffected. */
   white-space: pre-line;

--- a/src/components/visualise/EvidenceMapGrid.css
+++ b/src/components/visualise/EvidenceMapGrid.css
@@ -88,6 +88,85 @@
   border-right: 1px solid var(--color-border);
 }
 
+/* Clickable header: the whole cell shades on hover, the affordance spanning the
+   cell even though the click target is the label. */
+.evidence-map__col-head--clickable:hover,
+.evidence-map__col-head--clickable:focus-within,
+.evidence-map__row-head--clickable:hover,
+.evidence-map__row-head--clickable:focus-within {
+  background: var(--color-accent-light);
+}
+
+/* Underline the label to mark the header as a link through to Search. */
+.evidence-map__col-head--clickable .evidence-map__col-head-label,
+.evidence-map__row-head--clickable .evidence-map__row-head-label {
+  text-decoration: underline;
+  text-decoration-color: var(--color-text-tertiary);
+  text-underline-offset: 2px;
+}
+
+/* The clickable label: a button wrapping just the text. Sized to the text —
+   block in a column head so it keeps the centred, wrapping/hyphenating label;
+   inline in a row head so it hugs the left-aligned text. */
+.evidence-map__col-head .evidence-map__head-link,
+.evidence-map__row-head .evidence-map__head-link {
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  text-align: inherit;
+}
+
+.evidence-map__col-head .evidence-map__head-link {
+  display: block;
+  width: 100%;
+}
+
+.evidence-map__row-head .evidence-map__head-link {
+  display: inline-block;
+}
+
+.evidence-map__head-link:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+/* The header tooltip: a fixed-positioned bubble (JS sets left/top from the
+   hovered header) so it escapes the scroll box and the map column's overflow,
+   which clip any in-cell pseudo-element. It sits above the text; --tail-x keeps
+   the tail over the text when the bubble is clamped to the viewport edge. */
+.evidence-map__head-tip {
+  position: fixed;
+  transform: translate(-50%, calc(-100% - 8px));
+  z-index: 1000;
+  pointer-events: none;
+  background: var(--tooltip-bg);
+  color: var(--tooltip-color);
+  padding: var(--tooltip-padding);
+  border-radius: var(--radius-lg);
+  font-size: var(--font-size-xs);
+  line-height: var(--tooltip-line-height);
+  width: max-content;
+  max-width: var(--tooltip-max-width);
+  white-space: pre-line;
+  text-align: left;
+  box-shadow: var(--shadow-md);
+}
+
+.evidence-map__head-tip::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: calc(50% + var(--tail-x, 0px));
+  transform: translateX(-50%);
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-top: 8px solid var(--tooltip-bg);
+}
+
 /* ── Corner: total + axis key ── */
 .evidence-map__corner {
   top: 0;
@@ -187,7 +266,7 @@
   transform: translateX(-50%);
   border-left: 6px solid transparent;
   border-right: 6px solid transparent;
-  border-top: 8px solid #161b22;
+  border-top: 8px solid var(--tooltip-bg);
   z-index: 10;
 }
 

--- a/src/components/visualise/EvidenceMapGrid.css
+++ b/src/components/visualise/EvidenceMapGrid.css
@@ -166,7 +166,9 @@
 .evidence-map__cell .tooltip:focus-visible::after {
   white-space: pre-line;
   font-size: var(--font-size-xs);
-  bottom: calc(50% + var(--evidence-map-dot, 0px) + 8px);
+  bottom: calc(
+    50% + var(--evidence-map-dot, 0px) + var(--evidence-map-tip-lift, 0px) + 8px
+  );
 }
 
 /* Speech-bubble tail: a downward triangle whose apex meets the dot's top edge,
@@ -176,13 +178,21 @@
 .evidence-map__cell .tooltip:focus-visible::before {
   content: "";
   position: absolute;
-  bottom: calc(50% + var(--evidence-map-dot, 0px));
+  bottom: calc(
+    50% + var(--evidence-map-dot, 0px) + var(--evidence-map-tip-lift, 0px)
+  );
   left: 50%;
   transform: translateX(-50%);
   border-left: 6px solid transparent;
   border-right: 6px solid transparent;
   border-top: 8px solid #161b22;
   z-index: 10;
+}
+
+/* Table cells have no bubble (--evidence-map-dot is 0), so the tail would land
+   on the centre of the number. Lift it clear of the digits. */
+.evidence-map__table--table .evidence-map__cell {
+  --evidence-map-tip-lift: 14px;
 }
 
 .evidence-map__cell-inner,

--- a/src/components/visualise/EvidenceMapGrid.tsx
+++ b/src/components/visualise/EvidenceMapGrid.tsx
@@ -136,7 +136,7 @@ export function EvidenceMapGrid({
         >
           <thead>
             <tr>
-              <th class="evidence-map__corner" scope="col">
+              <th class="evidence-map__corner" role="presentation">
                 {total !== undefined && (
                   <span class="evidence-map__total">
                     <span class="evidence-map__total-count">{total}</span>{" "}

--- a/src/components/visualise/EvidenceMapGrid.tsx
+++ b/src/components/visualise/EvidenceMapGrid.tsx
@@ -31,10 +31,15 @@ interface EvidenceMapGridProps {
   onCellClick?: (row: AxisCategory, column: AxisCategory) => void;
 }
 
-// Just the count for now; the row and column are evident from the headers and
-// the dot's position. A line about where clicking navigates will follow.
-function cellTooltip(count: number | undefined, countNoun: string): string {
-  return `${(count ?? 0).toLocaleString()} ${countNoun}`;
+// Just the count (the row and column are evident from the headers), plus a
+// "click to view" affordance on cells that deep-link into Search.
+function cellTooltip(
+  count: number | undefined,
+  countNoun: string,
+  clickable: boolean,
+): string {
+  const summary = `${(count ?? 0).toLocaleString()} ${countNoun}`;
+  return clickable ? `${summary} — click to view` : summary;
 }
 
 export function EvidenceMapGrid({
@@ -104,6 +109,7 @@ export function EvidenceMapGrid({
                 {columns.map((column) => {
                   const count = getCount(row.key, column.key);
                   const empty = count === undefined || count <= 0;
+                  const clickable = onCellClick !== undefined && !empty;
                   return (
                     <Cell
                       key={column.key}
@@ -111,11 +117,9 @@ export function EvidenceMapGrid({
                       count={count ?? 0}
                       maxCount={maxCount}
                       view={view}
-                      tooltip={cellTooltip(count, countNoun)}
+                      tooltip={cellTooltip(count, countNoun, clickable)}
                       onClick={
-                        onCellClick && !empty
-                          ? () => onCellClick(row, column)
-                          : undefined
+                        clickable ? () => onCellClick(row, column) : undefined
                       }
                     />
                   );

--- a/src/components/visualise/EvidenceMapGrid.tsx
+++ b/src/components/visualise/EvidenceMapGrid.tsx
@@ -31,15 +31,19 @@ interface EvidenceMapGridProps {
   onCellClick?: (row: AxisCategory, column: AxisCategory) => void;
 }
 
-// Just the count (the row and column are evident from the headers), plus a
-// "click to view" affordance on cells that deep-link into Search.
+// Bubble view shows a compact count, so its tooltip leads with the exact value;
+// table view already shows the count, so its tooltip is only the action line.
+// The action line (second, in bubble view) appears on cells that deep-link.
 function cellTooltip(
   count: number | undefined,
   countNoun: string,
   clickable: boolean,
-): string {
+  view: MapView,
+): string | undefined {
+  const action = `Click to view matching ${countNoun}`;
+  if (view === "table") return clickable ? action : undefined;
   const summary = `${(count ?? 0).toLocaleString()} ${countNoun}`;
-  return clickable ? `${summary} — click to view` : summary;
+  return clickable ? `${summary}\n${action}` : summary;
 }
 
 export function EvidenceMapGrid({
@@ -117,7 +121,7 @@ export function EvidenceMapGrid({
                       count={count ?? 0}
                       maxCount={maxCount}
                       view={view}
-                      tooltip={cellTooltip(count, countNoun, clickable)}
+                      tooltip={cellTooltip(count, countNoun, clickable, view)}
                       onClick={
                         clickable ? () => onCellClick(row, column) : undefined
                       }
@@ -141,7 +145,7 @@ interface CellProps {
   count: number;
   maxCount: number;
   view: MapView;
-  tooltip: string;
+  tooltip: string | undefined;
   onClick?: () => void;
 }
 
@@ -170,19 +174,14 @@ function Cell({ empty, count, maxCount, view, tooltip, onClick }: CellProps) {
     <span class="evidence-map__cell-inner">{inner}</span>
   );
 
-  // No tooltip on the table view yet — the count is already shown in the cell.
-  // It returns once cells carry a second value beyond the count; the `tooltip`
-  // prop stays wired so that's a one-line change to the condition below.
+  // Tooltip shows in both views; it no-ops when `tooltip` is undefined (a
+  // non-clickable table cell, whose count is already on screen).
   return (
     <td
       class={`evidence-map__cell${empty ? " is-empty" : ""}`}
       style={{ "--evidence-map-dot": `${radius}px` }}
     >
-      {view === "bubble" ? (
-        <Tooltip text={tooltip}>{content}</Tooltip>
-      ) : (
-        content
-      )}
+      <Tooltip text={tooltip}>{content}</Tooltip>
     </td>
   );
 }

--- a/src/components/visualise/EvidenceMapGrid.tsx
+++ b/src/components/visualise/EvidenceMapGrid.tsx
@@ -48,6 +48,17 @@ function cellTooltip(
   return clickable ? `${summary}\n${action}` : summary;
 }
 
+// The button's only visible content is the count, so a screen reader would
+// announce just "5, button". Spell out the cell's coordinates and the action.
+function cellAriaLabel(
+  count: number,
+  countNoun: string,
+  rowLabel: string,
+  columnLabel: string,
+): string {
+  return `${rowLabel}, ${columnLabel}: ${count.toLocaleString()} ${countNoun}. View matching ${countNoun}.`;
+}
+
 export function EvidenceMapGrid({
   rows,
   columns,
@@ -129,6 +140,16 @@ export function EvidenceMapGrid({
                       maxCount={maxCount}
                       view={view}
                       tooltip={cellTooltip(count, countNoun, clickable, view)}
+                      ariaLabel={
+                        clickable
+                          ? cellAriaLabel(
+                              count ?? 0,
+                              countNoun,
+                              row.label,
+                              column.label,
+                            )
+                          : undefined
+                      }
                       onClick={
                         clickable ? () => onCellClick(row, column) : undefined
                       }
@@ -153,10 +174,19 @@ interface CellProps {
   maxCount: number;
   view: MapView;
   tooltip: string | undefined;
+  ariaLabel: string | undefined;
   onClick?: () => void;
 }
 
-function Cell({ empty, count, maxCount, view, tooltip, onClick }: CellProps) {
+function Cell({
+  empty,
+  count,
+  maxCount,
+  view,
+  tooltip,
+  ariaLabel,
+  onClick,
+}: CellProps) {
   // Bubble radius drives the tooltip/tail anchor (--evidence-map-dot): the dot
   // is centred in the cell, so the tail points at it rather than the cell edge.
   const radius =
@@ -174,7 +204,12 @@ function Cell({ empty, count, maxCount, view, tooltip, onClick }: CellProps) {
     );
 
   const content = onClick ? (
-    <button type="button" class="evidence-map__cell-button" onClick={onClick}>
+    <button
+      type="button"
+      class="evidence-map__cell-button"
+      aria-label={ariaLabel}
+      onClick={onClick}
+    >
       {inner}
     </button>
   ) : (

--- a/src/components/visualise/EvidenceMapGrid.tsx
+++ b/src/components/visualise/EvidenceMapGrid.tsx
@@ -1,3 +1,4 @@
+import { useLayoutEffect, useRef, useState } from "preact/hooks";
 import {
   bubbleRadius,
   formatCompact,
@@ -31,6 +32,10 @@ interface EvidenceMapGridProps {
   dimmed?: boolean;
   // When supplied, cells become clickable buttons.
   onCellClick?: (row: AxisCategory, column: AxisCategory) => void;
+  // When supplied, row/column headers become clickable buttons that deep-link
+  // into Search filtered by that single axis category.
+  onRowClick?: (row: AxisCategory) => void;
+  onColumnClick?: (column: AxisCategory) => void;
 }
 
 // Bubble view shows a compact count, so its tooltip leads with the exact value;
@@ -59,6 +64,12 @@ function cellAriaLabel(
   return `${rowLabel}, ${columnLabel}: ${count.toLocaleString()} ${countNoun}. View matching ${countNoun}.`;
 }
 
+// The button's visible content is only its label, so the action is spelled out
+// in the aria-label for screen readers (the tooltip conveys it to sighted users).
+function headerAriaLabel(label: string, countNoun: string): string {
+  return `${label}: view matching ${countNoun}.`;
+}
+
 export function EvidenceMapGrid({
   rows,
   columns,
@@ -72,7 +83,40 @@ export function EvidenceMapGrid({
   updating = false,
   dimmed = false,
   onCellClick,
+  onRowClick,
+  onColumnClick,
 }: EvidenceMapGridProps) {
+  const headerTooltip = `Click to view matching ${countNoun}`;
+
+  // Header tooltips can't be CSS pseudo-elements: the headers live inside the
+  // scroll box (overflow) and the map column (overflow: hidden), both of which
+  // clip a bubble that escapes the cell. Instead a single fixed-positioned
+  // bubble is measured against the hovered/focused header so it can sit above
+  // the text, clear of every clip. tailX tracks the text when the bubble is
+  // clamped to the viewport edge.
+  const [tip, setTip] = useState<{ text: string; x: number; y: number } | null>(
+    null,
+  );
+  const tipRef = useRef<HTMLDivElement>(null);
+  const showTip = (text: string, el: HTMLElement) => {
+    const r = el.getBoundingClientRect();
+    setTip({ text, x: r.left + r.width / 2, y: r.top });
+  };
+  const hideTip = () => setTip(null);
+
+  useLayoutEffect(() => {
+    const el = tipRef.current;
+    if (!tip || !el) return;
+    const half = el.offsetWidth / 2;
+    const margin = 8;
+    const x = Math.max(
+      margin + half,
+      Math.min(tip.x, window.innerWidth - margin - half),
+    );
+    el.style.left = `${x}px`;
+    el.style.setProperty("--tail-x", `${tip.x - x}px`);
+  }, [tip]);
+
   return (
     <div
       class={`evidence-map${updating ? " is-updating" : ""}${
@@ -114,10 +158,24 @@ export function EvidenceMapGrid({
                 </span>
               </th>
               {columns.map((column) => (
-                <th key={column.key} class="evidence-map__col-head" scope="col">
-                  <span class="evidence-map__col-head-label">
-                    {column.label}
-                  </span>
+                <th
+                  key={column.key}
+                  class={`evidence-map__col-head${
+                    onColumnClick ? " evidence-map__col-head--clickable" : ""
+                  }`}
+                  scope="col"
+                >
+                  <HeaderLabel
+                    label={column.label}
+                    labelClass="evidence-map__col-head-label"
+                    tooltip={headerTooltip}
+                    ariaLabel={headerAriaLabel(column.label, countNoun)}
+                    onClick={
+                      onColumnClick ? () => onColumnClick(column) : undefined
+                    }
+                    onTipShow={showTip}
+                    onTipHide={hideTip}
+                  />
                 </th>
               ))}
             </tr>
@@ -125,8 +183,21 @@ export function EvidenceMapGrid({
           <tbody>
             {rows.map((row) => (
               <tr key={row.key}>
-                <th class="evidence-map__row-head" scope="row">
-                  {row.label}
+                <th
+                  class={`evidence-map__row-head${
+                    onRowClick ? " evidence-map__row-head--clickable" : ""
+                  }`}
+                  scope="row"
+                >
+                  <HeaderLabel
+                    label={row.label}
+                    labelClass="evidence-map__row-head-label"
+                    tooltip={headerTooltip}
+                    ariaLabel={headerAriaLabel(row.label, countNoun)}
+                    onClick={onRowClick ? () => onRowClick(row) : undefined}
+                    onTipShow={showTip}
+                    onTipHide={hideTip}
+                  />
                 </th>
                 {columns.map((column) => {
                   const count = getCount(row.key, column.key);
@@ -164,7 +235,56 @@ export function EvidenceMapGrid({
       {view === "bubble" && (
         <MapLegend maxCount={maxCount} countNoun={countNoun} />
       )}
+      {tip && (
+        <div
+          ref={tipRef}
+          class="evidence-map__head-tip"
+          style={{ left: `${tip.x}px`, top: `${tip.y}px` }}
+          aria-hidden="true"
+        >
+          {tip.text}
+        </div>
+      )}
     </div>
+  );
+}
+
+// A row/column header label. When clickable it's a button wrapping just the
+// label text (the click target is the label, while the whole cell shades on
+// hover — see CSS). Hover/focus reports the button's box up to the grid, which
+// positions the shared fixed tooltip above the text.
+function HeaderLabel({
+  label,
+  labelClass,
+  tooltip,
+  ariaLabel,
+  onClick,
+  onTipShow,
+  onTipHide,
+}: {
+  label: string;
+  labelClass?: string;
+  tooltip: string;
+  ariaLabel: string;
+  onClick?: () => void;
+  onTipShow: (text: string, el: HTMLElement) => void;
+  onTipHide: () => void;
+}) {
+  const labelSpan = <span class={labelClass}>{label}</span>;
+  if (!onClick) return labelSpan;
+  return (
+    <button
+      type="button"
+      class="evidence-map__head-link"
+      aria-label={ariaLabel}
+      onClick={onClick}
+      onMouseEnter={(e) => onTipShow(tooltip, e.currentTarget)}
+      onMouseLeave={onTipHide}
+      onFocus={(e) => onTipShow(tooltip, e.currentTarget)}
+      onBlur={onTipHide}
+    >
+      {labelSpan}
+    </button>
   );
 }
 

--- a/src/hooks/useHistoryState.ts
+++ b/src/hooks/useHistoryState.ts
@@ -1,0 +1,19 @@
+import { useState, useEffect } from "preact/hooks";
+import { URL_CHANGE_EVENT } from "@/services/navigation";
+
+// Reactive read of history.state. State only changes alongside a navigation, so
+// the same events useUrlParams watches keep this in sync — popstate included, so
+// the browser restoring a prior entry's state on back/forward is picked up too.
+export function useHistoryState(): unknown {
+  const [state, setState] = useState(() => window.history.state);
+  useEffect(() => {
+    const onChange = () => setState(window.history.state);
+    window.addEventListener(URL_CHANGE_EVENT, onChange);
+    window.addEventListener("popstate", onChange);
+    return () => {
+      window.removeEventListener(URL_CHANGE_EVENT, onChange);
+      window.removeEventListener("popstate", onChange);
+    };
+  }, []);
+  return state;
+}

--- a/src/pages/SearchPage.css
+++ b/src/pages/SearchPage.css
@@ -3,6 +3,27 @@
   padding: 0 var(--spacing-lg) var(--spacing-xl);
 }
 
+.search-page__back {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: var(--spacing-md);
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+.search-page__back:hover {
+  color: var(--color-accent-hover);
+  text-decoration: underline;
+}
+
+.search-page__back-arrow {
+  font-size: 16px;
+  line-height: 1;
+}
+
 .search-hero {
   padding: 48px 32px 36px;
   text-align: center;

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -119,8 +119,13 @@ function SearchPageInner({ community }: { community: Community }) {
   // Set when a map cell deep-linked here (see VisualisePage). Confined to this
   // community's visualise route so a stale state entry can't render a bad link.
   const backUrl = backToVisualiseUrl(useHistoryState());
+  // Match the route exactly, then the query string — not a `startsWith` prefix,
+  // which would also accept sibling routes like `/{slug}/visualise-elsewhere`.
+  const visualisePath = `/${community.slug}/visualise`;
   const visualiseBackUrl =
-    backUrl?.startsWith(`/${community.slug}/visualise`) ? backUrl : null;
+    backUrl === visualisePath || backUrl?.startsWith(`${visualisePath}?`)
+      ? backUrl
+      : null;
 
   // Canonicalize once: if URL query string doesn't match the canonical form,
   // silently rewrite via replaceState. Keyed on canonicalQs so it runs per divergence.

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -9,7 +9,9 @@ import {
   type SortOption,
 } from "@/services/searchParams";
 import { navigate } from "@/services/navigation";
+import { backToVisualiseUrl } from "@/services/evidenceMap";
 import { useUrlParams } from "@/hooks/useUrlParams";
+import { useHistoryState } from "@/hooks/useHistoryState";
 import { useCorpusTotal } from "@/hooks/useCorpusTotal";
 import { useSearch } from "@/hooks/useSearch";
 import { useSearchDraft } from "@/hooks/useSearchDraft";
@@ -113,6 +115,12 @@ function SearchPageInner({ community }: { community: Community }) {
   const search = useUrlParams();
   const params = parseSearchParams(search);
   const canonicalQs = toQueryString(params);
+
+  // Set when a map cell deep-linked here (see VisualisePage). Confined to this
+  // community's visualise route so a stale state entry can't render a bad link.
+  const backUrl = backToVisualiseUrl(useHistoryState());
+  const visualiseBackUrl =
+    backUrl?.startsWith(`/${community.slug}/visualise`) ? backUrl : null;
 
   // Canonicalize once: if URL query string doesn't match the canonical form,
   // silently rewrite via replaceState. Keyed on canonicalQs so it runs per divergence.
@@ -271,6 +279,14 @@ function SearchPageInner({ community }: { community: Community }) {
 
   return (
     <div class="search-page">
+      {visualiseBackUrl && (
+        <a class="search-page__back" href={visualiseBackUrl}>
+          <span class="search-page__back-arrow" aria-hidden="true">
+            ←
+          </span>
+          Back to Visualise
+        </a>
+      )}
       <section class="search-hero">
         <h1 class="search-hero__title">Search the evidence</h1>
         <p class="search-hero__subtitle">

--- a/src/pages/VisualisePage.css
+++ b/src/pages/VisualisePage.css
@@ -96,6 +96,13 @@
   gap: var(--spacing-lg);
 }
 
+/* Pinned to the right of the toolbar — the wireframe's top-right hint. */
+.evidence-map-view__hint {
+  margin: 0 0 0 auto;
+  font-size: var(--font-size-small);
+  color: var(--color-text-tertiary);
+}
+
 .evidence-map-view__total {
   font-size: var(--font-size-body);
   color: var(--color-text-secondary);

--- a/src/pages/VisualisePage.tsx
+++ b/src/pages/VisualisePage.tsx
@@ -6,6 +6,7 @@ import { useVocabulary } from "@/hooks/useVocabulary";
 import {
   parseSearchParams,
   toQueryString,
+  buildSearchUrl,
   type SearchParams,
 } from "@/services/searchParams";
 import { navigate } from "@/services/navigation";
@@ -14,6 +15,9 @@ import {
   buildEvidenceMapModel,
   parseAxis,
   resolveMapAxis,
+  cellSearchParams,
+  backToVisualiseState,
+  type AxisCategory,
 } from "@/services/evidenceMap";
 import {
   AXIS_COUNTRIES,
@@ -189,6 +193,17 @@ function EvidenceMapView({
     );
   }
 
+  // Deep-link a cell into Search: the map's filters plus the cell's row and
+  // column applied as filters. Stash the map's own URL in history.state so the
+  // search page can offer a "Back to Visualise" link to exactly this view.
+  function handleCellClick(row: AxisCategory, column: AxisCategory) {
+    const next = cellSearchParams(params, axes, row, column);
+    const mapUrl = `/${community.slug}/visualise?${canonical}`;
+    navigate(buildSearchUrl(community.slug, next), {
+      state: backToVisualiseState(mapUrl),
+    });
+  }
+
   const noun = community.copy.countNoun;
   // Scheme axes draw their categories from the vocabulary, so a greyed grid can
   // render even when no cells come back (the no-coverage state).
@@ -245,6 +260,7 @@ function EvidenceMapView({
                 columnAxisLabel={columnAxis.title}
                 total={formatTotal(result.total)}
                 updating={loading}
+                onCellClick={handleCellClick}
               />
             ) : result.cells.length > 0 ? (
               // Data exists but the vocabulary hasn't supplied categories yet.

--- a/src/pages/VisualisePage.tsx
+++ b/src/pages/VisualisePage.tsx
@@ -291,7 +291,10 @@ function EvidenceMapView({
                 columnAxisLabel={columnAxis.title}
                 total={formatTotal(result.total)}
                 updating={loading}
-                onCellClick={handleCellClick}
+                // While refetching, the grid still shows the prior result but
+                // params/axes are already the new ones — a stale-cell click would
+                // mix old keys with new axes. Disable clicks until the fetch lands.
+                onCellClick={loading ? undefined : handleCellClick}
                 dimmed={result.total.count === 0}
               />
             ) : result.cells.length > 0 ? (

--- a/src/pages/VisualisePage.tsx
+++ b/src/pages/VisualisePage.tsx
@@ -209,6 +209,9 @@ function EvidenceMapView({
   // render even when no cells come back (the no-coverage state).
   const hasGrid =
     model !== null && model.rows.length > 0 && model.columns.length > 0;
+  // Gate the "click a cell" hint on there being a clickable (non-empty) cell, so
+  // it doesn't mislead in the over-filtered or no-coverage states.
+  const showHint = result !== null && result.cells.length > 0 && hasGrid;
 
   return (
     <div class="evidence-map-view">
@@ -216,6 +219,11 @@ function EvidenceMapView({
         <h1 class="visualise-page__title">Evidence map</h1>
         <div class="evidence-map-view__toolbar">
           <ViewToggle value={view} onChange={setView} />
+          {showHint && (
+            <p class="evidence-map-view__hint">
+              Click a cell to view matching {noun}
+            </p>
+          )}
         </div>
 
         {error ? (

--- a/src/pages/VisualisePage.tsx
+++ b/src/pages/VisualisePage.tsx
@@ -16,6 +16,7 @@ import {
   parseAxis,
   resolveMapAxis,
   cellSearchParams,
+  axisSearchParams,
   backToVisualiseState,
   type AxisCategory,
 } from "@/services/evidenceMap";
@@ -197,7 +198,22 @@ function EvidenceMapView({
   // column applied as filters. Stash the map's own URL in history.state so the
   // search page can offer a "Back to Visualise" link to exactly this view.
   function handleCellClick(row: AxisCategory, column: AxisCategory) {
-    const next = cellSearchParams(params, axes, row, column);
+    deepLinkToSearch(cellSearchParams(params, axes, row, column));
+  }
+
+  // Same deep-link, but filtered by a single axis category (a row/column header
+  // click) rather than both.
+  function handleRowClick(row: AxisCategory) {
+    deepLinkToSearch(axisSearchParams(params, axes.row, row));
+  }
+
+  function handleColumnClick(column: AxisCategory) {
+    deepLinkToSearch(axisSearchParams(params, axes.column, column));
+  }
+
+  // Navigate into Search with the given params, stashing the map's own URL in
+  // history.state so the search page can offer a "Back to Visualise" link.
+  function deepLinkToSearch(next: SearchParams) {
     const mapUrl = `/${community.slug}/visualise?${canonical}`;
     navigate(buildSearchUrl(community.slug, next), {
       state: backToVisualiseState(mapUrl),
@@ -295,6 +311,19 @@ function EvidenceMapView({
                 // params/axes are already the new ones — a stale-cell click would
                 // mix old keys with new axes. Disable clicks until the fetch lands.
                 onCellClick={loading ? undefined : handleCellClick}
+                // Headers deep-link by a single axis. Disabled while refetching
+                // (stale keys) and in the over-filtered state, where adding a
+                // filter to a 0-result set is pointless.
+                onRowClick={
+                  loading || result.total.count === 0
+                    ? undefined
+                    : handleRowClick
+                }
+                onColumnClick={
+                  loading || result.total.count === 0
+                    ? undefined
+                    : handleColumnClick
+                }
                 dimmed={result.total.count === 0}
               />
             ) : result.cells.length > 0 ? (

--- a/src/services/communities.ts
+++ b/src/services/communities.ts
@@ -49,7 +49,7 @@ const COMMUNITIES: Community[] = [
     filterExcludedSchemes: [
       "https://vocab.esea.education/ImplementationDescriptionScheme",
     ],
-    features: { ...DEFAULT_FEATURES, evidenceMap: true },
+    features: { ...DEFAULT_FEATURES },
     defaultEvidenceMapAxes: {
       row: {
         kind: "scheme",

--- a/src/services/communities.ts
+++ b/src/services/communities.ts
@@ -49,7 +49,7 @@ const COMMUNITIES: Community[] = [
     filterExcludedSchemes: [
       "https://vocab.esea.education/ImplementationDescriptionScheme",
     ],
-    features: { ...DEFAULT_FEATURES },
+    features: { ...DEFAULT_FEATURES, evidenceMap: true },
     defaultEvidenceMapAxes: {
       row: {
         kind: "scheme",

--- a/src/services/evidenceMap.ts
+++ b/src/services/evidenceMap.ts
@@ -1,4 +1,9 @@
-import type { CrossFacetCell, EvidenceMapAxis } from "@/types/models";
+import type {
+  CrossFacetCell,
+  EvidenceMapAxes,
+  EvidenceMapAxis,
+} from "@/types/models";
+import type { SearchParams } from "@/services/searchParams";
 import {
   schemeDisplayLabel,
   type Concept,
@@ -174,4 +179,50 @@ export function legendTicks(maxCount: number): number[] {
   if (maxCount <= 3) return Array.from({ length: maxCount }, (_, i) => i + 1);
   const mid = Math.round(((1 + Math.sqrt(maxCount)) / 2) ** 2);
   return [1, mid, maxCount];
+}
+
+/**
+ * Search params for the cell at (row, column): the map's current filters plus
+ * the two axis values applied as filters. A scheme axis contributes a
+ * single-concept filter group (AND'd with any existing groups, mirroring the
+ * cross-facet query); a countries axis contributes a country code. Page resets
+ * to 1 since the result set changes.
+ */
+export function cellSearchParams(
+  base: SearchParams,
+  axes: EvidenceMapAxes,
+  row: AxisCategory,
+  column: AxisCategory,
+): SearchParams {
+  const conceptFilters = [...base.conceptFilters];
+  const countryCodes = [...base.countryCodes];
+  for (const [axis, category] of [
+    [axes.row, row],
+    [axes.column, column],
+  ] as const) {
+    if (axis.kind === "countries") {
+      if (!countryCodes.includes(category.key)) countryCodes.push(category.key);
+    } else {
+      conceptFilters.push([category.key]);
+    }
+  }
+  return { ...base, conceptFilters, countryCodes, page: 1 };
+}
+
+// history.state key set when a cell deep-links into Search; its value is the
+// canonical map URL to return to. State (not a URL param) so a shared/bookmarked
+// search link — where the recipient never came from a map — shows no back link.
+const BACK_TO_VISUALISE = "backToVisualise";
+
+export function backToVisualiseState(mapUrl: string): Record<string, string> {
+  return { [BACK_TO_VISUALISE]: mapUrl };
+}
+
+// Reads the return URL out of an opaque history.state, or null if absent.
+export function backToVisualiseUrl(state: unknown): string | null {
+  if (state && typeof state === "object" && BACK_TO_VISUALISE in state) {
+    const url = (state as Record<string, unknown>)[BACK_TO_VISUALISE];
+    if (typeof url === "string") return url;
+  }
+  return null;
 }

--- a/src/services/evidenceMap.ts
+++ b/src/services/evidenceMap.ts
@@ -183,10 +183,8 @@ export function legendTicks(maxCount: number): number[] {
 
 /**
  * Search params for the cell at (row, column): the map's current filters plus
- * the two axis values applied as filters. A scheme axis contributes a
- * single-concept filter group (AND'd with any existing groups, mirroring the
- * cross-facet query); a countries axis contributes a country code. Page resets
- * to 1 since the result set changes.
+ * both axis values applied as filters (see applyAxisFilter). Page resets to 1
+ * since the result set changes.
  */
 export function cellSearchParams(
   base: SearchParams,
@@ -194,19 +192,42 @@ export function cellSearchParams(
   row: AxisCategory,
   column: AxisCategory,
 ): SearchParams {
-  const conceptFilters = [...base.conceptFilters];
-  const countryCodes = [...base.countryCodes];
+  let next = base;
   for (const [axis, category] of [
     [axes.row, row],
     [axes.column, column],
   ] as const) {
-    if (axis.kind === "countries") {
-      if (!countryCodes.includes(category.key)) countryCodes.push(category.key);
-    } else {
-      conceptFilters.push([category.key]);
-    }
+    next = applyAxisFilter(next, axis, category);
   }
-  return { ...base, conceptFilters, countryCodes, page: 1 };
+  return { ...next, page: 1 };
+}
+
+/**
+ * Search params for a single axis header: the map's current filters plus that
+ * one axis value applied as a filter. Powers the clickable row/column headers,
+ * which deep-link into Search filtered by just that category.
+ */
+export function axisSearchParams(
+  base: SearchParams,
+  axis: EvidenceMapAxis,
+  category: AxisCategory,
+): SearchParams {
+  return { ...applyAxisFilter(base, axis, category), page: 1 };
+}
+
+// Applies one axis value as a filter: a scheme axis contributes a single-concept
+// filter group (AND'd with any existing groups, mirroring the cross-facet
+// query); a countries axis contributes a country code.
+function applyAxisFilter(
+  base: SearchParams,
+  axis: EvidenceMapAxis,
+  category: AxisCategory,
+): SearchParams {
+  if (axis.kind === "countries") {
+    if (base.countryCodes.includes(category.key)) return base;
+    return { ...base, countryCodes: [...base.countryCodes, category.key] };
+  }
+  return { ...base, conceptFilters: [...base.conceptFilters, [category.key]] };
 }
 
 // history.state key set when a cell deep-links into Search; its value is the

--- a/src/services/navigation.ts
+++ b/src/services/navigation.ts
@@ -2,13 +2,24 @@ export const URL_CHANGE_EVENT = "urlchange";
 
 export function navigate(
   url: string,
-  options: { mode?: "push" | "replace" } = {},
+  options: { mode?: "push" | "replace"; state?: unknown } = {},
 ): void {
   const mode = options.mode ?? "push";
+  // Defaults to null — matches preact-router's own pushState calls so a plain
+  // navigation clears any state left by a previous one.
+  const state = options.state ?? null;
   if (mode === "replace") {
-    history.replaceState(null, "", url);
+    history.replaceState(state, "", url);
   } else {
-    history.pushState(null, "", url);
+    history.pushState(state, "", url);
   }
+  // Our own subscribers (useUrlParams, CommunityContext) listen for this.
   window.dispatchEvent(new Event(URL_CHANGE_EVENT));
+  // preact-router only re-evaluates its matched route on popstate (or its own
+  // anchor-click / route() navigations) — it ignores manual pushState. Without
+  // this nudge a programmatic *cross-route* jump (e.g. a map cell → Search)
+  // changes the address bar but leaves the previous page mounted. A synthetic
+  // popstate makes the Router re-route to the URL we just wrote; it neither
+  // moves history nor touches the entry's state.
+  window.dispatchEvent(new Event("popstate"));
 }

--- a/src/services/navigation.ts
+++ b/src/services/navigation.ts
@@ -13,7 +13,7 @@ export function navigate(
   } else {
     history.pushState(state, "", url);
   }
-  // Our own subscribers (useUrlParams, CommunityContext) listen for this.
+  // Our own subscribers (hooks and providers that track the URL) listen for this.
   window.dispatchEvent(new Event(URL_CHANGE_EVENT));
   // preact-router only re-evaluates its matched route on popstate (or its own
   // anchor-click / route() navigations) — it ignores manual pushState. Without

--- a/tests/components/visualise/EvidenceMapGrid.test.tsx
+++ b/tests/components/visualise/EvidenceMapGrid.test.tsx
@@ -65,14 +65,34 @@ describe("EvidenceMapGrid", () => {
     );
   });
 
-  test("table view carries no tooltips; bubble view does", () => {
-    const { container } = renderGrid("table");
-    expect(container.querySelectorAll("[data-tooltip]").length).toBe(0);
+  function firstCellTooltip(container: Element): string | null | undefined {
+    return container
+      .querySelector(".evidence-map__cell:not(.is-empty) [data-tooltip]")
+      ?.getAttribute("data-tooltip");
+  }
+
+  test("without a click handler: table cells carry no tooltip, bubble cells show just the count", () => {
+    const table = renderGrid("table");
+    expect(table.container.querySelectorAll("[data-tooltip]").length).toBe(0);
 
     const bubble = renderGrid("bubble");
+    expect(firstCellTooltip(bubble.container)).toBe("12 investigations");
+  });
+
+  test("with a handler: the bubble tooltip leads with the count then the action; the table tooltip is the action only", () => {
+    const bubble = renderGrid("bubble", vi.fn());
+    expect(firstCellTooltip(bubble.container)).toBe(
+      "12 investigations\nClick to view matching investigations",
+    );
+
+    const table = renderGrid("table", vi.fn());
+    expect(firstCellTooltip(table.container)).toBe(
+      "Click to view matching investigations",
+    );
+    // Empty cells stay inert in both views — no action tooltip.
     expect(
-      bubble.container.querySelectorAll("[data-tooltip]").length,
-    ).toBeGreaterThan(0);
+      table.container.querySelector(".evidence-map__cell.is-empty [data-tooltip]"),
+    ).toBeNull();
   });
 
   test("bubble view draws a sized bubble per filled cell, a dashed marker for empties, plus a legend", () => {

--- a/tests/components/visualise/EvidenceMapGrid.test.tsx
+++ b/tests/components/visualise/EvidenceMapGrid.test.tsx
@@ -148,4 +148,59 @@ describe("EvidenceMapGrid", () => {
     const empty = container.querySelector(".evidence-map__cell.is-empty");
     expect(empty?.querySelector("button")).toBeNull();
   });
+
+  test("headers are plain text without header click handlers", () => {
+    renderGrid("table");
+    expect(
+      screen.queryByRole("button", { name: /view matching/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  test("with header handlers, clicking a column or row header deep-links by that axis", () => {
+    const onRowClick = vi.fn();
+    const onColumnClick = vi.fn();
+    render(
+      <EvidenceMapGrid
+        rows={rows}
+        columns={columns}
+        getCount={getCount}
+        maxCount={12}
+        view="table"
+        countNoun="investigations"
+        rowAxisLabel="Education level"
+        columnAxisLabel="Education theme"
+        onRowClick={onRowClick}
+        onColumnClick={onColumnClick}
+      />,
+    );
+
+    const columnButton = screen.getByRole("button", {
+      name: "Literacy: view matching investigations.",
+    });
+    fireEvent.click(columnButton);
+    expect(onColumnClick).toHaveBeenCalledWith({
+      key: "thm:literacy",
+      label: "Literacy",
+    });
+
+    // Hovering shows the action tooltip for sighted users; leaving hides it.
+    fireEvent.mouseEnter(columnButton);
+    expect(
+      screen.getByText("Click to view matching investigations"),
+    ).toBeInTheDocument();
+    fireEvent.mouseLeave(columnButton);
+    expect(
+      screen.queryByText("Click to view matching investigations"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Secondary: view matching investigations.",
+      }),
+    );
+    expect(onRowClick).toHaveBeenCalledWith({
+      key: "lvl:secondary",
+      label: "Secondary",
+    });
+  });
 });

--- a/tests/pages/SearchPage.test.tsx
+++ b/tests/pages/SearchPage.test.tsx
@@ -740,4 +740,35 @@ describe("SearchPage", () => {
       });
     });
   });
+
+  describe("Back to Visualise link", () => {
+    const linkQuery = { name: /back to visualise/i } as const;
+
+    // Mount on the canonical (param-free) URL so SearchPage's URL rewrite never
+    // fires and clears the history.state under test.
+    async function renderWithState(state: unknown) {
+      history.replaceState(state, "", "/esea");
+      mockBoth({ results: makeResult(5, ["r1"]) });
+      renderSearchPage();
+      await waitFor(() =>
+        expect(screen.getByText("Title r1")).toBeInTheDocument(),
+      );
+    }
+
+    test("renders from history.state set by a map cell deep-link", async () => {
+      const mapUrl = "/esea/visualise?row=scheme%3Alevel&column=scheme%3Atheme";
+      await renderWithState({ backToVisualise: mapUrl });
+      expect(screen.getByRole("link", linkQuery)).toHaveAttribute("href", mapUrl);
+    });
+
+    test("absent without the state (e.g. a shared search URL)", async () => {
+      await renderWithState(null);
+      expect(screen.queryByRole("link", linkQuery)).not.toBeInTheDocument();
+    });
+
+    test("ignores a state URL pointing at a different community", async () => {
+      await renderWithState({ backToVisualise: "/other/visualise?row=a" });
+      expect(screen.queryByRole("link", linkQuery)).not.toBeInTheDocument();
+    });
+  });
 });

--- a/tests/pages/VisualisePage.test.tsx
+++ b/tests/pages/VisualisePage.test.tsx
@@ -226,6 +226,11 @@ describe("VisualisePage map", () => {
   });
 
   test("over-filtered: warns with an inline Reset all and still renders the greyed grid", () => {
+    // Distinct from the fixture default so the assertion proves the banner uses
+    // the live countNoun rather than passing by coincidence.
+    mockUseCommunity.mockReturnValue(
+      mappedCommunity({ copy: { countNoun: "investigations" } }),
+    );
     mockUseVocabulary.mockReturnValue({
       labels: LABELS,
       broader: null,
@@ -240,7 +245,9 @@ describe("VisualisePage map", () => {
       error: null,
     });
     const { container } = render(<VisualisePage />);
-    expect(screen.getByText(/No results match the current filters/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/No investigations match the current filters/i),
+    ).toBeInTheDocument();
     // The greyed-out grid still renders so the chosen axes stay visible, with a 0 total.
     expect(screen.getByRole("table")).toBeInTheDocument();
     expect(

--- a/tests/pages/VisualisePage.test.tsx
+++ b/tests/pages/VisualisePage.test.tsx
@@ -181,6 +181,29 @@ describe("VisualisePage map", () => {
     ).toBeInTheDocument();
   });
 
+  test("clicking a cell deep-links into Search with the cell's filters + a back-to-map state", () => {
+    mockUseCrossFacets.mockReturnValue({
+      result: crossFacetResult(9, [["level:primary", "theme:literacy", 6]]),
+      loading: false,
+      error: null,
+    });
+    const { container } = render(<VisualisePage />);
+    const cellButton = container.querySelector<HTMLButtonElement>(
+      ".evidence-map__cell-button",
+    );
+    expect(cellButton).not.toBeNull();
+    fireEvent.click(cellButton!);
+    expect(mockNavigate).toHaveBeenCalledWith(
+      "/test?concept=level%3Aprimary&concept=theme%3Aliteracy",
+      {
+        state: {
+          backToVisualise:
+            "/test/visualise?row=scheme%3Alevel&column=scheme%3Atheme",
+        },
+      },
+    );
+  });
+
   test("toggling to the table view shows counts as text", () => {
     mockUseCrossFacets.mockReturnValue({
       result: crossFacetResult(8, [["level:primary", "theme:literacy", 5]]),

--- a/tests/pages/VisualisePage.test.tsx
+++ b/tests/pages/VisualisePage.test.tsx
@@ -155,6 +155,10 @@ describe("VisualisePage map", () => {
     // Column/row labels resolved via the vocabulary.
     expect(screen.getByRole("columnheader", { name: "Literacy" })).toBeInTheDocument();
     expect(screen.getByRole("rowheader", { name: "Primary" })).toBeInTheDocument();
+    // The "click a cell" hint accompanies a grid with clickable cells.
+    expect(
+      screen.getByText(/click a cell to view matching/i),
+    ).toBeInTheDocument();
   });
 
   test("renders zero-hit rows and columns from the vocabulary", () => {
@@ -242,6 +246,10 @@ describe("VisualisePage map", () => {
     const banner = container.querySelector(".evidence-map-view__banner");
     expect(banner?.querySelector("button")).toBeNull();
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
+    // No clickable cells, so no hint.
+    expect(
+      screen.queryByText(/click a cell to view matching/i),
+    ).not.toBeInTheDocument();
   });
 
   test("distinguishes 'no map coverage' (results exist but none on both axes) from over-filtered", () => {
@@ -267,5 +275,9 @@ describe("VisualisePage map", () => {
     expect(
       screen.getByRole("columnheader", { name: "Science" }),
     ).toBeInTheDocument();
+    // ...but with no clickable cells, so no hint.
+    expect(
+      screen.queryByText(/click a cell to view matching/i),
+    ).not.toBeInTheDocument();
   });
 });

--- a/tests/services/evidenceMap.test.ts
+++ b/tests/services/evidenceMap.test.ts
@@ -341,6 +341,21 @@ describe("cellSearchParams", () => {
     expect(next.conceptFilters).toEqual([["scheme-a:x"], ["theme:literacy"]]);
   });
 
+  test("a countries axis appends a new code to the existing filter", () => {
+    const axes: EvidenceMapAxes = {
+      row: { kind: "scheme", schemeUri: "scheme:level" },
+      column: { kind: "countries" },
+    };
+    const next = cellSearchParams(
+      base,
+      axes,
+      { key: "level:primary", label: "Primary" },
+      { key: "DE", label: "Germany" },
+    );
+    // DE is new — added alongside the already-applied FR.
+    expect(next.countryCodes).toEqual(["FR", "DE"]);
+  });
+
   test("does not mutate the base params", () => {
     const axes: EvidenceMapAxes = {
       row: { kind: "scheme", schemeUri: "scheme:level" },

--- a/tests/services/evidenceMap.test.ts
+++ b/tests/services/evidenceMap.test.ts
@@ -8,6 +8,7 @@ import {
   formatCompact,
   legendTicks,
   cellSearchParams,
+  axisSearchParams,
   backToVisualiseState,
   backToVisualiseUrl,
   type AxisCategory,
@@ -369,6 +370,55 @@ describe("cellSearchParams", () => {
     );
     expect(base.conceptFilters).toEqual([["scheme-a:x"]]);
     expect(base.countryCodes).toEqual(["FR"]);
+  });
+});
+
+describe("axisSearchParams", () => {
+  const base: SearchParams = {
+    q: "literacy",
+    page: 3,
+    startYear: 2010,
+    endYear: undefined,
+    sort: "newest",
+    conceptFilters: [["scheme-a:x"]],
+    countryCodes: ["FR"],
+  };
+
+  test("a scheme axis adds a single-concept group and resets page", () => {
+    const next = axisSearchParams(
+      base,
+      { kind: "scheme", schemeUri: "scheme:level" },
+      { key: "level:primary", label: "Primary" },
+    );
+    expect(next.conceptFilters).toEqual([["scheme-a:x"], ["level:primary"]]);
+    expect(next.countryCodes).toEqual(["FR"]);
+    expect(next.page).toBe(1);
+    expect(next.q).toBe("literacy");
+  });
+
+  test("a countries axis appends a new, de-duplicated country code", () => {
+    const added = axisSearchParams(
+      base,
+      { kind: "countries" },
+      { key: "DE", label: "Germany" },
+    );
+    expect(added.countryCodes).toEqual(["FR", "DE"]);
+
+    const dupe = axisSearchParams(
+      base,
+      { kind: "countries" },
+      { key: "FR", label: "France" },
+    );
+    expect(dupe.countryCodes).toEqual(["FR"]);
+  });
+
+  test("does not mutate the base params", () => {
+    axisSearchParams(
+      base,
+      { kind: "scheme", schemeUri: "scheme:level" },
+      { key: "level:primary", label: "Primary" },
+    );
+    expect(base.conceptFilters).toEqual([["scheme-a:x"]]);
   });
 });
 

--- a/tests/services/evidenceMap.test.ts
+++ b/tests/services/evidenceMap.test.ts
@@ -7,10 +7,18 @@ import {
   bubbleRadius,
   formatCompact,
   legendTicks,
+  cellSearchParams,
+  backToVisualiseState,
+  backToVisualiseUrl,
   type AxisCategory,
 } from "@/services/evidenceMap";
 import { AXIS_COUNTRIES } from "@/services/crossFacets";
-import type { CrossFacetCell, EvidenceMapAxis } from "@/types/models";
+import type {
+  CrossFacetCell,
+  EvidenceMapAxis,
+  EvidenceMapAxes,
+} from "@/types/models";
+import type { SearchParams } from "@/services/searchParams";
 import type { ConceptScheme } from "@/services/vocabulary/vocabularyService";
 import { countryName } from "@/utils/country";
 
@@ -279,5 +287,87 @@ describe("axisToken / parseAxis", () => {
       kind: "scheme",
       schemeUri: "https://vocab.example/Thing",
     });
+  });
+});
+
+describe("cellSearchParams", () => {
+  const base: SearchParams = {
+    q: "literacy",
+    page: 3,
+    startYear: 2010,
+    endYear: undefined,
+    sort: "newest",
+    conceptFilters: [["scheme-a:x"]],
+    countryCodes: ["FR"],
+  };
+
+  test("scheme×scheme adds a single-concept group per axis and resets page", () => {
+    const axes: EvidenceMapAxes = {
+      row: { kind: "scheme", schemeUri: "scheme:level" },
+      column: { kind: "scheme", schemeUri: "scheme:theme" },
+    };
+    const next = cellSearchParams(
+      base,
+      axes,
+      { key: "level:primary", label: "Primary" },
+      { key: "theme:literacy", label: "Literacy" },
+    );
+    expect(next.conceptFilters).toEqual([
+      ["scheme-a:x"],
+      ["level:primary"],
+      ["theme:literacy"],
+    ]);
+    expect(next.countryCodes).toEqual(["FR"]);
+    expect(next.page).toBe(1);
+    // Other params are carried through untouched.
+    expect(next.q).toBe("literacy");
+    expect(next.sort).toBe("newest");
+    expect(next.startYear).toBe(2010);
+  });
+
+  test("a countries axis contributes a country code, de-duplicated", () => {
+    const axes: EvidenceMapAxes = {
+      row: { kind: "countries" },
+      column: { kind: "scheme", schemeUri: "scheme:theme" },
+    };
+    const next = cellSearchParams(
+      base,
+      axes,
+      { key: "FR", label: "France" },
+      { key: "theme:literacy", label: "Literacy" },
+    );
+    // FR was already applied — not duplicated.
+    expect(next.countryCodes).toEqual(["FR"]);
+    expect(next.conceptFilters).toEqual([["scheme-a:x"], ["theme:literacy"]]);
+  });
+
+  test("does not mutate the base params", () => {
+    const axes: EvidenceMapAxes = {
+      row: { kind: "scheme", schemeUri: "scheme:level" },
+      column: { kind: "countries" },
+    };
+    cellSearchParams(
+      base,
+      axes,
+      { key: "level:primary", label: "Primary" },
+      { key: "DE", label: "Germany" },
+    );
+    expect(base.conceptFilters).toEqual([["scheme-a:x"]]);
+    expect(base.countryCodes).toEqual(["FR"]);
+  });
+});
+
+describe("back-to-visualise history state", () => {
+  test("round-trips the map URL", () => {
+    const url = "/edu/visualise?q=x&row=a&column=b";
+    expect(backToVisualiseUrl(backToVisualiseState(url))).toBe(url);
+  });
+
+  test("returns null for absent or malformed state", () => {
+    expect(backToVisualiseUrl(null)).toBeNull();
+    expect(backToVisualiseUrl(undefined)).toBeNull();
+    expect(backToVisualiseUrl({})).toBeNull();
+    expect(backToVisualiseUrl({ backToVisualise: 42 })).toBeNull();
+    expect(backToVisualiseUrl("just a string")).toBeNull();
   });
 });

--- a/tests/services/navigationRouting.test.tsx
+++ b/tests/services/navigationRouting.test.tsx
@@ -1,0 +1,49 @@
+import { describe, test, expect, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/preact";
+import Router from "preact-router";
+import { navigate } from "@/services/navigation";
+
+// Guards the cross-route behaviour the map's cell deep-link relies on:
+// navigate() is a plain history.pushState, which preact-router ignores. The
+// synthetic popstate it dispatches is what makes the Router actually swap the
+// mounted page — without it the URL changes but the old page stays.
+function PageA(_props: { path?: string }) {
+  return <div>page-a</div>;
+}
+function PageB(_props: { path?: string }) {
+  return <div>page-b</div>;
+}
+
+function renderRouter() {
+  return render(
+    <Router>
+      <PageA path="/a" />
+      <PageB path="/b" />
+    </Router>,
+  );
+}
+
+beforeEach(() => {
+  history.replaceState(null, "", "/a");
+});
+
+describe("navigate() cross-route", () => {
+  test("swaps the mounted preact-router route on a programmatic navigation", async () => {
+    renderRouter();
+    expect(screen.getByText("page-a")).toBeInTheDocument();
+
+    navigate("/b");
+
+    await waitFor(() => expect(screen.getByText("page-b")).toBeInTheDocument());
+    expect(screen.queryByText("page-a")).toBeNull();
+    expect(window.location.pathname).toBe("/b");
+  });
+
+  test("carries history.state to the destination route", async () => {
+    renderRouter();
+    navigate("/b", { state: { from: "/a" } });
+
+    await waitFor(() => expect(screen.getByText("page-b")).toBeInTheDocument());
+    expect(history.state).toEqual({ from: "/a" });
+  });
+});


### PR DESCRIPTION
Closes #120 

Makes cells clickable to take you to the search page, with a "back to visualisation" button to take you... back!