### PR TITLE
HPV community: result-card tags, evidence-map defaults, and per-community feature gates

### DIFF
--- a/src/components/filters/FilterCardList.tsx
+++ b/src/components/filters/FilterCardList.tsx
@@ -12,6 +12,8 @@ import "./FilterCardList.css";
 interface FilterCardListProps {
   draft: FilterDraft;
   countNoun?: string;
+  // Show the facet-backed country card; off where the `countries` facet is empty (HPV).
+  showCountryFacetFilter?: boolean;
 }
 
 /**
@@ -22,6 +24,7 @@ interface FilterCardListProps {
 export function FilterCardList({
   draft,
   countNoun = "results",
+  showCountryFacetFilter = true,
 }: FilterCardListProps) {
   return (
     <>
@@ -37,19 +40,21 @@ export function FilterCardList({
       >
         <YearRangeFilter state={draft.yearDraft} onChange={draft.setYearDraft} />
       </FilterCard>
-      <FilterCard
-        title="Country"
-        summary={countrySummary(draft.countryDraft)}
-        defaultExpanded
-      >
-        <CountryFilter
-          state={draft.countryDraft}
-          counts={draft.facetCounts?.countries ?? null}
-          countsLoading={draft.facetCountsLoading}
-          countNoun={countNoun}
-          onChange={draft.setCountryDraft}
-        />
-      </FilterCard>
+      {showCountryFacetFilter && (
+        <FilterCard
+          title="Country"
+          summary={countrySummary(draft.countryDraft)}
+          defaultExpanded
+        >
+          <CountryFilter
+            state={draft.countryDraft}
+            counts={draft.facetCounts?.countries ?? null}
+            countsLoading={draft.facetCountsLoading}
+            countNoun={countNoun}
+            onChange={draft.setCountryDraft}
+          />
+        </FilterCard>
+      )}
       {draft.schemes.map((scheme) => {
         const state = draft.conceptStateFor(scheme);
         return (

--- a/src/components/filters/FilterCardList.tsx
+++ b/src/components/filters/FilterCardList.tsx
@@ -12,7 +12,7 @@ import "./FilterCardList.css";
 interface FilterCardListProps {
   draft: FilterDraft;
   countNoun?: string;
-  // Show the facet-backed country card; off where the `countries` facet is empty (HPV).
+  // Show the facet-backed country card; off where the `countries` facet is empty.
   showCountryFacetFilter?: boolean;
 }
 

--- a/src/components/filters/FilterDrawer.tsx
+++ b/src/components/filters/FilterDrawer.tsx
@@ -12,7 +12,7 @@ interface FilterDrawerProps {
   open: boolean;
   title?: string;
   countNoun?: string;
-  // Show the facet-backed country card; off where the `countries` facet is empty (HPV).
+  // Show the facet-backed country card; off where the `countries` facet is empty.
   showCountryFacetFilter?: boolean;
   schemes: ConceptScheme[];
   appliedConceptFilters: readonly (readonly string[])[];

--- a/src/components/filters/FilterDrawer.tsx
+++ b/src/components/filters/FilterDrawer.tsx
@@ -12,6 +12,8 @@ interface FilterDrawerProps {
   open: boolean;
   title?: string;
   countNoun?: string;
+  // Show the facet-backed country card; off where the `countries` facet is empty (HPV).
+  showCountryFacetFilter?: boolean;
   schemes: ConceptScheme[];
   appliedConceptFilters: readonly (readonly string[])[];
   appliedCountryCodes: readonly string[];
@@ -35,6 +37,7 @@ type FilterDrawerPanelProps = Omit<FilterDrawerProps, "open">;
 function FilterDrawerPanel({
   title = "Refine the evidence",
   countNoun = "results",
+  showCountryFacetFilter = true,
   schemes,
   appliedConceptFilters,
   appliedCountryCodes,
@@ -119,7 +122,11 @@ function FilterDrawerPanel({
         </header>
 
         <div class="filter-drawer__body">
-          <FilterCardList draft={draft} countNoun={countNoun} />
+          <FilterCardList
+            draft={draft}
+            countNoun={countNoun}
+            showCountryFacetFilter={showCountryFacetFilter}
+          />
         </div>
 
         <FilterActions

--- a/src/components/search/ResultRow.tsx
+++ b/src/components/search/ResultRow.tsx
@@ -24,10 +24,16 @@ interface ResultRowProps {
   communitySlug: string;
   reference: Reference;
   codingInstitution?: CodingInstitutionConfig;
+  // ESEA shows finding/estimate stat-badges; HPV (false) hides them.
+  findingsAndEstimates?: boolean;
+  // Concept schemes whose members are dropped from pills (HPV geo).
+  pillExcludedSchemes?: readonly string[];
 }
 
 const MAX_AUTHORS_SHOWN = 3;
 export const PILL_CAP = 8;
+// Stable default so the pill useMemo isn't busted by a fresh [] each render.
+const NO_PILL_EXCLUSIONS: readonly string[] = [];
 
 function formatAuthors(authors: { display_name: string }[]): string {
   if (authors.length === 0) return "";
@@ -70,6 +76,8 @@ export function ResultRow({
   communitySlug,
   reference,
   codingInstitution: codingConfig,
+  findingsAndEstimates = true,
+  pillExcludedSchemes = NO_PILL_EXCLUSIONS,
 }: ResultRowProps) {
   const bib = extractBibliographic(reference);
   const doi = extractDoi(reference.identifiers);
@@ -80,7 +88,9 @@ export function ResultRow({
   const rawContext = linkedData?.data?.["@context"];
   const contextUrl = typeof rawContext === "string" ? rawContext : undefined;
 
-  const { labels, definitions } = useVocabulary(linkedData?.vocabulary_uri);
+  const { labels, definitions, inScheme } = useVocabulary(
+    linkedData?.vocabulary_uri,
+  );
   const { context } = useContextPrefixes(contextUrl);
 
   const pillTags = useMemo(() => {
@@ -90,7 +100,17 @@ export function ResultRow({
       context.prefixes,
       labels,
     );
-    const concepts = aggregatePillConcepts(investigation);
+    // HPV carries flat hasAppliedConcept; ESEA builds pills from the
+    // documentType/findings walk. The two shapes are disjoint.
+    const sourced =
+      investigation.appliedConcepts.length > 0
+        ? investigation.appliedConcepts.map((value) => ({ value }))
+        : aggregatePillConcepts(investigation);
+    const excluded = new Set(pillExcludedSchemes);
+    const concepts =
+      excluded.size === 0
+        ? sourced
+        : sourced.filter((a) => !excluded.has(inScheme?.get(a.value.uri) ?? ""));
     // Flat pills (no parent breadcrumb) — pass an empty `broader` map.
     // Definitions still drive the hover tooltip.
     return conceptsToTags(
@@ -99,7 +119,7 @@ export function ResultRow({
       new Map(),
       definitions ?? new Map(),
     );
-  }, [linkedData, labels, definitions, context]);
+  }, [linkedData, labels, definitions, inScheme, context, pillExcludedSchemes]);
 
   const title = bib?.title ?? reference.id;
   const authors = bib?.authorship ? formatAuthors(bib.authorship) : "";
@@ -161,12 +181,16 @@ export function ResultRow({
             DOI ↗
           </a>
         )}
-        <span class="stat-badge">
-          <span class="stat-num">{findingsLabel}</span> findings
-        </span>
-        <span class="stat-badge">
-          <span class="stat-num">{estimatesLabel}</span> estimates
-        </span>
+        {findingsAndEstimates && (
+          <>
+            <span class="stat-badge">
+              <span class="stat-num">{findingsLabel}</span> findings
+            </span>
+            <span class="stat-badge">
+              <span class="stat-num">{estimatesLabel}</span> estimates
+            </span>
+          </>
+        )}
         {codingInstitution && (
           <span class="row-coder" data-testid="coder-text">
             {codingInstitution}

--- a/src/components/search/ResultRow.tsx
+++ b/src/components/search/ResultRow.tsx
@@ -24,9 +24,9 @@ interface ResultRowProps {
   communitySlug: string;
   reference: Reference;
   codingInstitution?: CodingInstitutionConfig;
-  // ESEA shows finding/estimate stat-badges; HPV (false) hides them.
+  // When false, hides the finding/estimate stat-badges.
   findingsAndEstimates?: boolean;
-  // Concept schemes whose members are dropped from pills (HPV geo).
+  // Concept schemes whose members are dropped from pills (e.g. geo).
   pillExcludedSchemes?: readonly string[];
 }
 

--- a/src/components/search/ResultRow.tsx
+++ b/src/components/search/ResultRow.tsx
@@ -100,8 +100,8 @@ export function ResultRow({
       context.prefixes,
       labels,
     );
-    // HPV carries flat hasAppliedConcept; ESEA builds pills from the
-    // documentType/findings walk. The two shapes are disjoint.
+    // Some communities carry flat investigation-level hasAppliedConcept; others
+    // build pills from the documentType/findings walk. The two shapes are disjoint.
     const sourced =
       investigation.appliedConcepts.length > 0
         ? investigation.appliedConcepts.map((value) => ({ value }))

--- a/src/components/visualise/MapConfigPanel.tsx
+++ b/src/components/visualise/MapConfigPanel.tsx
@@ -29,7 +29,7 @@ interface MapConfigPanelProps {
   // Drives the facet-count preview (q / annotations live here).
   params: SearchParams;
   countNoun?: string;
-  // Hide the facet-backed Country card where the `countries` facet is empty (HPV);
+  // Hide the facet-backed Country card where the `countries` facet is empty;
   // the Country concept-scheme card still renders from `schemes`.
   showCountryFacetFilter?: boolean;
   onApply: (next: { axes: EvidenceMapAxes; filters: AppliedFilters }) => void;

--- a/src/components/visualise/MapConfigPanel.tsx
+++ b/src/components/visualise/MapConfigPanel.tsx
@@ -29,6 +29,9 @@ interface MapConfigPanelProps {
   // Drives the facet-count preview (q / annotations live here).
   params: SearchParams;
   countNoun?: string;
+  // Hide the facet-backed Country card where the `countries` facet is empty (HPV);
+  // the Country concept-scheme card still renders from `schemes`.
+  showCountryFacetFilter?: boolean;
   onApply: (next: { axes: EvidenceMapAxes; filters: AppliedFilters }) => void;
 }
 
@@ -80,6 +83,7 @@ export function MapConfigPanel({
   appliedEndYear,
   params,
   countNoun = "results",
+  showCountryFacetFilter = true,
   onApply,
 }: MapConfigPanelProps) {
   const [rowDraft, setRowDraft] = useState<EvidenceMapAxis>(appliedAxes.row);
@@ -144,7 +148,11 @@ export function MapConfigPanel({
 
         <section class="map-config-panel__section">
           <h3 class="map-config-panel__section-title">Filters</h3>
-          <FilterCardList draft={draft} countNoun={countNoun} />
+          <FilterCardList
+            draft={draft}
+            countNoun={countNoun}
+            showCountryFacetFilter={showCountryFacetFilter}
+          />
         </section>
       </div>
 

--- a/src/hooks/useVocabulary.ts
+++ b/src/hooks/useVocabulary.ts
@@ -5,14 +5,19 @@ import type {
   VocabularyData,
 } from "@/services/vocabulary/vocabularyService";
 
-export function useVocabulary(vocabularyUrl: string | undefined): {
+export interface VocabularyResult {
   labels: Map<string, string> | null;
   broader: Map<string, string> | null;
   definitions: Map<string, string> | null;
+  inScheme: Map<string, string> | null;
   schemes: ConceptScheme[] | null;
   loading: boolean;
   error: Error | null;
-} {
+}
+
+export function useVocabulary(
+  vocabularyUrl: string | undefined,
+): VocabularyResult {
   const [data, setData] = useState<VocabularyData | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -42,6 +47,7 @@ export function useVocabulary(vocabularyUrl: string | undefined): {
     labels: data?.labels ?? null,
     broader: data?.broader ?? null,
     definitions: data?.definitions ?? null,
+    inScheme: data?.inScheme ?? null,
     schemes: data?.schemes ?? null,
     loading,
     error,

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -430,6 +430,7 @@ function SearchPageInner({ community }: { community: Community }) {
           open={drawerOpen}
           title={community.copy.drawerTitle}
           countNoun={community.copy.countNoun}
+          showCountryFacetFilter={community.features.countryFacetFilter}
           schemes={filterableSchemes}
           appliedConceptFilters={params.conceptFilters}
           appliedCountryCodes={params.countryCodes}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -409,6 +409,8 @@ function SearchPageInner({ community }: { community: Community }) {
               communitySlug={community.slug}
               reference={ref}
               codingInstitution={community.codingInstitution}
+              findingsAndEstimates={community.features.findingsAndEstimates}
+              pillExcludedSchemes={community.pillExcludedSchemes}
             />
           ))}
         </div>

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -356,7 +356,7 @@ function SearchPageInner({ community }: { community: Community }) {
                     {exportAnnouncement}
                   </span>
                 )}
-                {results.results && (
+                {results.results && community.features.exportExcel && (
                   <ExportButton
                     disabled={exportDisabled}
                     status={exportJob.status}

--- a/src/pages/VisualisePage.tsx
+++ b/src/pages/VisualisePage.tsx
@@ -370,6 +370,7 @@ function EvidenceMapView({
       <MapConfigPanel
         key={canonical}
         schemes={filterableSchemes}
+        showCountryFacetFilter={community.features.countryFacetFilter}
         appliedAxes={axes}
         defaultAxes={defaults}
         appliedConceptFilters={params.conceptFilters}

--- a/src/services/communities.ts
+++ b/src/services/communities.ts
@@ -19,6 +19,7 @@ export const DEFAULT_FEATURES: CommunityFeatures = {
   evidenceMap: false,
   findingsAndEstimates: true,
   exportExcel: true,
+  countryFacetFilter: true,
 };
 
 // HPV geo ConceptSchemes dropped from result-card pills (#125): they swamp the
@@ -109,6 +110,7 @@ const COMMUNITIES: Community[] = [
       evidenceMap: true,
       findingsAndEstimates: false,
       exportExcel: false,
+      countryFacetFilter: false,
     },
     copy: buildCopy("HPV Vaccine Delivery", {
       countNoun: "references",

--- a/src/services/communities.ts
+++ b/src/services/communities.ts
@@ -17,7 +17,18 @@ function requireEnv(name: string, value: string | undefined): string {
 
 export const DEFAULT_FEATURES: CommunityFeatures = {
   evidenceMap: false,
+  findingsAndEstimates: true,
 };
+
+// HPV geo ConceptSchemes dropped from result-card pills (#125): they swamp the
+// pill cap and geo has dedicated filters. Full scheme URIs to match inScheme.
+const HPV_GEO_SCHEMES = [
+  "https://vocab.aliveevidence.org/hpv/Country",
+  "https://vocab.aliveevidence.org/hpv/CountryClassification",
+  "https://vocab.aliveevidence.org/hpv/UNICEFRegion",
+  "https://vocab.aliveevidence.org/hpv/WorldBankRegion",
+  "https://vocab.aliveevidence.org/hpv/WHORegion",
+];
 
 // Shared copy fallbacks; a community overrides only what diverges.
 function buildCopy(
@@ -49,6 +60,7 @@ const COMMUNITIES: Community[] = [
     filterExcludedSchemes: [
       "https://vocab.esea.education/ImplementationDescriptionScheme",
     ],
+    pillExcludedSchemes: [],
     features: { ...DEFAULT_FEATURES, evidenceMap: true },
     defaultEvidenceMapAxes: {
       row: {
@@ -90,7 +102,8 @@ const COMMUNITIES: Community[] = [
       import.meta.env.VITE_HPV_CONTEXT_URL,
     ),
     filterExcludedSchemes: [],
-    features: { ...DEFAULT_FEATURES, evidenceMap: true },
+    pillExcludedSchemes: HPV_GEO_SCHEMES,
+    features: { ...DEFAULT_FEATURES, evidenceMap: true, findingsAndEstimates: false },
     copy: buildCopy("HPV Vaccine Delivery", {
       countNoun: "references",
       corpusDescriptor: "HPV vaccine delivery research",

--- a/src/services/communities.ts
+++ b/src/services/communities.ts
@@ -112,6 +112,16 @@ const COMMUNITIES: Community[] = [
       exportExcel: false,
       countryFacetFilter: false,
     },
+    defaultEvidenceMapAxes: {
+      row: {
+        kind: "scheme",
+        schemeUri: "https://vocab.aliveevidence.org/hpv/TargetPopulation",
+      },
+      column: {
+        kind: "scheme",
+        schemeUri: "https://vocab.aliveevidence.org/hpv/DeliveryActor",
+      },
+    },
     copy: buildCopy("HPV Vaccine Delivery", {
       countNoun: "references",
       corpusDescriptor: "HPV vaccine delivery research",

--- a/src/services/communities.ts
+++ b/src/services/communities.ts
@@ -18,6 +18,7 @@ function requireEnv(name: string, value: string | undefined): string {
 export const DEFAULT_FEATURES: CommunityFeatures = {
   evidenceMap: false,
   findingsAndEstimates: true,
+  exportExcel: true,
 };
 
 // HPV geo ConceptSchemes dropped from result-card pills (#125): they swamp the
@@ -103,7 +104,12 @@ const COMMUNITIES: Community[] = [
     ),
     filterExcludedSchemes: [],
     pillExcludedSchemes: HPV_GEO_SCHEMES,
-    features: { ...DEFAULT_FEATURES, evidenceMap: true, findingsAndEstimates: false },
+    features: {
+      ...DEFAULT_FEATURES,
+      evidenceMap: true,
+      findingsAndEstimates: false,
+      exportExcel: false,
+    },
     copy: buildCopy("HPV Vaccine Delivery", {
       countNoun: "references",
       corpusDescriptor: "HPV vaccine delivery research",

--- a/src/services/communities.ts
+++ b/src/services/communities.ts
@@ -18,7 +18,8 @@ function requireEnv(name: string, value: string | undefined): string {
 export const DEFAULT_FEATURES: CommunityFeatures = {
   evidenceMap: false,
   findingsAndEstimates: true,
-  exportExcel: true,
+  // Off until a community's Excel export is built — the export is Education-shaped today.
+  exportExcel: false,
   countryFacetFilter: true,
 };
 
@@ -63,7 +64,7 @@ const COMMUNITIES: Community[] = [
       "https://vocab.esea.education/ImplementationDescriptionScheme",
     ],
     pillExcludedSchemes: [],
-    features: { ...DEFAULT_FEATURES, evidenceMap: true },
+    features: { ...DEFAULT_FEATURES, evidenceMap: true, exportExcel: true },
     defaultEvidenceMapAxes: {
       row: {
         kind: "scheme",
@@ -109,7 +110,6 @@ const COMMUNITIES: Community[] = [
       ...DEFAULT_FEATURES,
       evidenceMap: true,
       findingsAndEstimates: false,
-      exportExcel: false,
       countryFacetFilter: false,
     },
     defaultEvidenceMapAxes: {

--- a/src/services/investigationParser.ts
+++ b/src/services/investigationParser.ts
@@ -262,6 +262,18 @@ function resolveConceptRef(
   return { uri, label: labels.get(uri) };
 }
 
+function parseAppliedConcepts(
+  investigation: Dict,
+  prefixes: Map<string, string>,
+  labels: Map<string, string>,
+): ResolvedConcept[] {
+  const raw = investigation["hasAppliedConcept"];
+  const items = Array.isArray(raw) ? raw : [];
+  return items
+    .map((v) => resolveConceptRef(v, prefixes, labels))
+    .filter((c): c is ResolvedConcept => c !== undefined);
+}
+
 function parseArm(node: Dict): ArmData {
   const numField = (key: string) => resolveNumericValue(node[key]);
   return {
@@ -447,5 +459,6 @@ export function parseInvestigation(
     ),
     isRetracted: investigation["isRetracted"] === true,
     findings: parseFindings(investigation, prefixes, labels),
+    appliedConcepts: parseAppliedConcepts(investigation, prefixes, labels),
   };
 }

--- a/src/services/vocabulary/vocabularyService.ts
+++ b/src/services/vocabulary/vocabularyService.ts
@@ -9,6 +9,7 @@ interface JsonLdGraphEntry {
   "skos:prefLabel"?: string;
   "skos:definition"?: string;
   "skos:broader"?: JsonLdRef | JsonLdRef[];
+  "skos:inScheme"?: JsonLdRef | JsonLdRef[];
   "skos:hasTopConcept"?: JsonLdRef | JsonLdRef[];
   "dct:title"?: string;
   "rdfs:label"?: string;
@@ -46,6 +47,7 @@ export interface VocabularyData {
   labels: Map<string, string>;
   broader: Map<string, string>;
   definitions: Map<string, string>;
+  inScheme: Map<string, string>;
   schemes: ConceptScheme[];
 }
 
@@ -119,6 +121,7 @@ export function buildVocabularyData(doc: VocabularyJsonLd): VocabularyData {
   const labels = new Map<string, string>();
   const broader = new Map<string, string>();
   const definitions = new Map<string, string>();
+  const inScheme = new Map<string, string>();
   const rawSchemes: RawScheme[] = [];
 
   for (const entry of doc["@graph"] ?? []) {
@@ -138,6 +141,10 @@ export function buildVocabularyData(doc: VocabularyJsonLd): VocabularyData {
       const broaderUri = extractFirstRefId(entry["skos:broader"]);
       if (broaderUri) {
         broader.set(id, expand(broaderUri));
+      }
+      const schemeUri = extractFirstRefId(entry["skos:inScheme"]);
+      if (schemeUri) {
+        inScheme.set(entry["@id"], schemeUri);
       }
       continue;
     }
@@ -188,7 +195,7 @@ export function buildVocabularyData(doc: VocabularyJsonLd): VocabularyData {
       .filter((c): c is Concept => c !== null),
   }));
 
-  return { labels, broader, definitions, schemes };
+  return { labels, broader, definitions, inScheme, schemes };
 }
 
 /**

--- a/src/services/vocabulary/vocabularyService.ts
+++ b/src/services/vocabulary/vocabularyService.ts
@@ -144,7 +144,7 @@ export function buildVocabularyData(doc: VocabularyJsonLd): VocabularyData {
       }
       const schemeUri = extractFirstRefId(entry["skos:inScheme"]);
       if (schemeUri) {
-        inScheme.set(entry["@id"], schemeUri);
+        inScheme.set(id, expand(schemeUri));
       }
       continue;
     }

--- a/src/types/investigation.ts
+++ b/src/types/investigation.ts
@@ -77,7 +77,7 @@ export interface EffectEstimateData {
   // Provenance, e.g. "Computed from summary statistics".
   estimateSource?: ResolvedConcept;
   baselineAdjusted?: boolean;
-  // ESEA context types this as xsd:string with values "yes" / "no".
+  // Typed as xsd:string with values "yes" / "no" in some vocabularies.
   clusteringAdjusted?: string;
   derivedFromIds?: string[];
 }
@@ -103,7 +103,7 @@ export interface InvestigationData {
   documentType?: CodedAnnotation<ResolvedConcept>;
   isRetracted: boolean;
   findings: FindingData[];
-  // Flat investigation-level concept refs (HPV's hasAppliedConcept). Bare URI
+  // Flat investigation-level concept refs (hasAppliedConcept). Bare URI
   // strings, no CodingAnnotation wrapper. Empty for vocabularies that omit it.
   appliedConcepts: ResolvedConcept[];
 }

--- a/src/types/investigation.ts
+++ b/src/types/investigation.ts
@@ -103,4 +103,7 @@ export interface InvestigationData {
   documentType?: CodedAnnotation<ResolvedConcept>;
   isRetracted: boolean;
   findings: FindingData[];
+  // Flat investigation-level concept refs (HPV's hasAppliedConcept). Bare URI
+  // strings, no CodingAnnotation wrapper. Empty for vocabularies that omit it.
+  appliedConcepts: ResolvedConcept[];
 }

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -5,6 +5,8 @@ export interface CommunityFeatures {
   findingsAndEstimates: boolean;
   // HPV export runs the Education-shaped pipeline today; hide it until #127.
   exportExcel: boolean;
+  // Polished country filter fed by the `countries` search facet; off for HPV until that facet fills.
+  countryFacetFilter: boolean;
 }
 
 // One axis of the evidence map.

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -3,6 +3,8 @@ export interface CommunityFeatures {
   evidenceMap: boolean;
   // ESEA studies carry findings/estimates (the stat-badges); HPV references don't.
   findingsAndEstimates: boolean;
+  // HPV export runs the Education-shaped pipeline today; hide it until #127.
+  exportExcel: boolean;
 }
 
 // One axis of the evidence map.

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -1,6 +1,8 @@
 export interface CommunityFeatures {
   // No UI yet; reserved so the evidence map can ship behind a flag (#103).
   evidenceMap: boolean;
+  // ESEA studies carry findings/estimates (the stat-badges); HPV references don't.
+  findingsAndEstimates: boolean;
 }
 
 // One axis of the evidence map.
@@ -45,6 +47,9 @@ export interface Community {
   vocabularyUrl: string;
   contextUrl: string;
   filterExcludedSchemes: string[];
+  // Concept schemes dropped from result-card pills (HPV geo). Distinct from
+  // filterExcludedSchemes (drawer): geo stays filterable, just isn't a pill.
+  pillExcludedSchemes: string[];
   features: CommunityFeatures;
   // Default evidence-map axes; absent ⇒ the map shows a "not configured" notice
   // even where features.evidenceMap is on (e.g. before a vocabulary is published).

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -1,11 +1,11 @@
 export interface CommunityFeatures {
   // No UI yet; reserved so the evidence map can ship behind a flag (#103).
   evidenceMap: boolean;
-  // ESEA studies carry findings/estimates (the stat-badges); HPV references don't.
+  // Whether result cards show finding/estimate stat-badges.
   findingsAndEstimates: boolean;
-  // HPV export runs the Education-shaped pipeline today; hide it until #127.
+  // Whether the Excel export button is shown.
   exportExcel: boolean;
-  // Polished country filter fed by the `countries` search facet; off for HPV until that facet fills.
+  // Whether the facet-backed country filter card is shown; needs a populated `countries` facet.
   countryFacetFilter: boolean;
 }
 
@@ -51,7 +51,7 @@ export interface Community {
   vocabularyUrl: string;
   contextUrl: string;
   filterExcludedSchemes: string[];
-  // Concept schemes dropped from result-card pills (HPV geo). Distinct from
+  // Concept schemes dropped from result-card pills (e.g. geo). Distinct from
   // filterExcludedSchemes (drawer): geo stays filterable, just isn't a pill.
   pillExcludedSchemes: string[];
   features: CommunityFeatures;

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -30,8 +30,11 @@ test("renders not found for invalid community", () => {
 
 test("shows the Visualise tab and routes to the visualise page when enabled", () => {
   history.pushState({}, "", "/hpv");
-  render(<App />);
+  const { unmount } = render(<App />);
   expect(screen.getByRole("link", { name: /visualise/i })).toBeInTheDocument();
+  // VisualisePage canonicalizes the URL (HPV default axes) via a replace-navigate
+  // on mount; unmount first so a stale App doesn't pick it up and double-render.
+  unmount();
 
   history.pushState({}, "", "/hpv/visualise");
   render(<App />);

--- a/tests/components/filters/FilterDrawer.test.tsx
+++ b/tests/components/filters/FilterDrawer.test.tsx
@@ -100,6 +100,16 @@ describe("FilterDrawer", () => {
     ).toBeDefined();
   });
 
+  test("shows the dedicated Country card by default", () => {
+    renderDrawer();
+    expect(screen.getByText("Country")).toBeInTheDocument();
+  });
+
+  test("hides the dedicated Country card when showCountryFacetFilter is false", () => {
+    renderDrawer({ showCountryFacetFilter: false });
+    expect(screen.queryByText("Country")).toBeNull();
+  });
+
   test("shows a subtitle nudge with the current query when params.q is set", () => {
     const { container } = renderDrawer({
       params: makeSearchParams({ q: "phonics" }),

--- a/tests/components/search/ResultRow.test.tsx
+++ b/tests/components/search/ResultRow.test.tsx
@@ -6,6 +6,7 @@ import {
   abstractEnh,
   bibliographicEnh,
   makeReference,
+  makeVocabResult,
 } from "../../fixtures";
 
 const CODING = rawSourcePatterns([[/(^|[^a-z])eef([^a-z]|$)/, "EEF"]]);
@@ -14,19 +15,20 @@ const vocabState = {
   labels: null as Map<string, string> | null,
   broader: null as Map<string, string> | null,
   definitions: null as Map<string, string> | null,
+  inScheme: null as Map<string, string> | null,
 };
 const contextState = {
   context: null as { prefixes: Map<string, string> } | null,
 };
 
 vi.mock("@/hooks/useVocabulary", () => ({
-  useVocabulary: () => ({
-    labels: vocabState.labels,
-    broader: vocabState.broader,
-    definitions: vocabState.definitions,
-    loading: false,
-    error: null,
-  }),
+  useVocabulary: () =>
+    makeVocabResult({
+      labels: vocabState.labels,
+      broader: vocabState.broader,
+      definitions: vocabState.definitions,
+      inScheme: vocabState.inScheme,
+    }),
 }));
 
 vi.mock("@/hooks/useContextPrefixes", () => ({
@@ -41,6 +43,7 @@ beforeEach(() => {
   vocabState.labels = null;
   vocabState.broader = null;
   vocabState.definitions = null;
+  vocabState.inScheme = null;
   contextState.context = null;
 });
 
@@ -351,5 +354,68 @@ describe("ResultRow", () => {
     render(<ResultRow communitySlug="esea" reference={ref} />);
     expect(screen.getByText(/FULL INTACT ABSTRACT BODY/)).toBeInTheDocument();
     expect(screen.queryByText("TRUNCATED TAIL")).toBeNull();
+  });
+
+  test("omits the findings/estimates stat-badges when findingsAndEstimates is false", () => {
+    const { container } = render(
+      <ResultRow
+        communitySlug="hpv"
+        reference={makeRef()}
+        findingsAndEstimates={false}
+      />,
+    );
+    expect(container.querySelectorAll(".stat-badge")).toHaveLength(0);
+    expect(container.querySelector(".row-right")).not.toHaveTextContent(
+      /findings|estimates/,
+    );
+  });
+
+  test("sources pills from hasAppliedConcept when present (HPV shape)", () => {
+    const study = "https://vocab.aliveevidence.org/hpv/StudyDesign/HPVV0148";
+    vocabState.labels = new Map([[study, "Cohort study"]]);
+    vocabState.broader = new Map();
+    vocabState.definitions = new Map();
+    vocabState.inScheme = new Map();
+    contextState.context = { prefixes: new Map() };
+
+    const ref = makeRef({ investigation: { hasAppliedConcept: [study] } });
+    render(
+      <ResultRow
+        communitySlug="hpv"
+        reference={ref}
+        findingsAndEstimates={false}
+      />,
+    );
+    expect(screen.queryByText("Cohort study")).not.toBeNull();
+  });
+
+  test("drops applied concepts whose scheme is in pillExcludedSchemes", () => {
+    const country = "https://vocab.aliveevidence.org/hpv/Country/NG";
+    const study = "https://vocab.aliveevidence.org/hpv/StudyDesign/HPVV0148";
+    vocabState.labels = new Map([
+      [country, "Nigeria"],
+      [study, "Cohort study"],
+    ]);
+    vocabState.broader = new Map();
+    vocabState.definitions = new Map();
+    vocabState.inScheme = new Map([
+      [country, "https://vocab.aliveevidence.org/hpv/Country"],
+      [study, "https://vocab.aliveevidence.org/hpv/StudyDesign"],
+    ]);
+    contextState.context = { prefixes: new Map() };
+
+    const ref = makeRef({
+      investigation: { hasAppliedConcept: [country, study] },
+    });
+    render(
+      <ResultRow
+        communitySlug="hpv"
+        reference={ref}
+        findingsAndEstimates={false}
+        pillExcludedSchemes={["https://vocab.aliveevidence.org/hpv/Country"]}
+      />,
+    );
+    expect(screen.queryByText("Cohort study")).not.toBeNull();
+    expect(screen.queryByText("Nigeria")).toBeNull();
   });
 });

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -56,7 +56,7 @@ export function makeCommunity(
     contextUrl: "https://vocab.example/ctx",
     filterExcludedSchemes: [],
     pillExcludedSchemes: [],
-    features: { evidenceMap: false, findingsAndEstimates: true, exportExcel: true, ...features },
+    features: { evidenceMap: false, findingsAndEstimates: true, exportExcel: true, countryFacetFilter: true, ...features },
     copy: {
       searchPlaceholder: "Search the evidence",
       drawerTitle: "Refine the evidence",

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -56,7 +56,7 @@ export function makeCommunity(
     contextUrl: "https://vocab.example/ctx",
     filterExcludedSchemes: [],
     pillExcludedSchemes: [],
-    features: { evidenceMap: false, findingsAndEstimates: true, ...features },
+    features: { evidenceMap: false, findingsAndEstimates: true, exportExcel: true, ...features },
     copy: {
       searchPlaceholder: "Search the evidence",
       drawerTitle: "Refine the evidence",

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -11,11 +11,14 @@ import type {
   AbstractContentEnhancement,
   BibliographicMetadataEnhancement,
   Community,
+  CommunityCopy,
+  CommunityFeatures,
   Enhancement,
   LinkedDataEnhancement,
   Reference,
 } from "@/types/models";
 import type { SearchParams } from "@/services/searchParams";
+import type { VocabularyResult } from "@/hooks/useVocabulary";
 
 /** SearchParams with all-undefined filters and no facets — override per test. */
 export function makeSearchParams(
@@ -38,7 +41,12 @@ export function makeSearchParams(
  * behaviour without depending on the real registry in services/communities.ts.
  * `features` and `copy` merge shallowly so callers override just one field.
  */
-export function makeCommunity(overrides: Partial<Community> = {}): Community {
+export function makeCommunity(
+  overrides: Partial<Omit<Community, "features" | "copy">> & {
+    features?: Partial<CommunityFeatures>;
+    copy?: Partial<CommunityCopy>;
+  } = {},
+): Community {
   const { features, copy, ...rest } = overrides;
   return {
     slug: "test",
@@ -47,7 +55,8 @@ export function makeCommunity(overrides: Partial<Community> = {}): Community {
     vocabularyUrl: "https://vocab.example/v1",
     contextUrl: "https://vocab.example/ctx",
     filterExcludedSchemes: [],
-    features: { evidenceMap: false, ...features },
+    pillExcludedSchemes: [],
+    features: { evidenceMap: false, findingsAndEstimates: true, ...features },
     copy: {
       searchPlaceholder: "Search the evidence",
       drawerTitle: "Refine the evidence",
@@ -56,6 +65,26 @@ export function makeCommunity(overrides: Partial<Community> = {}): Community {
       ...copy,
     },
     ...rest,
+  };
+}
+
+/**
+ * A useVocabulary() result, all-null/idle by default — override per test.
+ * The one place to extend when VocabularyResult grows a field, so adding a
+ * field doesn't ripple to every test that mocks the hook.
+ */
+export function makeVocabResult(
+  overrides: Partial<VocabularyResult> = {},
+): VocabularyResult {
+  return {
+    labels: null,
+    broader: null,
+    definitions: null,
+    inScheme: null,
+    schemes: null,
+    loading: false,
+    error: null,
+    ...overrides,
   };
 }
 

--- a/tests/pages/RecordDetailPage.test.tsx
+++ b/tests/pages/RecordDetailPage.test.tsx
@@ -2,7 +2,7 @@ import { describe, test, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/preact";
 import { RecordDetailPage } from "@/pages/RecordDetailPage";
 import { CommunityProvider } from "@/community/CommunityContext";
-import { makeReference } from "../fixtures";
+import { makeReference, makeVocabResult } from "../fixtures";
 
 function renderRecordDetail(id: string) {
   return render(
@@ -36,14 +36,7 @@ const mockLabels = new Map([
 beforeEach(() => {
   vi.clearAllMocks();
   history.replaceState(null, "", "/esea");
-  mockUseVocabulary.mockReturnValue({
-    labels: null,
-    broader: null,
-    definitions: null,
-    schemes: null,
-    loading: false,
-    error: null,
-  });
+  mockUseVocabulary.mockReturnValue(makeVocabResult());
   mockUseContextPrefixes.mockReturnValue({
     context: null,
     loading: false,
@@ -107,14 +100,7 @@ describe("RecordDetailPage", () => {
       loading: false,
       error: null,
     });
-    mockUseVocabulary.mockReturnValue({
-      labels: mockLabels,
-      broader: new Map(),
-      definitions: new Map(),
-      schemes: [],
-      loading: false,
-      error: null,
-    });
+    mockUseVocabulary.mockReturnValue(makeVocabResult({ labels: mockLabels }));
     mockUseContextPrefixes.mockReturnValue({
       context: { prefixes: PREFIXES },
       loading: false,
@@ -180,14 +166,9 @@ describe("RecordDetailPage", () => {
       loading: false,
       error: null,
     });
-    mockUseVocabulary.mockReturnValue({
-      labels: null,
-      broader: null,
-      definitions: null,
-      schemes: null,
-      loading: false,
-      error: new Error("Network failure"),
-    });
+    mockUseVocabulary.mockReturnValue(
+      makeVocabResult({ error: new Error("Network failure") }),
+    );
     mockUseContextPrefixes.mockReturnValue({
       context: null,
       loading: false,

--- a/tests/pages/SearchPage.test.tsx
+++ b/tests/pages/SearchPage.test.tsx
@@ -46,31 +46,18 @@ import {
   getSearchExport,
 } from "@/services/apiClient";
 import { useVocabulary } from "@/hooks/useVocabulary";
+import { makeVocabResult } from "../fixtures";
 const mockSearch = vi.mocked(searchReferences);
 const mockRequestExport = vi.mocked(requestSearchExport);
 const mockGetExport = vi.mocked(getSearchExport);
 const mockVocab = vi.mocked(useVocabulary);
 
 function silentVocab(): ReturnType<typeof useVocabulary> {
-  return {
-    labels: null,
-    broader: null,
-    definitions: null,
-    schemes: null,
-    loading: false,
-    error: null,
-  };
+  return makeVocabResult();
 }
 
 function vocabWith(schemes: typeof OUTCOME_SCHEME_FIXTURE[]): ReturnType<typeof useVocabulary> {
-  return {
-    labels: null,
-    broader: null,
-    definitions: null,
-    schemes,
-    loading: false,
-    error: null,
-  };
+  return makeVocabResult({ schemes });
 }
 
 function makeResult(count: number, ids: string[] = [], isLowerBound = false): SearchResult {
@@ -531,14 +518,7 @@ describe("SearchPage", () => {
     });
 
     test("Refine is disabled while vocabulary is loading", async () => {
-      mockVocab.mockReturnValue({
-        labels: null,
-        broader: null,
-        definitions: null,
-        schemes: null,
-        loading: true,
-        error: null,
-      });
+      mockVocab.mockReturnValue(makeVocabResult({ loading: true }));
       mockBoth({ results: makeResult(120, ["r1"]) });
       renderSearchPage();
       await waitFor(() => expect(screen.getByText("Title r1")).toBeInTheDocument());

--- a/tests/pages/SearchPage.test.tsx
+++ b/tests/pages/SearchPage.test.tsx
@@ -555,6 +555,18 @@ describe("SearchPage", () => {
       });
     });
 
+    test("export button hidden on /hpv until HPV Excel export (#127) lands", async () => {
+      history.replaceState(null, "", "/hpv");
+      mockBoth({ results: makeResult(6, ["r1"]) });
+      renderSearchPage();
+      await waitFor(() =>
+        expect(screen.getByText("Title r1")).toBeInTheDocument(),
+      );
+      expect(
+        screen.queryByRole("button", { name: /export to excel/i }),
+      ).toBeNull();
+    });
+
     test("enabled in year-only URL; click POSTs with q=* and the year filter", async () => {
       history.replaceState(null, "", "/esea?start_year=2020");
       mockBoth({ results: makeResult(120, ["r1"]) });

--- a/tests/services/communities.test.ts
+++ b/tests/services/communities.test.ts
@@ -54,4 +54,26 @@ describe("communities", () => {
     const { DEFAULT_FEATURES } = await import("@/services/communities");
     expect(DEFAULT_FEATURES.evidenceMap).toBe(false);
   });
+
+  it("gates findings/estimates per community (ESEA on, HPV off)", async () => {
+    const { findCommunity } = await import("@/services/communities");
+    expect(findCommunity("esea")?.features.findingsAndEstimates).toBe(true);
+    expect(findCommunity("hpv")?.features.findingsAndEstimates).toBe(false);
+  });
+
+  it("excludes exactly the 5 HPV geo schemes from card pills, none for ESEA", async () => {
+    const { findCommunity } = await import("@/services/communities");
+    expect(findCommunity("esea")?.pillExcludedSchemes).toEqual([]);
+    const hpvExcluded = findCommunity("hpv")?.pillExcludedSchemes ?? [];
+    expect(hpvExcluded).toHaveLength(5);
+    expect(hpvExcluded).toEqual(
+      expect.arrayContaining([
+        "https://vocab.aliveevidence.org/hpv/Country",
+        "https://vocab.aliveevidence.org/hpv/CountryClassification",
+        "https://vocab.aliveevidence.org/hpv/UNICEFRegion",
+        "https://vocab.aliveevidence.org/hpv/WorldBankRegion",
+        "https://vocab.aliveevidence.org/hpv/WHORegion",
+      ]),
+    );
+  });
 });

--- a/tests/services/communities.test.ts
+++ b/tests/services/communities.test.ts
@@ -50,7 +50,7 @@ describe("communities", () => {
     expect(hpv?.codingInstitution).toBeUndefined();
   });
 
-  it("opts every feature out by default, leaving communities to enable them", async () => {
+  it("opts evidence-map out by default, leaving communities to enable it", async () => {
     const { DEFAULT_FEATURES } = await import("@/services/communities");
     expect(DEFAULT_FEATURES.evidenceMap).toBe(false);
   });

--- a/tests/services/communities.test.ts
+++ b/tests/services/communities.test.ts
@@ -55,6 +55,11 @@ describe("communities", () => {
     expect(DEFAULT_FEATURES.evidenceMap).toBe(false);
   });
 
+  it("opts Excel export out by default, leaving communities to enable it", async () => {
+    const { DEFAULT_FEATURES } = await import("@/services/communities");
+    expect(DEFAULT_FEATURES.exportExcel).toBe(false);
+  });
+
   it("gates findings/estimates per community (ESEA on, HPV off)", async () => {
     const { findCommunity } = await import("@/services/communities");
     expect(findCommunity("esea")?.features.findingsAndEstimates).toBe(true);

--- a/tests/services/communities.test.ts
+++ b/tests/services/communities.test.ts
@@ -61,6 +61,12 @@ describe("communities", () => {
     expect(findCommunity("hpv")?.features.findingsAndEstimates).toBe(false);
   });
 
+  it("gates Excel export per community (ESEA on, HPV off until #127)", async () => {
+    const { findCommunity } = await import("@/services/communities");
+    expect(findCommunity("esea")?.features.exportExcel).toBe(true);
+    expect(findCommunity("hpv")?.features.exportExcel).toBe(false);
+  });
+
   it("excludes exactly the 5 HPV geo schemes from card pills, none for ESEA", async () => {
     const { findCommunity } = await import("@/services/communities");
     expect(findCommunity("esea")?.pillExcludedSchemes).toEqual([]);

--- a/tests/services/communities.test.ts
+++ b/tests/services/communities.test.ts
@@ -67,6 +67,12 @@ describe("communities", () => {
     expect(findCommunity("hpv")?.features.exportExcel).toBe(false);
   });
 
+  it("gates the facet-backed country filter per community (ESEA on, HPV off)", async () => {
+    const { findCommunity } = await import("@/services/communities");
+    expect(findCommunity("esea")?.features.countryFacetFilter).toBe(true);
+    expect(findCommunity("hpv")?.features.countryFacetFilter).toBe(false);
+  });
+
   it("excludes exactly the 5 HPV geo schemes from card pills, none for ESEA", async () => {
     const { findCommunity } = await import("@/services/communities");
     expect(findCommunity("esea")?.pillExcludedSchemes).toEqual([]);

--- a/tests/services/investigationParser.test.ts
+++ b/tests/services/investigationParser.test.ts
@@ -90,6 +90,35 @@ describe("parseInvestigation", () => {
     expect(parseInvestigation(data, PREFIXES, LABELS).isRetracted).toBe(false);
   });
 
+  test("resolves hasAppliedConcept bare URI strings into concepts", () => {
+    const data = makeData({
+      hasAppliedConcept: [
+        "https://vocab.esea.education/C00086",
+        "https://vocab.esea.education/C00122",
+      ],
+    });
+    const result = parseInvestigation(data, PREFIXES, LABELS);
+    expect(result.appliedConcepts).toEqual([
+      { uri: "https://vocab.esea.education/C00086", label: "Cooperative Learning" },
+      { uri: "https://vocab.esea.education/C00122", label: "Curriculum" },
+    ]);
+  });
+
+  test("returns empty appliedConcepts when hasAppliedConcept is absent", () => {
+    const result = parseInvestigation(makeData({}), PREFIXES, LABELS);
+    expect(result.appliedConcepts).toEqual([]);
+  });
+
+  test("resolves an applied concept with no known label to undefined label", () => {
+    const data = makeData({
+      hasAppliedConcept: ["https://vocab.esea.education/C99999"],
+    });
+    const result = parseInvestigation(data, PREFIXES, LABELS);
+    expect(result.appliedConcepts).toEqual([
+      { uri: "https://vocab.esea.education/C99999", label: undefined },
+    ]);
+  });
+
   test("extractIsRetracted returns true when set", () => {
     const data = makeData({ isRetracted: true });
     expect(extractIsRetracted(data)).toBe(true);

--- a/tests/services/vocabulary/vocabularyService.test.ts
+++ b/tests/services/vocabulary/vocabularyService.test.ts
@@ -219,6 +219,30 @@ describe("buildVocabularyData", () => {
       definition: "Peer-reviewed publication.",
     });
   });
+
+  it("maps each concept to its scheme via skos:inScheme", () => {
+    const { inScheme } = buildVocabularyData(SAMPLE_VOCABULARY);
+
+    expect(
+      inScheme.get("https://vocab.esea.education/DocumentTypeScheme/C00008"),
+    ).toBe("esea:DocumentTypeScheme");
+
+    // Concepts with no skos:inScheme are absent (C00022 is a top concept but
+    // carries no inScheme of its own).
+    expect(
+      inScheme.has("https://vocab.esea.education/EducationThemeScheme/C00022"),
+    ).toBe(false);
+  });
+
+  it("reads skos:inScheme directly, even for a concept absent from any scheme tree", () => {
+    // C00002 has skos:inScheme but no scheme tree entry; derive-from-tree would lose it.
+    const { inScheme, schemes } = buildVocabularyData(SAMPLE_VOCABULARY);
+
+    expect(
+      inScheme.get("https://vocab.esea.education/EducationLevelScheme/C00002"),
+    ).toBe("esea:EducationLevelScheme");
+    expect(schemes.some((s) => s.uri === "esea:EducationLevelScheme")).toBe(false);
+  });
 });
 
 describe("fetchVocabulary", () => {

--- a/tests/services/vocabulary/vocabularyService.test.ts
+++ b/tests/services/vocabulary/vocabularyService.test.ts
@@ -225,7 +225,7 @@ describe("buildVocabularyData", () => {
 
     expect(
       inScheme.get("https://vocab.esea.education/DocumentTypeScheme/C00008"),
-    ).toBe("esea:DocumentTypeScheme");
+    ).toBe("https://vocab.esea.education/DocumentTypeScheme");
 
     // Concepts with no skos:inScheme are absent (C00022 is a top concept but
     // carries no inScheme of its own).
@@ -240,7 +240,7 @@ describe("buildVocabularyData", () => {
 
     expect(
       inScheme.get("https://vocab.esea.education/EducationLevelScheme/C00002"),
-    ).toBe("esea:EducationLevelScheme");
+    ).toBe("https://vocab.esea.education/EducationLevelScheme");
     expect(schemes.some((s) => s.uri === "esea:EducationLevelScheme")).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #125. Part of the UI epic #103; builds on the HPV community routing from #106. Rebased onto `main` after the evidence-map stack (#123 / #128 / #129) landed.

## What this does

Generalises the search result cards, the Refine drawer, and the evidence-map config panel so the HPV community renders correctly against its own data shape, with no change to Education (ESEA). Each difference is expressed as per-community config rather than a slug check in the components.

**Result card tags (the #125 core)**
- References surface the concepts coded against them as tags, sourced from the reference's applied-concept data (`investigationParser` gains an `appliedConcepts` slot) rather than aggregated from Education's scheme-specific fields.
- A new `inScheme` map on the vocabulary service resolves each concept to its scheme (stored as full URIs, consistent with `schemes[].uri`), which drives the geo exclusion below.

**No findings/estimates badges for HPV**
- `CommunityFeatures.findingsAndEstimates` (ESEA `true` / HPV `false`) gates the stat-badge render. HPV references carry no findings or effect estimates, so the labels would be empty.

**Geo concepts excluded from HPV pills**
- `Community.pillExcludedSchemes` drops HPV's five geography schemes from the card pills, resolved via the `inScheme` map. Kept distinct from `filterExcludedSchemes`: geo stays filterable in the drawer, it just isn't a pill.

**HPV evidence map enabled with default axes**
- `Community.defaultEvidenceMapAxes` opens HPV's map on TargetPopulation (rows) by DeliveryActor (columns). DeliveryPlatform was rejected as an axis: no coded records, so it would plot an empty map.

**Country filter hidden for HPV, in both the drawer and the map panel**
- `CommunityFeatures.countryFacetFilter` (ESEA `true` / HPV `false`) gates the typeahead Country card backed by the `countries` search facet. HPV codes country as an ISO suffix on a concept URI rather than the object property ESEA uses, so that facet is empty and the card would render "No countries match." The gate is threaded as `showCountryFacetFilter` through the shared `FilterCardList` (used by both the Refine drawer and the evidence-map config panel), so the empty card is suppressed in both places. This is a separate lever from `filterExcludedSchemes`, which only filters the vocabulary concept-scheme cards, not the hardcoded Country `FilterCard`.

**Export to Excel hidden for HPV, and off by default**
- `CommunityFeatures.exportExcel` gates the toolbar button. The default is now `false`, with ESEA opting in explicitly. Today's export runs the Education-shaped pipeline, so defaulting it off means a new community cannot silently ship a malformed workbook. Re-enabled for HPV once #127 lands.

## Why community flags, not slug checks

Each difference is a boolean or config value on `CommunityFeatures` / `Community`, so adding a third community is a config edit, not a new branch in the components. Same shape as the community-config pattern introduced in #106.

## Validation performed

- Full suite green: 774 passing across 68 files; `tsc --noEmit` clean.
- Live-verified locally against a dev server (Vite on `:3000` to a local destiny-repository on `:8000`, with 6 HPV records seeded):
  - `/hpv`: cards render applied-concept tags, no stat-badges, geo schemes excluded from pills (a 52-concept reference resolved to 6 topical pills, under the 8-pill cap), Export to Excel absent, no Country card in the Refine drawer.
  - `/hpv/visualise`: the map renders on the TargetPopulation by DeliveryActor axes with no console errors; the config panel shows HPV's Country concept-scheme card and suppresses the facet-backed Country card.
  - `/esea` and `/esea/visualise`: unchanged. Stat-badges with real counts, document-type-led pills, Export present, Country card populated with facet counts, map opens on its EducationLevel by EducationTheme defaults.
- Confirmed against the live HPV vocabulary that geo exclusion holds: `skos:inScheme` is serialised as full URIs there, matching the full-URI exclusion list.

## Follow-ups

- `countryFacetFilter` flips back to `true` for HPV as a fast-follow if/when a country projection populates the `countries` facet (not built yet). That flip also adds HPV's Country scheme to `filterExcludedSchemes` so the concept-scheme duplicate does not surface (two levers, opposite directions).
- Export stays hidden until the HPV Excel pipeline in #127 lands.
