### PR TITLE
AI Summaries UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ VITE_KEYCLOAK_REALM=destiny
 VITE_KEYCLOAK_CLIENT_ID=evidence-repo-ui-client-development
 # VITE_MATOMO_CONTAINER_URL=https://cdn.matomo.cloud/futureevidence.matomo.cloud/container_<id>_dev_<hash>.js
 VITE_FEEDBACK_FORM_URL=https://forms.gle/zH9fsNZk8BApTaVj9
+# Where "Flag this summary" sends accuracy reports (a Google Form for now)
+# VITE_AI_SUMMARY_FLAG_FORM_URL=https://forms.gle/your-flag-form
+# Base URL of the evidence-summariser service; unset ⇒ UI uses placeholder data
+# VITE_SUMMARISER_BASE=http://localhost:8001/api
 VITE_ESEA_VOCABULARY_URL=https://vocab.staging.evidence-repository.org/published/019d40cf-2a63-77af-9828-c6a70647792c/1.1/vocabulary.jsonld
 VITE_ESEA_CONTEXT_URL=https://vocab.staging.evidence-repository.org/published/019d40cf-2a63-77af-9828-c6a70647792c/1.1/context.jsonld
 # HPV vocabulary is not yet published — these are placeholders

--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,10 @@ VITE_KEYCLOAK_CLIENT_ID=evidence-repo-ui-client-development
 VITE_FEEDBACK_FORM_URL=https://forms.gle/zH9fsNZk8BApTaVj9
 # Where "Flag this summary" sends accuracy reports (a Google Form for now)
 # VITE_AI_SUMMARY_FLAG_FORM_URL=https://forms.gle/your-flag-form
-# Base URL of the evidence-summariser service; unset ⇒ UI uses placeholder data
-# VITE_SUMMARISER_BASE=http://localhost:8001/api
+# Base URL of the evidence-summariser service. This is the on-switch for AI
+# summaries: unset ⇒ the feature is hidden. Routes are served at the root, so
+# don't append /api (e.g. the local docker-compose service is http://localhost:8000).
+# VITE_SUMMARISER_BASE=http://localhost:8000
 VITE_ESEA_VOCABULARY_URL=https://vocab.staging.evidence-repository.org/published/019d40cf-2a63-77af-9828-c6a70647792c/1.1/vocabulary.jsonld
 VITE_ESEA_CONTEXT_URL=https://vocab.staging.evidence-repository.org/published/019d40cf-2a63-77af-9828-c6a70647792c/1.1/context.jsonld
 # HPV vocabulary is not yet published — these are placeholders

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,7 @@ jobs:
           VITE_HPV_VOCABULARY_URL: ${{ vars.VITE_HPV_VOCABULARY_URL }}
           VITE_HPV_CONTEXT_URL: ${{ vars.VITE_HPV_CONTEXT_URL }}
           VITE_SUMMARISER_BASE: ${{ vars.VITE_SUMMARISER_BASE }}
+          VITE_AI_SUMMARY_FLAG_FORM_URL: ${{ vars.VITE_AI_SUMMARY_FLAG_FORM_URL }}
         run: npm run build
 
       - name: Upload build artifacts

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,6 +57,7 @@ jobs:
           VITE_ESEA_CONTEXT_URL: ${{ vars.VITE_ESEA_CONTEXT_URL }}
           VITE_HPV_VOCABULARY_URL: ${{ vars.VITE_HPV_VOCABULARY_URL }}
           VITE_HPV_CONTEXT_URL: ${{ vars.VITE_HPV_CONTEXT_URL }}
+          VITE_SUMMARISER_BASE: ${{ vars.VITE_SUMMARISER_BASE }}
         run: npm run build
 
       - name: Upload build artifacts

--- a/infra/app/github_actions.tf
+++ b/infra/app/github_actions.tf
@@ -133,6 +133,15 @@ resource "github_actions_environment_variable" "vite_summariser_base" {
   value         = var.summariser_base
 }
 
+# Empty until the accuracy-flag form exists; the UI hides the flag link without it.
+resource "github_actions_environment_variable" "vite_ai_summary_flag_form_url" {
+  count         = var.ai_summary_flag_form_url != "" ? 1 : 0
+  repository    = github_repository_environment.environment.repository
+  environment   = github_repository_environment.environment.environment
+  variable_name = "VITE_AI_SUMMARY_FLAG_FORM_URL"
+  value         = var.ai_summary_flag_form_url
+}
+
 resource "github_actions_environment_variable" "vite_esea_vocabulary_url" {
   repository    = github_repository_environment.environment.repository
   environment   = github_repository_environment.environment.environment

--- a/infra/app/github_actions.tf
+++ b/infra/app/github_actions.tf
@@ -123,6 +123,16 @@ resource "github_actions_environment_variable" "vite_feedback_form_url" {
   value         = var.feedback_form_url
 }
 
+# Empty in environments where the summariser isn't deployed yet, which keeps the
+# AI summaries feature hidden (the UI gates on this being set).
+resource "github_actions_environment_variable" "vite_summariser_base" {
+  count         = var.summariser_base != "" ? 1 : 0
+  repository    = github_repository_environment.environment.repository
+  environment   = github_repository_environment.environment.environment
+  variable_name = "VITE_SUMMARISER_BASE"
+  value         = var.summariser_base
+}
+
 resource "github_actions_environment_variable" "vite_esea_vocabulary_url" {
   repository    = github_repository_environment.environment.repository
   environment   = github_repository_environment.environment.environment

--- a/infra/app/variables.tf
+++ b/infra/app/variables.tf
@@ -112,6 +112,12 @@ variable "summariser_base" {
   default     = ""
 }
 
+variable "ai_summary_flag_form_url" {
+  description = "Google Form URL for flagging an AI summary's accuracy; empty hides the flag link"
+  type        = string
+  default     = ""
+}
+
 variable "esea_vocabulary_url" {
   description = "URL of the ESEA community's published SKOS vocabulary (.jsonld) — used to resolve concept labels in exports and other vocabulary-driven features"
   type        = string

--- a/infra/app/variables.tf
+++ b/infra/app/variables.tf
@@ -106,6 +106,12 @@ variable "feedback_form_url" {
   default     = "https://forms.gle/zH9fsNZk8BApTaVj9"
 }
 
+variable "summariser_base" {
+  description = "Base URL of the evidence-summariser service; empty hides the AI summaries feature"
+  type        = string
+  default     = ""
+}
+
 variable "esea_vocabulary_url" {
   description = "URL of the ESEA community's published SKOS vocabulary (.jsonld) — used to resolve concept labels in exports and other vocabulary-driven features"
   type        = string

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -13,9 +13,9 @@ export class ApiError extends Error {
 
 async function request<T>(
   endpoint: string,
-  options: { method?: string; body?: unknown } = {},
+  options: { method?: string; body?: unknown; signal?: AbortSignal } = {},
 ): Promise<T> {
-  const { method = "GET", body } = options;
+  const { method = "GET", body, signal } = options;
 
   try {
     await keycloak.updateToken(30);
@@ -36,6 +36,7 @@ async function request<T>(
     method,
     headers,
     body: body ? JSON.stringify(body) : undefined,
+    signal,
   });
 
   if (!response.ok) {
@@ -54,7 +55,8 @@ async function request<T>(
 }
 
 export const api = {
-  get: <T>(endpoint: string) => request<T>(endpoint),
+  get: <T>(endpoint: string, signal?: AbortSignal) =>
+    request<T>(endpoint, { signal }),
   post: <T>(endpoint: string, body: unknown) =>
     request<T>(endpoint, { method: "POST", body }),
   put: <T>(endpoint: string, body: unknown) =>

--- a/src/components/ai-summary/AiSummaryButton.tsx
+++ b/src/components/ai-summary/AiSummaryButton.tsx
@@ -2,19 +2,13 @@ import "./ai-summary.css";
 
 interface AiSummaryButtonProps {
   onClick: () => void;
-  disabled?: boolean;
 }
 
 /** "Generate AI summary" entry point shown above the results list. */
-export function AiSummaryButton({ onClick, disabled }: AiSummaryButtonProps) {
+export function AiSummaryButton({ onClick }: AiSummaryButtonProps) {
   return (
     <div class="gen-row">
-      <button
-        type="button"
-        class="gen-btn"
-        onClick={onClick}
-        disabled={disabled}
-      >
+      <button type="button" class="gen-btn" onClick={onClick}>
         <span>Generate AI summary</span>
         <span class="ai-beta">BETA</span>
       </button>

--- a/src/components/ai-summary/AiSummaryButton.tsx
+++ b/src/components/ai-summary/AiSummaryButton.tsx
@@ -1,0 +1,23 @@
+import "./ai-summary.css";
+
+interface AiSummaryButtonProps {
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+/** "Generate AI summary" entry point shown above the results list. */
+export function AiSummaryButton({ onClick, disabled }: AiSummaryButtonProps) {
+  return (
+    <div class="gen-row">
+      <button
+        type="button"
+        class="gen-btn"
+        onClick={onClick}
+        disabled={disabled}
+      >
+        <span>Generate AI summary</span>
+        <span class="beta">BETA</span>
+      </button>
+    </div>
+  );
+}

--- a/src/components/ai-summary/AiSummaryButton.tsx
+++ b/src/components/ai-summary/AiSummaryButton.tsx
@@ -16,7 +16,7 @@ export function AiSummaryButton({ onClick, disabled }: AiSummaryButtonProps) {
         disabled={disabled}
       >
         <span>Generate AI summary</span>
-        <span class="beta">BETA</span>
+        <span class="ai-beta">BETA</span>
       </button>
     </div>
   );

--- a/src/components/ai-summary/AiSummaryButton.tsx
+++ b/src/components/ai-summary/AiSummaryButton.tsx
@@ -1,9 +1,10 @@
+import { Tooltip } from "@/components/common/Tooltip";
 import "./ai-summary.css";
 
 interface AiSummaryButtonProps {
   onClick: () => void;
   disabled?: boolean;
-  /** Tooltip explaining why the button is disabled. */
+  /** Shown as a tooltip explaining why the button is disabled. */
   disabledReason?: string;
 }
 
@@ -13,18 +14,21 @@ export function AiSummaryButton({
   disabled = false,
   disabledReason,
 }: AiSummaryButtonProps) {
+  const button = (
+    <button type="button" class="gen-btn" onClick={onClick} disabled={disabled}>
+      <span>Generate AI summary</span>
+      <span class="ai-beta">BETA</span>
+    </button>
+  );
+  // Tooltip wrapper lives outside the disabled button so the bubble still
+  // appears on hover (disabled buttons don't receive pointer events).
   return (
     <div class="gen-row">
-      <button
-        type="button"
-        class="gen-btn"
-        onClick={onClick}
-        disabled={disabled}
-        title={disabled ? disabledReason : undefined}
-      >
-        <span>Generate AI summary</span>
-        <span class="ai-beta">BETA</span>
-      </button>
+      {disabled && disabledReason ? (
+        <Tooltip text={disabledReason}>{button}</Tooltip>
+      ) : (
+        button
+      )}
     </div>
   );
 }

--- a/src/components/ai-summary/AiSummaryButton.tsx
+++ b/src/components/ai-summary/AiSummaryButton.tsx
@@ -2,13 +2,26 @@ import "./ai-summary.css";
 
 interface AiSummaryButtonProps {
   onClick: () => void;
+  disabled?: boolean;
+  /** Tooltip explaining why the button is disabled. */
+  disabledReason?: string;
 }
 
 /** "Generate AI summary" entry point shown above the results list. */
-export function AiSummaryButton({ onClick }: AiSummaryButtonProps) {
+export function AiSummaryButton({
+  onClick,
+  disabled = false,
+  disabledReason,
+}: AiSummaryButtonProps) {
   return (
     <div class="gen-row">
-      <button type="button" class="gen-btn" onClick={onClick}>
+      <button
+        type="button"
+        class="gen-btn"
+        onClick={onClick}
+        disabled={disabled}
+        title={disabled ? disabledReason : undefined}
+      >
         <span>Generate AI summary</span>
         <span class="ai-beta">BETA</span>
       </button>

--- a/src/components/ai-summary/AiSummaryDrawer.tsx
+++ b/src/components/ai-summary/AiSummaryDrawer.tsx
@@ -1,0 +1,150 @@
+import { Fragment } from "preact";
+import { Drawer } from "@/components/common/Drawer";
+import { AI_SUMMARY_FLAG_FORM_URL } from "@/config";
+import type { UseAiSummaryResult } from "@/hooks/useAiSummary";
+import { SummaryBody } from "./renderSummary";
+import "./ai-summary.css";
+
+export interface AiSummaryContext {
+  /** Intersecting term labels shown as chips. */
+  terms: string[];
+  /** Number of papers feeding the summary. */
+  count: number;
+}
+
+interface AiSummaryDrawerProps {
+  ai: UseAiSummaryResult;
+  context: AiSummaryContext;
+}
+
+function pluralPapers(n: number): string {
+  return `${n} ${n === 1 ? "paper" : "papers"}`;
+}
+
+export function AiSummaryDrawer({ ai, context }: AiSummaryDrawerProps) {
+  const title =
+    ai.status === "generating"
+      ? "Generating summary…"
+      : ai.status === "error"
+        ? "Summary unavailable"
+        : "AI summary";
+
+  return (
+    <Drawer
+      open={ai.drawerOpen}
+      block="ai-drawer"
+      title={title}
+      titleAdornment={<span class="beta">BETA</span>}
+      subtitle={<ContextChips terms={context.terms} count={context.count} />}
+      headerAction={
+        <button
+          type="button"
+          class="ai-iconbtn"
+          aria-label="Close"
+          title="Close"
+          onClick={ai.dismiss}
+        >
+          ✕
+        </button>
+      }
+      footer={<DrawerFooter ai={ai} />}
+      closeOnBackdrop
+      onClose={ai.dismiss}
+    >
+      {ai.status === "generating" && (
+        <div class="ai-loading">
+          <span class="ai-spinner" />
+          <span>
+            Summarising {pluralPapers(context.count)}… this can take several
+            minutes. You can keep working — use “Run in background”.
+          </span>
+        </div>
+      )}
+
+      {ai.status === "error" && (
+        <p class="ai-error" role="alert">
+          {ai.errorMessage ?? "Couldn't generate the summary."}
+        </p>
+      )}
+
+      {ai.status === "done" && ai.result && (
+        <>
+          <Disclaimer />
+          <SummaryBody
+            summary={ai.result.summary}
+            papers={ai.result.papers}
+          />
+        </>
+      )}
+    </Drawer>
+  );
+}
+
+function ContextChips({ terms, count }: AiSummaryContext) {
+  return (
+    <div class="ai-ctx">
+      {terms.map((term, i) => (
+        <Fragment key={i}>
+          {i > 0 && (
+            <span class="ai-cross" aria-hidden="true">
+              ×
+            </span>
+          )}
+          <span class="ai-term">{term}</span>
+        </Fragment>
+      ))}
+      <span class="ai-pill">
+        {count} {count === 1 ? "result" : "results"}
+      </span>
+    </div>
+  );
+}
+
+function Disclaimer() {
+  return (
+    <div class="ai-disclaimer">
+      <svg width="16" height="16" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path d="M10 2 19 17H1L10 2Z" />
+        <rect x="9" y="8" width="2" height="5" fill="#fff" />
+        <rect x="9" y="14" width="2" height="2" fill="#fff" />
+      </svg>
+      <span>
+        AI-generated from the papers at this intersection. Quotes are extracted
+        verbatim — verify against the sources before using in synthesis.
+      </span>
+    </div>
+  );
+}
+
+function DrawerFooter({ ai }: { ai: UseAiSummaryResult }) {
+  if (ai.status === "generating") {
+    return (
+      <footer class="ai-drawer__footer">
+        <button type="button" class="ai-btn" onClick={ai.dismiss}>
+          Cancel
+        </button>
+        <button
+          type="button"
+          class="ai-btn ai-btn--primary ai-btn--push"
+          onClick={ai.runInBackground}
+        >
+          Run in background
+        </button>
+      </footer>
+    );
+  }
+
+  if (!AI_SUMMARY_FLAG_FORM_URL) return null;
+  return (
+    <footer class="ai-drawer__footer">
+      <a
+        class="ai-btn ai-btn--flag ai-btn--push"
+        href={AI_SUMMARY_FLAG_FORM_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        ⚑ Flag this summary
+      </a>
+    </footer>
+  );
+}

--- a/src/components/ai-summary/AiSummaryDrawer.tsx
+++ b/src/components/ai-summary/AiSummaryDrawer.tsx
@@ -1,14 +1,16 @@
 import { Drawer } from "@/components/common/Drawer";
 import { AI_SUMMARY_FLAG_FORM_URL } from "@/config";
 import type { UseAiSummaryResult } from "@/hooks/useAiSummary";
+import type { SearchResultTotal } from "@/types/models";
+import { formatTotal } from "@/utils/searchTotal";
 import { SummaryBody } from "./renderSummary";
 import "./ai-summary.css";
 
 export interface AiSummaryContext {
   /** Intersecting term labels shown as chips. */
   terms: string[];
-  /** Number of papers feeding the summary. */
-  count: number;
+  /** Papers feeding the summary (the full match total, may be a lower bound). */
+  count: SearchResultTotal;
 }
 
 interface AiSummaryDrawerProps {
@@ -59,8 +61,9 @@ export function AiSummaryDrawer({ ai, context }: AiSummaryDrawerProps) {
         <div class="ai-loading">
           <span class="ai-spinner" />
           <span>
-            Summarising {pluralPapers(context.count)}… this can take several
-            minutes. You can keep working — use “Run in background”.
+            Summarising {formatTotal(context.count)}{" "}
+            {context.count.count === 1 ? "paper" : "papers"}… this can take
+            several minutes. You can keep working — use “Run in background”.
           </span>
         </div>
       )}
@@ -100,7 +103,7 @@ function ContextChips({ terms, count }: AiSummaryContext) {
         </span>
       ))}
       <span class="ai-pill">
-        {count} {count === 1 ? "result" : "results"}
+        {formatTotal(count)} {count.count === 1 ? "result" : "results"}
       </span>
     </div>
   );

--- a/src/components/ai-summary/AiSummaryDrawer.tsx
+++ b/src/components/ai-summary/AiSummaryDrawer.tsx
@@ -2,6 +2,7 @@ import { Drawer } from "@/components/common/Drawer";
 import { AI_SUMMARY_FLAG_FORM_URL } from "@/config";
 import type { UseAiSummaryResult } from "@/hooks/useAiSummary";
 import type { SearchResultTotal } from "@/types/models";
+import type { SkipReason, SummariseResponse } from "@/services/summariser";
 import { formatTotal } from "@/utils/searchTotal";
 import { SummaryBody } from "./renderSummary";
 import "./ai-summary.css";
@@ -18,9 +19,11 @@ interface AiSummaryDrawerProps {
   context: AiSummaryContext;
 }
 
-function pluralPapers(n: number): string {
-  return `${n} ${n === 1 ? "paper" : "papers"}`;
-}
+const SKIP_REASON_TEXT: Record<SkipReason, string> = {
+  no_full_text: "had no full text available",
+  not_pdf: "were not in PDF format",
+  download_failed: "couldn't be downloaded",
+};
 
 export function AiSummaryDrawer({ ai, context }: AiSummaryDrawerProps) {
   const title =
@@ -77,20 +80,41 @@ export function AiSummaryDrawer({ ai, context }: AiSummaryDrawerProps) {
       {ai.status === "done" && ai.result && (
         <>
           <Disclaimer />
-          {ai.result.extraction_errors.length > 0 && (
-            <p class="ai-extraction-note">
-              {pluralPapers(ai.result.extraction_errors.length)} couldn't be read
-              and {ai.result.extraction_errors.length === 1 ? "was" : "were"} left
-              out of this summary.
-            </p>
-          )}
           <SummaryBody
             summary={ai.result.summary}
             papers={ai.result.papers}
           />
+          <CoverageNote result={ai.result} />
         </>
       )}
     </Drawer>
+  );
+}
+
+// How many references the summary actually drew on, and which were left out.
+function CoverageNote({ result }: { result: SummariseResponse }) {
+  const used = result.papers.length;
+
+  const reasonCounts = new Map<SkipReason, number>();
+  for (const ref of result.skipped_references) {
+    reasonCounts.set(ref.reason, (reasonCounts.get(ref.reason) ?? 0) + 1);
+  }
+  const clauses = [...reasonCounts].map(
+    ([reason, n]) => `${n} ${SKIP_REASON_TEXT[reason]}`,
+  );
+  if (result.extraction_errors.length > 0) {
+    clauses.push(`${result.extraction_errors.length} couldn't be read`);
+  }
+
+  const leftOut = result.skipped_references.length + result.extraction_errors.length;
+  const total = used + leftOut;
+
+  return (
+    <p class="ai-coverage">
+      {leftOut === 0
+        ? `Based on ${total} ${total === 1 ? "reference" : "references"}.`
+        : `Based on ${used} of ${total} references. ${clauses.join("; ")} — left out of this summary.`}
+    </p>
   );
 }
 

--- a/src/components/ai-summary/AiSummaryDrawer.tsx
+++ b/src/components/ai-summary/AiSummaryDrawer.tsx
@@ -1,23 +1,14 @@
 import { Drawer } from "@/components/common/Drawer";
 import { WarningIcon } from "@/components/common/icons";
 import { AI_SUMMARY_FLAG_FORM_URL } from "@/config";
-import type { UseAiSummaryResult } from "@/hooks/useAiSummary";
-import type { SearchResultTotal } from "@/types/models";
+import type { AiSummaryContext, UseAiSummaryResult } from "@/hooks/useAiSummary";
 import type { SkipReason, SummariseResponse } from "@/services/summariser";
 import { formatTotal } from "@/utils/searchTotal";
 import { SummaryBody } from "./renderSummary";
 import "./ai-summary.css";
 
-export interface AiSummaryContext {
-  /** Intersecting term labels shown as chips. */
-  terms: string[];
-  /** Papers feeding the summary (the full match total, may be a lower bound). */
-  count: SearchResultTotal;
-}
-
 interface AiSummaryDrawerProps {
   ai: UseAiSummaryResult;
-  context: AiSummaryContext;
 }
 
 const SKIP_REASON_TEXT: Record<SkipReason, string> = {
@@ -26,7 +17,7 @@ const SKIP_REASON_TEXT: Record<SkipReason, string> = {
   download_failed: "couldn't be downloaded",
 };
 
-export function AiSummaryDrawer({ ai, context }: AiSummaryDrawerProps) {
+export function AiSummaryDrawer({ ai }: AiSummaryDrawerProps) {
   const title =
     ai.status === "generating"
       ? "Generating summary…"
@@ -38,6 +29,7 @@ export function AiSummaryDrawer({ ai, context }: AiSummaryDrawerProps) {
   // does. While generating, close drops it to the background chip; once there's
   // nothing running, close clears the finished summary.
   const handleClose = ai.status === "generating" ? ai.runInBackground : ai.dismiss;
+  const context = ai.context;
 
   return (
     <Drawer
@@ -45,7 +37,7 @@ export function AiSummaryDrawer({ ai, context }: AiSummaryDrawerProps) {
       block="ai-drawer"
       title={title}
       titleAdornment={<span class="ai-beta">BETA</span>}
-      subtitle={<ContextChips terms={context.terms} count={context.count} />}
+      subtitle={context ? <ContextChips context={context} /> : undefined}
       headerAction={
         <button
           type="button"
@@ -61,13 +53,13 @@ export function AiSummaryDrawer({ ai, context }: AiSummaryDrawerProps) {
       closeOnBackdrop
       onClose={handleClose}
     >
-      {ai.status === "generating" && (
+      {ai.status === "generating" && context && (
         <div class="ai-loading">
           <span class="ai-spinner" />
           <span>
-            Summarising {formatTotal(context.count)}{" "}
-            {context.count.count === 1 ? "paper" : "papers"}… this can take
-            several minutes. You can keep working — use “Run in background”.
+            Summarising {formatTotal(context.count)} {context.countNoun}… this
+            can take several minutes. You can keep working — use “Run in
+            background”.
           </span>
         </div>
       )}
@@ -119,16 +111,16 @@ function CoverageNote({ result }: { result: SummariseResponse }) {
   );
 }
 
-function ContextChips({ terms, count }: AiSummaryContext) {
+function ContextChips({ context }: { context: AiSummaryContext }) {
   return (
     <div class="ai-ctx">
-      {terms.map((term, i) => (
+      {context.terms.map((term, i) => (
         <span key={i} class="ai-term">
           {term}
         </span>
       ))}
       <span class="ai-pill">
-        {formatTotal(count)} {count.count === 1 ? "result" : "results"}
+        {formatTotal(context.count)} {context.countNoun}
       </span>
     </div>
   );

--- a/src/components/ai-summary/AiSummaryDrawer.tsx
+++ b/src/components/ai-summary/AiSummaryDrawer.tsx
@@ -1,4 +1,3 @@
-import { Fragment } from "preact";
 import { Drawer } from "@/components/common/Drawer";
 import { AI_SUMMARY_FLAG_FORM_URL } from "@/config";
 import type { UseAiSummaryResult } from "@/hooks/useAiSummary";
@@ -29,6 +28,11 @@ export function AiSummaryDrawer({ ai, context }: AiSummaryDrawerProps) {
         ? "Summary unavailable"
         : "AI summary";
 
+  // Closing should never abort an in-flight job — only the explicit "Cancel"
+  // does. While generating, close drops it to the background chip; once there's
+  // nothing running, close clears the finished summary.
+  const handleClose = ai.status === "generating" ? ai.runInBackground : ai.dismiss;
+
   return (
     <Drawer
       open={ai.drawerOpen}
@@ -42,14 +46,14 @@ export function AiSummaryDrawer({ ai, context }: AiSummaryDrawerProps) {
           class="ai-iconbtn"
           aria-label="Close"
           title="Close"
-          onClick={ai.dismiss}
+          onClick={handleClose}
         >
           ✕
         </button>
       }
       footer={<DrawerFooter ai={ai} />}
       closeOnBackdrop
-      onClose={ai.dismiss}
+      onClose={handleClose}
     >
       {ai.status === "generating" && (
         <div class="ai-loading">
@@ -91,14 +95,9 @@ function ContextChips({ terms, count }: AiSummaryContext) {
   return (
     <div class="ai-ctx">
       {terms.map((term, i) => (
-        <Fragment key={i}>
-          {i > 0 && (
-            <span class="ai-cross" aria-hidden="true">
-              ×
-            </span>
-          )}
-          <span class="ai-term">{term}</span>
-        </Fragment>
+        <span key={i} class="ai-term">
+          {term}
+        </span>
       ))}
       <span class="ai-pill">
         {count} {count === 1 ? "result" : "results"}

--- a/src/components/ai-summary/AiSummaryDrawer.tsx
+++ b/src/components/ai-summary/AiSummaryDrawer.tsx
@@ -140,7 +140,8 @@ function DrawerFooter({ ai }: { ai: UseAiSummaryResult }) {
     );
   }
 
-  if (!AI_SUMMARY_FLAG_FORM_URL) return null;
+  // Flagging only applies to a produced summary — not the error state.
+  if (ai.status !== "done" || !AI_SUMMARY_FLAG_FORM_URL) return null;
   return (
     <footer class="ai-drawer__footer">
       <a

--- a/src/components/ai-summary/AiSummaryDrawer.tsx
+++ b/src/components/ai-summary/AiSummaryDrawer.tsx
@@ -1,4 +1,5 @@
 import { Drawer } from "@/components/common/Drawer";
+import { WarningIcon } from "@/components/common/icons";
 import { AI_SUMMARY_FLAG_FORM_URL } from "@/config";
 import type { UseAiSummaryResult } from "@/hooks/useAiSummary";
 import type { SearchResultTotal } from "@/types/models";
@@ -136,11 +137,7 @@ function ContextChips({ terms, count }: AiSummaryContext) {
 function Disclaimer() {
   return (
     <div class="ai-disclaimer">
-      <svg width="16" height="16" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-        <path d="M10 2 19 17H1L10 2Z" />
-        <rect x="9" y="8" width="2" height="5" fill="#fff" />
-        <rect x="9" y="14" width="2" height="2" fill="#fff" />
-      </svg>
+      <WarningIcon size={16} />
       <span>
         AI-generated from the papers at this intersection. Quotes are extracted
         verbatim — verify against the sources before using in synthesis.

--- a/src/components/ai-summary/AiSummaryDrawer.tsx
+++ b/src/components/ai-summary/AiSummaryDrawer.tsx
@@ -34,7 +34,7 @@ export function AiSummaryDrawer({ ai, context }: AiSummaryDrawerProps) {
       open={ai.drawerOpen}
       block="ai-drawer"
       title={title}
-      titleAdornment={<span class="beta">BETA</span>}
+      titleAdornment={<span class="ai-beta">BETA</span>}
       subtitle={<ContextChips terms={context.terms} count={context.count} />}
       headerAction={
         <button
@@ -70,6 +70,13 @@ export function AiSummaryDrawer({ ai, context }: AiSummaryDrawerProps) {
       {ai.status === "done" && ai.result && (
         <>
           <Disclaimer />
+          {ai.result.extraction_errors.length > 0 && (
+            <p class="ai-extraction-note">
+              {pluralPapers(ai.result.extraction_errors.length)} couldn't be read
+              and {ai.result.extraction_errors.length === 1 ? "was" : "were"} left
+              out of this summary.
+            </p>
+          )}
           <SummaryBody
             summary={ai.result.summary}
             papers={ai.result.papers}

--- a/src/components/ai-summary/AiSummaryMiniChip.tsx
+++ b/src/components/ai-summary/AiSummaryMiniChip.tsx
@@ -1,0 +1,40 @@
+import type { UseAiSummaryResult } from "@/hooks/useAiSummary";
+import "./ai-summary.css";
+
+interface AiSummaryMiniChipProps {
+  ai: UseAiSummaryResult;
+}
+
+/**
+ * Background indicator shown while the drawer is minimized: a working spinner
+ * during generation, or a "Summary ready" nudge that reopens the drawer.
+ */
+export function AiSummaryMiniChip({ ai }: AiSummaryMiniChipProps) {
+  if (!ai.minimized) return null;
+
+  if (ai.status === "done") {
+    return (
+      <div class="ai-mini is-ready">
+        <span class="ai-mini__dot-ready" aria-hidden="true">
+          ✓
+        </span>
+        <span>Summary ready</span>
+        <span class="ai-mini__sep" aria-hidden="true" />
+        <button type="button" class="ai-mini__view" onClick={ai.open}>
+          View
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div class="ai-mini">
+      <span class="ai-spinner" aria-hidden="true" />
+      <span>Summarising…</span>
+      <span class="ai-mini__sep" aria-hidden="true" />
+      <button type="button" class="ai-mini__cancel" onClick={ai.dismiss}>
+        Cancel
+      </button>
+    </div>
+  );
+}

--- a/src/components/ai-summary/ai-summary.css
+++ b/src/components/ai-summary/ai-summary.css
@@ -1,0 +1,386 @@
+/* AI summary feature styles. The drawer shell comes from the shared Drawer
+   (components/common/Drawer.css); these are the AI-specific content styles,
+   ported from the mid-fi design and reusing the system's tokens. */
+
+/* ── Generate button (above results) ──────────────────────── */
+.gen-row {
+  max-width: 960px;
+  margin: var(--spacing-md) auto;
+  display: flex;
+  justify-content: flex-end;
+}
+.gen-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  background: var(--color-accent);
+  border: 1px solid var(--color-accent);
+  color: #fff;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-body);
+  font-size: var(--font-size-small);
+  font-weight: 500;
+  padding: 8px 14px;
+  cursor: pointer;
+  transition: background 0.12s, box-shadow 0.12s;
+}
+.gen-btn:hover:not(:disabled) {
+  background: var(--color-accent-hover);
+  box-shadow: var(--shadow-sm);
+}
+.gen-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.beta {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  background: var(--color-accent);
+  color: #fff;
+  border-radius: 2px;
+  padding: 2px 4px;
+}
+.gen-btn .beta {
+  background: rgba(255, 255, 255, 0.22);
+}
+
+/* ── Drawer panel/body sizing (companions to .drawer__*) ──── */
+.ai-drawer__panel {
+  width: min(500px, 100vw);
+}
+.ai-drawer__body {
+  padding: var(--spacing-lg);
+}
+
+/* ── Close button ─────────────────────────────────────────── */
+.ai-iconbtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-surface);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font-size: 14px;
+  transition: border-color 0.12s, color 0.12s;
+}
+.ai-iconbtn:hover {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+/* ── Context chips ────────────────────────────────────────── */
+.ai-ctx {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+.ai-term {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-mono-sm);
+  font-weight: 500;
+  color: var(--color-accent);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-accent);
+  border-radius: 20px;
+  padding: 2px 10px;
+}
+.ai-cross {
+  color: var(--color-text-tertiary);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-mono-sm);
+}
+.ai-pill {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-mono-sm);
+  color: var(--color-text-tertiary);
+  background: var(--color-bg-inset);
+  border: 1px solid var(--color-border);
+  border-radius: 20px;
+  padding: 2px 9px;
+}
+
+/* ── Disclaimer banner ────────────────────────────────────── */
+.ai-disclaimer {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-sm);
+  background: var(--color-warning-light);
+  border: 1px solid #f3dca0;
+  border-radius: var(--radius-md);
+  padding: 10px 12px;
+  margin-bottom: var(--spacing-md);
+  font-size: var(--font-size-small);
+  line-height: 1.45;
+  color: #7a5a00;
+}
+.ai-disclaimer svg {
+  flex: 0 0 auto;
+  margin-top: 1px;
+  color: #b8860b;
+}
+
+/* ── Loading / error ──────────────────────────────────────── */
+.ai-loading {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-sm);
+  font-size: var(--font-size-body);
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+}
+.ai-error {
+  font-size: var(--font-size-body);
+  color: var(--color-danger);
+}
+.ai-spinner {
+  flex: 0 0 auto;
+  width: 14px;
+  height: 14px;
+  border: 1.5px solid var(--color-accent-light);
+  border-top-color: var(--color-accent);
+  border-radius: 50%;
+  margin-top: 3px;
+  animation: ai-spin 0.7s linear infinite;
+}
+@keyframes ai-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* ── Narrative prose + footnotes ──────────────────────────── */
+.ai-narrative__header {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-mono-caps);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
+  margin: 0 0 var(--spacing-sm);
+}
+.ai-prose {
+  font-family: var(--font-body);
+  font-size: var(--font-size-body);
+  line-height: 1.62;
+  color: var(--color-text-primary);
+  margin: 0 0 var(--spacing-lg);
+}
+.ai-fn {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--color-accent);
+  vertical-align: super;
+  line-height: 0;
+  cursor: pointer;
+  padding: 0 1px;
+  text-decoration: none;
+}
+.ai-fn:hover {
+  text-decoration: underline;
+}
+
+/* ── Claims & sources ─────────────────────────────────────── */
+.ai-claims-head {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-mono-caps);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+  padding-top: var(--spacing-md);
+  border-top: 1px solid var(--color-border);
+  margin: 0 0 var(--spacing-sm);
+}
+.ai-claim {
+  display: grid;
+  grid-template-columns: 22px 1fr;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) 0;
+  border-bottom: 1px dashed var(--color-border);
+  border-radius: var(--radius-sm);
+  transition: background 0.3s ease;
+}
+.ai-claim:last-child {
+  border-bottom: none;
+}
+.ai-claim.is-flash {
+  background: var(--color-accent-light);
+}
+.ai-claim__num {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  color: #fff;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.ai-claim__source + .ai-claim__source {
+  margin-top: var(--spacing-sm);
+}
+.ai-quote {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: var(--font-size-body);
+  line-height: 1.5;
+  color: var(--color-text-secondary);
+  border-left: 2px solid var(--color-border-strong);
+  padding-left: 10px;
+  margin: 0 0 5px;
+}
+.ai-cite {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--font-size-small);
+  color: var(--color-text-tertiary);
+}
+.ai-cite__doi {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-mono-sm);
+  color: var(--color-accent);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+.ai-cite__doi:hover {
+  text-decoration: underline;
+}
+
+/* ── Footer ───────────────────────────────────────────────── */
+.ai-drawer__footer {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md) var(--spacing-lg);
+  border-top: 1px solid var(--color-border);
+  background: var(--color-bg-surface);
+}
+.ai-btn {
+  font-family: var(--font-body);
+  font-size: var(--font-size-small);
+  font-weight: 500;
+  padding: 8px 14px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-primary);
+  text-decoration: none;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.ai-btn:hover {
+  background: var(--color-bg-hover);
+}
+.ai-btn--push {
+  margin-left: auto;
+}
+.ai-btn--primary {
+  border-color: var(--color-accent);
+  background: var(--color-accent);
+  color: #fff;
+}
+.ai-btn--primary:hover {
+  background: var(--color-accent-hover);
+  border-color: var(--color-accent-hover);
+}
+.ai-btn--flag {
+  border-color: var(--color-border);
+  color: var(--color-danger);
+}
+.ai-btn--flag:hover {
+  border-color: var(--color-danger);
+  background: #fdecec;
+}
+
+/* ── Background chip ───────────────────────────────────────── */
+.ai-mini {
+  position: fixed;
+  right: 28px;
+  bottom: 84px;
+  z-index: 300;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  padding: 10px 12px;
+  font-size: var(--font-size-small);
+  color: var(--color-text-primary);
+  animation: ai-rise 0.22s ease;
+}
+@keyframes ai-rise {
+  from {
+    transform: translateY(8px);
+    opacity: 0;
+  }
+}
+.ai-mini.is-ready {
+  border-color: var(--color-success);
+}
+.ai-mini__dot-ready {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--color-success);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+}
+.ai-mini__view {
+  font-family: var(--font-body);
+  font-weight: 500;
+  font-size: var(--font-size-small);
+  color: var(--color-accent);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+.ai-mini__view:hover {
+  text-decoration: underline;
+}
+.ai-mini__cancel {
+  font-family: var(--font-body);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-tertiary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+.ai-mini__cancel:hover {
+  color: var(--color-danger);
+}
+.ai-mini__sep {
+  width: 1px;
+  height: 16px;
+  background: var(--color-border);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ai-mini {
+    animation: none;
+  }
+  .ai-spinner {
+    animation-duration: 1.4s;
+  }
+}

--- a/src/components/ai-summary/ai-summary.css
+++ b/src/components/ai-summary/ai-summary.css
@@ -32,7 +32,7 @@
   opacity: 0.5;
   cursor: not-allowed;
 }
-.beta {
+.ai-beta {
   font-family: var(--font-mono);
   font-size: 9px;
   letter-spacing: 0.08em;
@@ -42,7 +42,7 @@
   border-radius: 2px;
   padding: 2px 4px;
 }
-.gen-btn .beta {
+.gen-btn .ai-beta {
   background: rgba(255, 255, 255, 0.22);
 }
 
@@ -138,6 +138,11 @@
 .ai-error {
   font-size: var(--font-size-body);
   color: var(--color-danger);
+}
+.ai-extraction-note {
+  font-size: var(--font-size-small);
+  color: var(--color-text-tertiary);
+  margin: 0 0 var(--spacing-md);
 }
 .ai-spinner {
   flex: 0 0 auto;

--- a/src/components/ai-summary/ai-summary.css
+++ b/src/components/ai-summary/ai-summary.css
@@ -5,7 +5,9 @@
 /* ── Generate button (above results) ──────────────────────── */
 .gen-row {
   max-width: 960px;
-  margin: var(--spacing-md) auto;
+  /* The search hero already pads 36px below the search bar; pull up so the
+     button lands at the design's ~16px gap instead of stacking both. */
+  margin: calc(var(--spacing-md) - 36px) auto var(--spacing-md);
   display: flex;
   justify-content: flex-end;
 }

--- a/src/components/ai-summary/ai-summary.css
+++ b/src/components/ai-summary/ai-summary.css
@@ -91,11 +91,6 @@
   border-radius: 20px;
   padding: 2px 10px;
 }
-.ai-cross {
-  color: var(--color-text-tertiary);
-  font-family: var(--font-mono);
-  font-size: var(--font-size-mono-sm);
-}
 .ai-pill {
   font-family: var(--font-mono);
   font-size: var(--font-size-mono-sm);

--- a/src/components/ai-summary/ai-summary.css
+++ b/src/components/ai-summary/ai-summary.css
@@ -136,10 +136,12 @@
   font-size: var(--font-size-body);
   color: var(--color-danger);
 }
-.ai-extraction-note {
+.ai-coverage {
+  margin: var(--spacing-md) 0 0;
+  padding-top: var(--spacing-md);
+  border-top: 1px solid var(--color-border);
   font-size: var(--font-size-small);
   color: var(--color-text-tertiary);
-  margin: 0 0 var(--spacing-md);
 }
 .ai-spinner {
   flex: 0 0 auto;

--- a/src/components/ai-summary/ai-summary.css
+++ b/src/components/ai-summary/ai-summary.css
@@ -107,7 +107,7 @@
   align-items: flex-start;
   gap: var(--spacing-sm);
   background: var(--color-warning-light);
-  border: 1px solid #f3dca0;
+  border: 1px solid var(--color-warning);
   border-radius: var(--radius-md);
   padding: 10px 12px;
   margin-bottom: var(--spacing-md);

--- a/src/components/ai-summary/renderSummary.tsx
+++ b/src/components/ai-summary/renderSummary.tsx
@@ -37,6 +37,9 @@ interface SummaryBodyProps {
 /**
  * Renders the narrative prose with footnote markers linking to a numbered
  * "Claims & sources" list. Clicking a footnote scrolls to and flashes its claim.
+ *
+ * `summary.contradictions` is intentionally not rendered in this minimal
+ * version; surfacing conflicting findings is a follow-up.
  */
 export function SummaryBody({ summary, papers }: SummaryBodyProps) {
   const rootRef = useRef<HTMLDivElement>(null);
@@ -64,6 +67,7 @@ export function SummaryBody({ summary, papers }: SummaryBodyProps) {
                     key={n}
                     class="ai-fn"
                     href="#"
+                    aria-label={`Jump to claim ${n}`}
                     onClick={(e) => {
                       e.preventDefault();
                       jumpToClaim(n);

--- a/src/components/ai-summary/renderSummary.tsx
+++ b/src/components/ai-summary/renderSummary.tsx
@@ -1,0 +1,115 @@
+import { Fragment } from "preact";
+import { useRef } from "preact/hooks";
+import type { PaperMeta, SummaryBlock } from "@/services/summariser";
+
+const EXT_ICON = (
+  <svg
+    width="11"
+    height="11"
+    viewBox="0 0 12 12"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M4 2H2v8h8V8" />
+    <path d="M7 2h3v3" />
+    <path d="M10 2 6 6" />
+  </svg>
+);
+
+function citation(papers: PaperMeta[], paperId: string): string {
+  const paper = papers.find((p) => p.paper === paperId);
+  if (!paper) return paperId;
+  const lead = paper.authors[0] ?? paper.title ?? paperId;
+  const etAl = paper.authors.length > 1 ? " et al." : "";
+  const year = paper.year ? ` (${paper.year})` : "";
+  return `${lead}${etAl}${year}`;
+}
+
+interface SummaryBodyProps {
+  summary: SummaryBlock;
+  papers: PaperMeta[];
+}
+
+/**
+ * Renders the narrative prose with footnote markers linking to a numbered
+ * "Claims & sources" list. Clicking a footnote scrolls to and flashes its claim.
+ */
+export function SummaryBody({ summary, papers }: SummaryBodyProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  function jumpToClaim(n: number) {
+    const el = rootRef.current?.querySelector<HTMLElement>(`#aiClaim-${n}`);
+    if (!el) return;
+    el.scrollIntoView({ behavior: "smooth", block: "center" });
+    el.classList.add("is-flash");
+    setTimeout(() => el.classList.remove("is-flash"), 1300);
+  }
+
+  return (
+    <div ref={rootRef}>
+      {summary.narrative.map((para, i) => (
+        <div key={i} class="ai-narrative">
+          {para.header && <p class="ai-narrative__header">{para.header}</p>}
+          <p class="ai-prose">
+            {para.sentences.map((sentence, j) => (
+              <Fragment key={j}>
+                {j > 0 ? " " : ""}
+                {sentence.text}
+                {sentence.claims.map((n) => (
+                  <a
+                    key={n}
+                    class="ai-fn"
+                    href="#"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      jumpToClaim(n);
+                    }}
+                  >
+                    {n}
+                  </a>
+                ))}
+              </Fragment>
+            ))}
+          </p>
+        </div>
+      ))}
+
+      <p class="ai-claims-head">Claims &amp; sources</p>
+      {summary.claims.map((claim, idx) => {
+        const n = idx + 1;
+        return (
+          <div key={n} id={`aiClaim-${n}`} class="ai-claim">
+            <div class="ai-claim__num">{n}</div>
+            <div class="ai-claim__body">
+              {claim.quotes.map((quote, qi) => {
+                const paper = papers.find((p) => p.paper === quote.paper);
+                return (
+                  <div key={qi} class="ai-claim__source">
+                    <p class="ai-quote">“{quote.quote}”</p>
+                    <div class="ai-cite">
+                      <span>{citation(papers, quote.paper)}</span>
+                      {paper?.doi && (
+                        <a
+                          class="ai-cite__doi"
+                          href={`https://doi.org/${paper.doi}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          DOI {EXT_ICON}
+                        </a>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/ai-summary/renderSummary.tsx
+++ b/src/components/ai-summary/renderSummary.tsx
@@ -1,24 +1,7 @@
 import { Fragment } from "preact";
 import { useRef } from "preact/hooks";
+import { ExternalLinkIcon } from "@/components/common/icons";
 import type { PaperMeta, SummaryBlock } from "@/services/summariser";
-
-const EXT_ICON = (
-  <svg
-    width="11"
-    height="11"
-    viewBox="0 0 12 12"
-    fill="none"
-    stroke="currentColor"
-    stroke-width="1.5"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-    aria-hidden="true"
-  >
-    <path d="M4 2H2v8h8V8" />
-    <path d="M7 2h3v3" />
-    <path d="M10 2 6 6" />
-  </svg>
-);
 
 function citation(papers: PaperMeta[], paperId: string): string {
   const paper = papers.find((p) => p.paper === paperId);
@@ -103,7 +86,7 @@ export function SummaryBody({ summary, papers }: SummaryBodyProps) {
                           target="_blank"
                           rel="noopener noreferrer"
                         >
-                          DOI {EXT_ICON}
+                          DOI <ExternalLinkIcon size={11} />
                         </a>
                       )}
                     </div>

--- a/src/components/ai-summary/summaryTerms.ts
+++ b/src/components/ai-summary/summaryTerms.ts
@@ -1,0 +1,22 @@
+import type { SearchParams } from "@/services/searchParams";
+
+/**
+ * The terms a summary is framed around, drawn from the current search: the
+ * free-text query (when set) plus the labels of any applied concept filters —
+ * the subjects the summary intersects. A map cell arrives as concept filters
+ * with no free-text query, so resolving them to labels is what gives a
+ * map-driven summary its terms. Country and year filters are scoping
+ * constraints rather than subjects, so they're excluded (they still scope
+ * which references are summarised).
+ */
+export function deriveSummaryTerms(
+  params: SearchParams,
+  labels: Map<string, string> | null,
+): string[] {
+  const queryTerm =
+    params.q !== "" && params.q !== "*" ? [params.q] : [];
+  const conceptTerms = params.conceptFilters
+    .flat()
+    .map((uri) => labels?.get(uri) ?? uri);
+  return [...queryTerm, ...conceptTerms];
+}

--- a/src/components/common/Drawer.css
+++ b/src/components/common/Drawer.css
@@ -1,0 +1,96 @@
+.drawer {
+  position: fixed;
+  inset: 0;
+  /* Above AppShell header (100) and FeedbackFAB (200) — a modal must
+     cover everything else on the page. */
+  z-index: 1000;
+}
+
+.drawer__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(22, 27, 34, 0.4);
+  animation: drawer-fade 0.18s ease;
+}
+
+/* Width is left to the consumer's `${block}__panel` companion class. */
+.drawer__panel {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--color-bg-surface);
+  border-left: 1px solid var(--color-border);
+  box-shadow: var(--shadow-lg);
+  display: flex;
+  flex-direction: column;
+  animation: drawer-slide 0.24s cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+.drawer__panel:focus {
+  outline: none;
+}
+
+@keyframes drawer-fade {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes drawer-slide {
+  from {
+    transform: translateX(28px);
+    opacity: 0.4;
+  }
+}
+
+.drawer__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  padding: var(--spacing-md) var(--spacing-lg);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.drawer__heading {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  min-width: 0;
+}
+
+.drawer__titlerow {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.drawer__title {
+  margin: 0;
+  font-size: var(--font-size-xl);
+  font-weight: 500;
+  color: var(--color-text-primary);
+}
+
+.drawer__subtitle {
+  margin: 0;
+  font-size: var(--font-size-small);
+  color: var(--color-text-tertiary);
+  /* Break unbroken strings (pasted URLs) so they don't overflow the panel. */
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+/* Padding is left to the consumer's `${block}__body` companion class. */
+.drawer__body {
+  flex: 1;
+  overflow-y: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .drawer__panel,
+  .drawer__backdrop {
+    animation: none;
+  }
+}

--- a/src/components/common/Drawer.tsx
+++ b/src/components/common/Drawer.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useId, useRef } from "preact/hooks";
+import type { ComponentChildren } from "preact";
+import "./Drawer.css";
+
+interface DrawerProps {
+  open: boolean;
+  /** Drawer heading. */
+  title: string;
+  /** Inline element shown beside the title, e.g. a "BETA" chip. */
+  titleAdornment?: ComponentChildren;
+  /** Content under the title row (a query nudge, context chips, …). */
+  subtitle?: ComponentChildren;
+  /** Right-aligned header control, e.g. a Cancel or Close button. */
+  headerAction?: ComponentChildren;
+  /** Full footer element; rendered after the scrolling body. */
+  footer?: ComponentChildren;
+  /**
+   * BEM block name for per-drawer styling/targeting. When set, each structural
+   * node also carries a `${block}__…` companion class alongside the shared
+   * `drawer__…` class, so consumers can override width/padding and tests can
+   * bind to a stable selector.
+   */
+  block?: string;
+  /** Close when the backdrop is clicked. Off by default (matches FilterDrawer). */
+  closeOnBackdrop?: boolean;
+  onClose: () => void;
+  children: ComponentChildren;
+}
+
+/**
+ * Right-anchored slide-over shell shared by the filter and AI-summary drawers.
+ * Owns the modal mechanics — body scroll-lock, focus capture/restore,
+ * Escape-to-close, backdrop — and the header/body/footer structure, while the
+ * content and footer are supplied by the caller.
+ *
+ * Gating on `open` mounts the panel fresh each time it opens (so caller state
+ * resets) and keeps the caller's body hooks from running while closed.
+ */
+export function Drawer({ open, ...rest }: DrawerProps) {
+  if (!open) return null;
+  return <DrawerPanel {...rest} />;
+}
+
+type DrawerPanelProps = Omit<DrawerProps, "open">;
+
+function DrawerPanel({
+  title,
+  titleAdornment,
+  subtitle,
+  headerAction,
+  footer,
+  block,
+  closeOnBackdrop = false,
+  onClose,
+  children,
+}: DrawerPanelProps) {
+  const panelRef = useRef<HTMLElement>(null);
+  const previousFocusRef = useRef<Element | null>(document.activeElement);
+  const titleId = useId();
+
+  // Shared `drawer__x` class plus an optional `${block}__x` companion.
+  const bem = (suffix: string) => {
+    const shared = suffix ? `drawer__${suffix}` : "drawer";
+    if (!block) return shared;
+    return `${shared} ${suffix ? `${block}__${suffix}` : block}`;
+  };
+
+  useEffect(() => {
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, []);
+
+  useEffect(() => {
+    panelRef.current?.focus();
+    return () => {
+      const target = previousFocusRef.current;
+      if (target instanceof HTMLElement) target.focus();
+    };
+  }, []);
+
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  return (
+    <div class={bem("")} role="presentation">
+      <div
+        class={bem("backdrop")}
+        aria-hidden="true"
+        onClick={closeOnBackdrop ? onClose : undefined}
+      />
+      <aside
+        ref={panelRef}
+        class={bem("panel")}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+      >
+        <header class={bem("header")}>
+          <div class={bem("heading")}>
+            <div class={bem("titlerow")}>
+              <h2 id={titleId} class={bem("title")}>
+                {title}
+              </h2>
+              {titleAdornment}
+            </div>
+            {subtitle}
+          </div>
+          {headerAction}
+        </header>
+
+        <div class={bem("body")}>{children}</div>
+
+        {footer}
+      </aside>
+    </div>
+  );
+}

--- a/src/components/filters/FilterDrawer.css
+++ b/src/components/filters/FilterDrawer.css
@@ -1,73 +1,12 @@
-.filter-drawer {
-  position: fixed;
-  inset: 0;
-  /* Above AppShell header (100) and FeedbackFAB (200) — a modal must
-     cover everything else on the page. */
-  z-index: 1000;
-}
-
-.filter-drawer__backdrop {
-  position: absolute;
-  inset: 0;
-  background: rgba(22, 27, 34, 0.4);
-}
+/* Shell styles (panel chrome, header, backdrop, animations) live in the shared
+   Drawer (components/common/Drawer.css). Only filter-specific overrides remain. */
 
 .filter-drawer__panel {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
   width: min(420px, 100vw);
-  background: var(--color-bg-surface);
-  border-left: 1px solid var(--color-border);
-  box-shadow: var(--shadow-lg);
-  display: flex;
-  flex-direction: column;
-}
-
-.filter-drawer__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--spacing-md);
-  padding: var(--spacing-md) var(--spacing-lg);
-  border-bottom: 1px solid var(--color-border);
-}
-
-.filter-drawer__heading {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 0;
-}
-
-.filter-drawer__title {
-  margin: 0;
-  font-size: var(--font-size-xl);
-  font-weight: 500;
-  color: var(--color-text-primary);
-}
-
-.filter-drawer__subtitle {
-  margin: 0;
-  font-size: var(--font-size-small);
-  color: var(--color-text-tertiary);
-  /* Break unbroken strings (pasted URLs) so they don't overflow the panel. */
-  overflow-wrap: anywhere;
-  word-break: break-word;
-}
-
-.filter-drawer__panel:focus {
-  outline: none;
 }
 
 .filter-drawer__body {
-  flex: 1;
-  overflow-y: auto;
   padding: var(--spacing-sm) 0;
   display: flex;
   flex-direction: column;
 }
-
-/* Footer (Reset all / Show results) and the header's Cancel button both use the
-   shared .filter-actions__btn styles. */

--- a/src/components/filters/FilterDrawer.tsx
+++ b/src/components/filters/FilterDrawer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef } from "preact/hooks";
+import { Drawer } from "@/components/common/Drawer";
 import { FilterCardList } from "./FilterCardList";
 import { FilterActions } from "./FilterActions";
 import { useFilterDraft, type AppliedFilters } from "./useFilterDraft";
@@ -52,36 +52,6 @@ function FilterDrawerPanel({
     appliedEndYear,
     params,
   });
-  const panelRef = useRef<HTMLElement>(null);
-  const previousFocusRef = useRef<Element | null>(document.activeElement);
-  const titleId = useId();
-
-  useEffect(() => {
-    const previous = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = previous;
-    };
-  }, []);
-
-  useEffect(() => {
-    panelRef.current?.focus();
-    return () => {
-      const target = previousFocusRef.current;
-      if (target instanceof HTMLElement) target.focus();
-    };
-  }, []);
-
-  useEffect(() => {
-    function handleKey(e: KeyboardEvent) {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        onCancel();
-      }
-    }
-    window.addEventListener("keydown", handleKey);
-    return () => window.removeEventListener("keydown", handleKey);
-  }, [onCancel]);
 
   function handleApply() {
     const applied = draft.buildApplied();
@@ -89,45 +59,37 @@ function FilterDrawerPanel({
   }
 
   return (
-    <div class="filter-drawer" role="presentation">
-      <div class="filter-drawer__backdrop" aria-hidden="true" />
-      <aside
-        ref={panelRef}
-        class="filter-drawer__panel"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={titleId}
-        tabIndex={-1}
-      >
-        <header class="filter-drawer__header">
-          <div class="filter-drawer__heading">
-            <h2 id={titleId} class="filter-drawer__title">
-              {title}
-            </h2>
-            {/* "*" is the browse-mode sentinel — don't echo it as a query. */}
-            {params.q !== "" && params.q !== "*" && (
-              <p class="filter-drawer__subtitle">Searching for “{params.q}”</p>
-            )}
-          </div>
-          <button
-            type="button"
-            class="filter-actions__btn filter-actions__btn--reset"
-            onClick={onCancel}
-          >
-            Cancel
-          </button>
-        </header>
-
-        <div class="filter-drawer__body">
-          <FilterCardList draft={draft} countNoun={countNoun} />
-        </div>
-
+    <Drawer
+      open
+      block="filter-drawer"
+      title={title}
+      // "*" is the browse-mode sentinel — don't echo it as a query.
+      subtitle={
+        params.q !== "" && params.q !== "*" ? (
+          <p class="drawer__subtitle filter-drawer__subtitle">
+            Searching for “{params.q}”
+          </p>
+        ) : undefined
+      }
+      headerAction={
+        <button
+          type="button"
+          class="filter-actions__btn filter-actions__btn--reset"
+          onClick={onCancel}
+        >
+          Cancel
+        </button>
+      }
+      footer={
         <FilterActions
           onReset={draft.reset}
           onApply={handleApply}
           applyDisabled={!draft.canApply}
         />
-      </aside>
-    </div>
+      }
+      onClose={onCancel}
+    >
+      <FilterCardList draft={draft} countNoun={countNoun} />
+    </Drawer>
   );
 }

--- a/src/components/filters/FilterDrawer.tsx
+++ b/src/components/filters/FilterDrawer.tsx
@@ -69,7 +69,7 @@ function FilterDrawerPanel({
       // "*" is the browse-mode sentinel — don't echo it as a query.
       subtitle={
         params.q !== "" && params.q !== "*" ? (
-          <p class="drawer__subtitle filter-drawer__subtitle">
+          <p class="drawer__subtitle">
             Searching for “{params.q}”
           </p>
         ) : undefined

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,8 +13,8 @@ export const FEEDBACK_FORM_URL: string | undefined =
 export const AI_SUMMARY_FLAG_FORM_URL: string | undefined =
   import.meta.env.VITE_AI_SUMMARY_FLAG_FORM_URL;
 
-// Base URL of the evidence-summariser service. Absent until the service is
-// deployed; the summariser client falls back to placeholder data without it.
+// Base URL of the evidence-summariser service. Unset until the service is
+// deployed; the UI hides the AI summaries feature while it's absent.
 export const SUMMARISER_BASE: string | undefined =
   import.meta.env.VITE_SUMMARISER_BASE;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,15 @@ export const MATOMO_CONTAINER_URL = import.meta.env.VITE_MATOMO_CONTAINER_URL;
 export const FEEDBACK_FORM_URL: string | undefined =
   import.meta.env.VITE_FEEDBACK_FORM_URL;
 
+// Where "Flag this summary" sends accuracy reports (a Google Form for now).
+export const AI_SUMMARY_FLAG_FORM_URL: string | undefined =
+  import.meta.env.VITE_AI_SUMMARY_FLAG_FORM_URL;
+
+// Base URL of the evidence-summariser service. Absent until the service is
+// deployed; the summariser client falls back to placeholder data without it.
+export const SUMMARISER_BASE: string | undefined =
+  import.meta.env.VITE_SUMMARISER_BASE;
+
 const VOCAB_PROXY_TARGET = import.meta.env.VITE_VOCAB_PROXY_TARGET;
 
 /**

--- a/src/hooks/useAiSummary.ts
+++ b/src/hooks/useAiSummary.ts
@@ -1,16 +1,27 @@
 import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import { requestSummary } from "@/services/summariserClient";
 import { searchReferenceIds, type SearchFilters } from "@/services/apiClient";
-import type { SummariseResponse, TermInfo } from "@/services/summariser";
+import type { SummariseResponse } from "@/services/summariser";
+import type { SearchResultTotal } from "@/types/models";
 
 export type AiSummaryStatus = "idle" | "generating" | "done" | "error";
 
+/** What the drawer displays about a summary — snapshotted at generate time. */
+export interface AiSummaryContext {
+  /** Intersecting term labels (query + applied concept filters). */
+  terms: string[];
+  /** Matching references at the intersection (may be a lower bound). */
+  count: SearchResultTotal;
+  /** The community's plural noun for evidence items ("references", …). */
+  countNoun: string;
+}
+
 export interface AiSummaryInput {
-  /** Intersecting terms the summary is framed against. */
-  terms: TermInfo[];
   /** Search query + filters identifying the references to summarise. */
   query: string | undefined;
   filters: Omit<SearchFilters, "page">;
+  /** Display context, captured now so a later search can't make it drift. */
+  context: AiSummaryContext;
 }
 
 export interface UseAiSummaryResult {
@@ -19,6 +30,8 @@ export interface UseAiSummaryResult {
   minimized: boolean;
   result: SummariseResponse | null;
   errorMessage: string | null;
+  /** Context for the active summary, frozen at generate time (null when idle). */
+  context: AiSummaryContext | null;
   /** The drawer is visible when there's an active summary and it isn't minimized. */
   drawerOpen: boolean;
   generate: (input: AiSummaryInput) => void;
@@ -40,6 +53,7 @@ export function useAiSummary(): UseAiSummaryResult {
   const [minimized, setMinimized] = useState(false);
   const [result, setResult] = useState<SummariseResponse | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [context, setContext] = useState<AiSummaryContext | null>(null);
 
   const abortRef = useRef<AbortController | null>(null);
   // Guards against a stale request resolving after dismiss/regenerate.
@@ -53,6 +67,7 @@ export function useAiSummary(): UseAiSummaryResult {
     setMinimized(false);
     setResult(null);
     setErrorMessage(null);
+    setContext(null);
   }, []);
 
   const generate = useCallback((input: AiSummaryInput) => {
@@ -66,6 +81,9 @@ export function useAiSummary(): UseAiSummaryResult {
     setMinimized(false);
     setResult(null);
     setErrorMessage(null);
+    // Freeze the context for this run so editing the search afterwards (while it
+    // generates or runs in the background) can't change what the drawer shows.
+    setContext(input.context);
 
     // Resolve every matching reference id, then summarise them. Both steps
     // honour the abort signal, so dismiss/regenerate cancels in-flight work.
@@ -78,7 +96,10 @@ export function useAiSummary(): UseAiSummaryResult {
         );
         if (stale()) return;
         const res = await requestSummary(
-          { terms: input.terms, referenceIds: reference_ids },
+          {
+            terms: input.context.terms.map((name) => ({ name })),
+            referenceIds: reference_ids,
+          },
           controller.signal,
         );
         if (stale()) return;
@@ -106,6 +127,7 @@ export function useAiSummary(): UseAiSummaryResult {
     minimized,
     result,
     errorMessage,
+    context,
     drawerOpen: status !== "idle" && !minimized,
     generate,
     open,

--- a/src/hooks/useAiSummary.ts
+++ b/src/hooks/useAiSummary.ts
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useRef, useState } from "preact/hooks";
+import { requestSummary } from "@/services/summariserClient";
+import type { SummariseResponse, SummaryRequest } from "@/services/summariser";
+
+export type AiSummaryStatus = "idle" | "generating" | "done" | "error";
+
+export interface UseAiSummaryResult {
+  status: AiSummaryStatus;
+  /** True while the drawer is dismissed to the background chip. */
+  minimized: boolean;
+  result: SummariseResponse | null;
+  errorMessage: string | null;
+  /** The drawer is visible when there's an active summary and it isn't minimized. */
+  drawerOpen: boolean;
+  generate: (request: SummaryRequest) => void;
+  /** Bring a minimized summary back into the drawer. */
+  open: () => void;
+  /** Dismiss the drawer to the background chip; generation keeps running. */
+  runInBackground: () => void;
+  /** Abort (if running) and clear everything. */
+  dismiss: () => void;
+}
+
+/**
+ * Owns AI-summary generation state for a page. Lives above the drawer so a
+ * summary survives "Run in background" (the drawer closing) and can be reopened
+ * from the background chip without losing the result.
+ */
+export function useAiSummary(): UseAiSummaryResult {
+  const [status, setStatus] = useState<AiSummaryStatus>("idle");
+  const [minimized, setMinimized] = useState(false);
+  const [result, setResult] = useState<SummariseResponse | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const abortRef = useRef<AbortController | null>(null);
+  // Guards against a stale request resolving after dismiss/regenerate.
+  const runRef = useRef(0);
+
+  const dismiss = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    runRef.current += 1;
+    setStatus("idle");
+    setMinimized(false);
+    setResult(null);
+    setErrorMessage(null);
+  }, []);
+
+  const generate = useCallback((request: SummaryRequest) => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    const runId = ++runRef.current;
+
+    setStatus("generating");
+    setMinimized(false);
+    setResult(null);
+    setErrorMessage(null);
+
+    requestSummary(request, controller.signal).then(
+      (res) => {
+        if (runRef.current !== runId) return;
+        setResult(res);
+        setStatus("done");
+      },
+      (err: unknown) => {
+        if (runRef.current !== runId) return;
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        setErrorMessage(
+          err instanceof Error ? err.message : "Couldn't generate the summary.",
+        );
+        setStatus("error");
+        setMinimized(false);
+      },
+    );
+  }, []);
+
+  const open = useCallback(() => setMinimized(false), []);
+  const runInBackground = useCallback(() => setMinimized(true), []);
+
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  return {
+    status,
+    minimized,
+    result,
+    errorMessage,
+    drawerOpen: status !== "idle" && !minimized,
+    generate,
+    open,
+    runInBackground,
+    dismiss,
+  };
+}

--- a/src/hooks/useAiSummary.ts
+++ b/src/hooks/useAiSummary.ts
@@ -1,8 +1,17 @@
 import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import { requestSummary } from "@/services/summariserClient";
-import type { SummariseResponse, SummaryRequest } from "@/services/summariser";
+import { searchReferenceIds, type SearchFilters } from "@/services/apiClient";
+import type { SummariseResponse, TermInfo } from "@/services/summariser";
 
 export type AiSummaryStatus = "idle" | "generating" | "done" | "error";
+
+export interface AiSummaryInput {
+  /** Intersecting terms the summary is framed against. */
+  terms: TermInfo[];
+  /** Search query + filters identifying the references to summarise. */
+  query: string | undefined;
+  filters: Omit<SearchFilters, "page">;
+}
 
 export interface UseAiSummaryResult {
   status: AiSummaryStatus;
@@ -12,7 +21,7 @@ export interface UseAiSummaryResult {
   errorMessage: string | null;
   /** The drawer is visible when there's an active summary and it isn't minimized. */
   drawerOpen: boolean;
-  generate: (request: SummaryRequest) => void;
+  generate: (input: AiSummaryInput) => void;
   /** Bring a minimized summary back into the drawer. */
   open: () => void;
   /** Dismiss the drawer to the background chip; generation keeps running. */
@@ -46,33 +55,45 @@ export function useAiSummary(): UseAiSummaryResult {
     setErrorMessage(null);
   }, []);
 
-  const generate = useCallback((request: SummaryRequest) => {
+  const generate = useCallback((input: AiSummaryInput) => {
     abortRef.current?.abort();
     const controller = new AbortController();
     abortRef.current = controller;
     const runId = ++runRef.current;
+    const stale = () => runRef.current !== runId;
 
     setStatus("generating");
     setMinimized(false);
     setResult(null);
     setErrorMessage(null);
 
-    requestSummary(request, controller.signal).then(
-      (res) => {
-        if (runRef.current !== runId) return;
+    // Resolve every matching reference id, then summarise them. Both steps
+    // honour the abort signal, so dismiss/regenerate cancels in-flight work.
+    (async () => {
+      try {
+        const { reference_ids } = await searchReferenceIds(
+          input.query,
+          input.filters,
+          controller.signal,
+        );
+        if (stale()) return;
+        const res = await requestSummary(
+          { terms: input.terms, referenceIds: reference_ids },
+          controller.signal,
+        );
+        if (stale()) return;
         setResult(res);
         setStatus("done");
-      },
-      (err: unknown) => {
-        if (runRef.current !== runId) return;
+      } catch (err: unknown) {
+        if (stale()) return;
         if (err instanceof DOMException && err.name === "AbortError") return;
         setErrorMessage(
           err instanceof Error ? err.message : "Couldn't generate the summary.",
         );
         setStatus("error");
         setMinimized(false);
-      },
-    );
+      }
+    })();
   }, []);
 
   const open = useCallback(() => setMinimized(false), []);

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -279,11 +279,14 @@ function SearchPageInner({ community }: { community: Community }) {
 
   // Context shown in the AI-summary drawer. The query stands in for the
   // intersecting terms until the evidence map deep-links explicit row/column
-  // labels here.
+  // labels here. Until an all-references source exists, a summary covers only
+  // the references on the current page, so the count reflects that rather than
+  // the full intersection total.
   const aiSummariesEnabled = community.features.aiSummaries;
+  const aiReferenceIds = results.results?.references.map((ref) => ref.id) ?? [];
   const aiContext = {
     terms: params.q !== "" && params.q !== "*" ? [params.q] : [],
-    count: results.results?.total.count ?? 0,
+    count: aiReferenceIds.length,
   };
 
   function handleGenerateSummary() {
@@ -293,7 +296,7 @@ function SearchPageInner({ community }: { community: Community }) {
     }
     ai.generate({
       terms: aiContext.terms.map((name) => ({ name })),
-      referenceIds: results.results?.references.map((ref) => ref.id) ?? [],
+      referenceIds: aiReferenceIds,
     });
   }
 

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -24,6 +24,10 @@ import { RefineButton } from "@/components/search/RefineButton";
 import { ResultRow } from "@/components/search/ResultRow";
 import { Pagination } from "@/components/common/Pagination";
 import { FilterDrawer, type AppliedFilters } from "@/components/filters/FilterDrawer";
+import { AiSummaryButton } from "@/components/ai-summary/AiSummaryButton";
+import { AiSummaryDrawer } from "@/components/ai-summary/AiSummaryDrawer";
+import { AiSummaryMiniChip } from "@/components/ai-summary/AiSummaryMiniChip";
+import { useAiSummary } from "@/hooks/useAiSummary";
 import { totalSelectedCount } from "@/components/filters/conceptSchemeFilterState";
 import { totalSelectedCount as totalSelectedCountryCount } from "@/components/filters/countryFilterState";
 import { totalSelectedCount as totalSelectedYearCount } from "@/components/filters/yearRangeFilterState";
@@ -142,6 +146,7 @@ function SearchPageInner({ community }: { community: Community }) {
   const corpus = useCorpusTotal();
   const results = useSearch(params);
   const exportJob = useSearchExport();
+  const ai = useAiSummary();
 
   // Kick off the vocabulary fetch on page mount (not on drawer open) via the
   // shared cache, so the Refine button is almost always ready by the time
@@ -272,6 +277,26 @@ function SearchPageInner({ community }: { community: Community }) {
     });
   }
 
+  // Context shown in the AI-summary drawer. The query stands in for the
+  // intersecting terms until the evidence map deep-links explicit row/column
+  // labels here.
+  const aiSummariesEnabled = community.features.aiSummaries;
+  const aiContext = {
+    terms: params.q !== "" && params.q !== "*" ? [params.q] : [],
+    count: results.results?.total.count ?? 0,
+  };
+
+  function handleGenerateSummary() {
+    if (ai.minimized) {
+      ai.open();
+      return;
+    }
+    ai.generate({
+      terms: aiContext.terms.map((name) => ({ name })),
+      referenceIds: results.results?.references.map((ref) => ref.id) ?? [],
+    });
+  }
+
   // Page size comes from the API response (page.count) so the UI stays in
   // sync if the backend ever changes its fixed page size. Math.max guards
   // against page.count = 0 to avoid divide-by-zero / Infinity totalPages.
@@ -309,6 +334,10 @@ function SearchPageInner({ community }: { community: Community }) {
           disabled={results.loading && results.results !== null}
         />
       </section>
+
+      {aiSummariesEnabled && hasResults && (
+        <AiSummaryButton onClick={handleGenerateSummary} />
+      )}
 
       <section class="search-results">
         {showMetaBar && (
@@ -422,6 +451,13 @@ function SearchPageInner({ community }: { community: Community }) {
           />
         )}
       </section>
+
+      {aiSummariesEnabled && (
+        <>
+          <AiSummaryDrawer ai={ai} context={aiContext} />
+          <AiSummaryMiniChip ai={ai} />
+        </>
+      )}
 
       {filterableSchemes.length > 0 && (
         <FilterDrawer

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -29,6 +29,7 @@ import { AiSummaryDrawer } from "@/components/ai-summary/AiSummaryDrawer";
 import { AiSummaryMiniChip } from "@/components/ai-summary/AiSummaryMiniChip";
 import { useAiSummary } from "@/hooks/useAiSummary";
 import { deriveSummaryTerms } from "@/components/ai-summary/summaryTerms";
+import { SUMMARISER_BASE } from "@/config";
 import { totalSelectedCount } from "@/components/filters/conceptSchemeFilterState";
 import { totalSelectedCount as totalSelectedCountryCount } from "@/components/filters/countryFilterState";
 import { totalSelectedCount as totalSelectedYearCount } from "@/components/filters/yearRangeFilterState";
@@ -284,7 +285,10 @@ function SearchPageInner({ community }: { community: Community }) {
   // concept filters (a map cell arrives here with those filters pre-applied).
   // The count is the full matching total — the hook summarises every reference
   // the ids endpoint returns, not just the current page.
-  const aiSummariesEnabled = community.features.aiSummaries;
+  // Also requires a configured summariser so users never see placeholder data:
+  // unset VITE_SUMMARISER_BASE ⇒ the feature stays hidden.
+  const aiSummariesEnabled =
+    community.features.aiSummaries && Boolean(SUMMARISER_BASE);
   const aiContext = {
     terms: deriveSummaryTerms(params, vocab.labels),
     count: results.results?.total.count ?? 0,

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -45,6 +45,9 @@ interface SearchPageProps {
 // past that are explicitly out of scope. Mirrors the search backend cap.
 const EXPORT_MAX_RESULTS = 10000;
 
+// The summariser accepts at most 50 references per request (1–50).
+const MAX_SUMMARY_REFERENCES = 50;
+
 // Maps the useVocabulary() result to the SearchBar `refine` prop. Returns
 // undefined when there are no facets to offer (empty schemes) so the Refine
 // trigger isn't rendered at all.
@@ -273,20 +276,23 @@ function SearchPageInner({ community }: { community: Community }) {
     });
   }
 
-  // Context shown in the AI-summary drawer and sent to the summariser as the
-  // terms to frame the summary around. A summary can be generated from any
-  // search, so the terms are the current free-text query plus any applied
-  // concept filters (a map cell arrives here with those filters pre-applied).
-  // The count is the full matching total — the hook summarises every reference
-  // the ids endpoint returns, not just the current page.
-  // Also requires a configured summariser so users never see placeholder data:
-  // unset VITE_SUMMARISER_BASE ⇒ the feature stays hidden.
+  // The AI-summary entry point. Requires a configured summariser so users never
+  // see placeholder data: unset VITE_SUMMARISER_BASE ⇒ the feature stays hidden.
   const aiSummariesEnabled =
     community.features.aiSummaries && Boolean(SUMMARISER_BASE);
-  const aiContext = {
-    terms: deriveSummaryTerms(params, vocab.labels),
-    count: results.results?.total ?? { count: 0, is_lower_bound: false },
-  };
+
+  // Terms framing the summary: the free-text query plus any applied concept
+  // filters (a map cell arrives here with those filters pre-applied).
+  const aiTerms = deriveSummaryTerms(params, vocab.labels);
+  const aiTotal = results.results?.total ?? { count: 0, is_lower_bound: false };
+  // The summariser accepts 1–50 references and at least one term; gate here so
+  // the user gets a clear reason rather than a server error.
+  const aiDisabledReason =
+    aiTerms.length === 0
+      ? "Search or filter by a term to summarise."
+      : aiTotal.count > MAX_SUMMARY_REFERENCES
+        ? `AI summaries cover up to ${MAX_SUMMARY_REFERENCES} references — refine your search.`
+        : undefined;
 
   function handleGenerateSummary() {
     if (ai.minimized) {
@@ -297,10 +303,15 @@ function SearchPageInner({ community }: { community: Community }) {
       params,
       community.defaultAnnotations,
     );
+    // Snapshot the display context now so a later search can't make it drift.
     ai.generate({
-      terms: aiContext.terms.map((name) => ({ name })),
       query,
       filters,
+      context: {
+        terms: aiTerms,
+        count: aiTotal,
+        countNoun: community.copy.countNoun,
+      },
     });
   }
 
@@ -343,7 +354,11 @@ function SearchPageInner({ community }: { community: Community }) {
       </section>
 
       {aiSummariesEnabled && hasResults && (
-        <AiSummaryButton onClick={handleGenerateSummary} />
+        <AiSummaryButton
+          onClick={handleGenerateSummary}
+          disabled={aiDisabledReason !== undefined}
+          disabledReason={aiDisabledReason}
+        />
       )}
 
       <section class="search-results">
@@ -463,7 +478,7 @@ function SearchPageInner({ community }: { community: Community }) {
 
       {aiSummariesEnabled && (
         <>
-          <AiSummaryDrawer ai={ai} context={aiContext} />
+          <AiSummaryDrawer ai={ai} />
           <AiSummaryMiniChip ai={ai} />
         </>
       )}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -30,6 +30,7 @@ import { AiSummaryMiniChip } from "@/components/ai-summary/AiSummaryMiniChip";
 import { useAiSummary } from "@/hooks/useAiSummary";
 import { deriveSummaryTerms } from "@/components/ai-summary/summaryTerms";
 import { SUMMARISER_BASE } from "@/config";
+import { formatTotal } from "@/utils/searchTotal";
 import { totalSelectedCount } from "@/components/filters/conceptSchemeFilterState";
 import { totalSelectedCount as totalSelectedCountryCount } from "@/components/filters/countryFilterState";
 import { totalSelectedCount as totalSelectedYearCount } from "@/components/filters/yearRangeFilterState";
@@ -38,13 +39,6 @@ import "./SearchPage.css";
 
 interface SearchPageProps {
   path?: string;
-}
-
-// ES caps deep pagination at 10k; when the true count exceeds that, the
-// backend returns is_lower_bound=true and count=10000. Render "10,000+" so
-// the UI doesn't understate the corpus size.
-function formatTotal(total: { count: number; is_lower_bound: boolean }): string {
-  return `${total.count.toLocaleString()}${total.is_lower_bound ? "+" : ""}`;
 }
 
 // 10k is destiny-repository's max_result_window; deep pagination + exports
@@ -291,7 +285,7 @@ function SearchPageInner({ community }: { community: Community }) {
     community.features.aiSummaries && Boolean(SUMMARISER_BASE);
   const aiContext = {
     terms: deriveSummaryTerms(params, vocab.labels),
-    count: results.results?.total.count ?? 0,
+    count: results.results?.total ?? { count: 0, is_lower_bound: false },
   };
 
   function handleGenerateSummary() {

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -5,7 +5,7 @@ import {
   parseSearchParams,
   toQueryString,
   buildSearchUrl,
-  toExportSearchQuery,
+  toUnpaginatedSearchQuery,
   type SortOption,
 } from "@/services/searchParams";
 import { navigate } from "@/services/navigation";
@@ -263,7 +263,7 @@ function SearchPageInner({ community }: { community: Community }) {
   const exportAnnouncement = exportAnnouncementFor(exportJob.status);
 
   function handleExport() {
-    const { query, filters } = toExportSearchQuery(
+    const { query, filters } = toUnpaginatedSearchQuery(
       params,
       community.defaultAnnotations,
     );
@@ -279,14 +279,12 @@ function SearchPageInner({ community }: { community: Community }) {
 
   // Context shown in the AI-summary drawer. The query stands in for the
   // intersecting terms until the evidence map deep-links explicit row/column
-  // labels here. Until an all-references source exists, a summary covers only
-  // the references on the current page, so the count reflects that rather than
-  // the full intersection total.
+  // labels here. The summary covers every matching reference (gathered by the
+  // hook from the ids endpoint), so the count is the full intersection total.
   const aiSummariesEnabled = community.features.aiSummaries;
-  const aiReferenceIds = results.results?.references.map((ref) => ref.id) ?? [];
   const aiContext = {
     terms: params.q !== "" && params.q !== "*" ? [params.q] : [],
-    count: aiReferenceIds.length,
+    count: results.results?.total.count ?? 0,
   };
 
   function handleGenerateSummary() {
@@ -294,9 +292,14 @@ function SearchPageInner({ community }: { community: Community }) {
       ai.open();
       return;
     }
+    const { query, filters } = toUnpaginatedSearchQuery(
+      params,
+      community.defaultAnnotations,
+    );
     ai.generate({
       terms: aiContext.terms.map((name) => ({ name })),
-      referenceIds: aiReferenceIds,
+      query,
+      filters,
     });
   }
 

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -28,6 +28,7 @@ import { AiSummaryButton } from "@/components/ai-summary/AiSummaryButton";
 import { AiSummaryDrawer } from "@/components/ai-summary/AiSummaryDrawer";
 import { AiSummaryMiniChip } from "@/components/ai-summary/AiSummaryMiniChip";
 import { useAiSummary } from "@/hooks/useAiSummary";
+import { deriveSummaryTerms } from "@/components/ai-summary/summaryTerms";
 import { totalSelectedCount } from "@/components/filters/conceptSchemeFilterState";
 import { totalSelectedCount as totalSelectedCountryCount } from "@/components/filters/countryFilterState";
 import { totalSelectedCount as totalSelectedYearCount } from "@/components/filters/yearRangeFilterState";
@@ -277,13 +278,15 @@ function SearchPageInner({ community }: { community: Community }) {
     });
   }
 
-  // Context shown in the AI-summary drawer. The query stands in for the
-  // intersecting terms until the evidence map deep-links explicit row/column
-  // labels here. The summary covers every matching reference (gathered by the
-  // hook from the ids endpoint), so the count is the full intersection total.
+  // Context shown in the AI-summary drawer and sent to the summariser as the
+  // terms to frame the summary around. A summary can be generated from any
+  // search, so the terms are the current free-text query plus any applied
+  // concept filters (a map cell arrives here with those filters pre-applied).
+  // The count is the full matching total — the hook summarises every reference
+  // the ids endpoint returns, not just the current page.
   const aiSummariesEnabled = community.features.aiSummaries;
   const aiContext = {
-    terms: params.q !== "" && params.q !== "*" ? [params.q] : [],
+    terms: deriveSummaryTerms(params, vocab.labels),
     count: results.results?.total.count ?? 0,
   };
 

--- a/src/pages/VisualisePage.tsx
+++ b/src/pages/VisualisePage.tsx
@@ -29,8 +29,8 @@ import type {
   Community,
   EvidenceMapAxes,
   EvidenceMapAxis,
-  SearchResultTotal,
 } from "@/types/models";
+import { formatTotal } from "@/utils/searchTotal";
 import { EvidenceMapGrid } from "@/components/visualise/EvidenceMapGrid";
 import { ViewToggle, type MapView } from "@/components/visualise/ViewToggle";
 import { MapConfigPanel } from "@/components/visualise/MapConfigPanel";
@@ -45,11 +45,6 @@ interface VisualisePageProps {
 
 const ROW_PARAM = "row";
 const COLUMN_PARAM = "column";
-
-// Mirrors SearchPage: render "10,000+" when ES caps the count (is_lower_bound).
-function formatTotal(total: SearchResultTotal): string {
-  return `${total.count.toLocaleString()}${total.is_lower_bound ? "+" : ""}`;
-}
 
 // Config axis → the shape the cross-facets client/hook expects.
 function toCrossFacetAxis(axis: EvidenceMapAxis): CrossFacetAxis {

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -3,6 +3,7 @@ import type {
   Reference,
   ReferenceCrossFacetResult,
   ReferenceFacetResult,
+  ReferenceIdSearchResult,
   SearchExportRead,
   SearchResult,
 } from "@/types/models";
@@ -73,6 +74,22 @@ export async function searchReferences(
   if (isPositiveSafeInt(filters.page)) params.set("page", String(filters.page));
   for (const s of filters.sort ?? []) params.append("sort", s);
   return api.get<SearchResult>(`/v1/references/search/?${params.toString()}`);
+}
+
+// All matching reference ids for a query, without pagination or reference data.
+// Accepts the same filters as searchReferences (minus page); the backend caps
+// the result at its result window and flags truncation via total.is_lower_bound.
+export async function searchReferenceIds(
+  query: string | undefined,
+  filters: Omit<SearchFilters, "page"> = {},
+  signal?: AbortSignal,
+): Promise<ReferenceIdSearchResult> {
+  const params = buildSharedSearchParams(query, filters);
+  for (const s of filters.sort ?? []) params.append("sort", s);
+  return api.get<ReferenceIdSearchResult>(
+    `/v1/references/search/ids/?${params.toString()}`,
+    signal,
+  );
 }
 
 export async function searchReferenceFacets(

--- a/src/services/communities.ts
+++ b/src/services/communities.ts
@@ -17,6 +17,7 @@ function requireEnv(name: string, value: string | undefined): string {
 
 export const DEFAULT_FEATURES: CommunityFeatures = {
   evidenceMap: false,
+  aiSummaries: false,
 };
 
 // Shared copy fallbacks; a community overrides only what diverges.
@@ -90,7 +91,7 @@ const COMMUNITIES: Community[] = [
       import.meta.env.VITE_HPV_CONTEXT_URL,
     ),
     filterExcludedSchemes: [],
-    features: { ...DEFAULT_FEATURES, evidenceMap: true },
+    features: { ...DEFAULT_FEATURES, evidenceMap: true, aiSummaries: true },
     copy: buildCopy("HPV Vaccine Delivery", {
       countNoun: "references",
       corpusDescriptor: "HPV vaccine delivery research",

--- a/src/services/searchParams.ts
+++ b/src/services/searchParams.ts
@@ -94,9 +94,10 @@ export function buildSearchUrl(communitySlug: string, params: SearchParams): str
 }
 
 // Maps a SearchParams + community annotations to the query/filters shape the
-// export endpoint expects. Substitutes "*" for an empty browse-mode query
-// so the backend's `min_length=1` constraint is satisfied.
-export function toExportSearchQuery(
+// whole-result-set endpoints expect (export, reference-id search) — i.e. minus
+// pagination. Substitutes "*" for an empty browse-mode query so the backend's
+// `min_length=1` constraint is satisfied.
+export function toUnpaginatedSearchQuery(
   params: SearchParams,
   annotations: string[] | undefined,
 ): { query: string; filters: Omit<SearchFilters, "page"> } {

--- a/src/services/summariser.ts
+++ b/src/services/summariser.ts
@@ -65,11 +65,22 @@ export interface ExtractionError {
   error: string;
 }
 
+/** Why a requested reference was dropped before summarisation. */
+export type SkipReason = "no_full_text" | "download_failed" | "not_pdf";
+
+export interface SkippedReference {
+  reference_id: string;
+  reason: SkipReason;
+}
+
 export interface SummariseResponse {
   kind: "summary";
   summary: SummaryBlock;
   papers: PaperMeta[];
+  /** Papers fetched but whose text couldn't be parsed. */
   extraction_errors: ExtractionError[];
+  /** References dropped before summarisation (no full text, non-PDF, or failed download). */
+  skipped_references: SkippedReference[];
   terms: TermInfo[];
 }
 

--- a/src/services/summariser.ts
+++ b/src/services/summariser.ts
@@ -1,0 +1,81 @@
+/**
+ * Types for the evidence-summariser service's summary payload.
+ *
+ * These mirror the `SummariseResponse` shape published by the summariser's
+ * FastAPI surface (see futureevidence/ai-evidence-summariser `http/models.py`),
+ * so the UI can render against the real response once the service is wired in.
+ */
+
+export interface TermInfo {
+  name: string;
+  description?: string | null;
+}
+
+/** A verbatim quote backing a claim, with provenance. */
+export interface QuoteRef {
+  quote: string;
+  /** Identifies the source paper; joins to `PaperMeta.paper`. */
+  paper: string;
+  page?: number | null;
+  /** 1-based indices into the run's `terms` list. */
+  terms: number[];
+}
+
+export interface Claim {
+  claim: string;
+  quotes: QuoteRef[];
+}
+
+export interface Contradiction {
+  contradiction: string;
+  quotes: QuoteRef[];
+}
+
+export interface NarrativeSentence {
+  text: string;
+  /** 1-based indices into `SummaryBlock.claims` this sentence draws from. */
+  claims: number[];
+}
+
+export interface NarrativeParagraph {
+  header: string;
+  sentences: NarrativeSentence[];
+}
+
+export interface SummaryBlock {
+  claims: Claim[];
+  contradictions: Contradiction[];
+  narrative: NarrativeParagraph[];
+}
+
+/** Provenance read off the source paper; `paper` is the join key for quotes. */
+export interface PaperMeta {
+  paper: string;
+  title?: string | null;
+  authors: string[];
+  affiliations: string[];
+  journal?: string | null;
+  publisher?: string | null;
+  doi?: string | null;
+  year?: number | null;
+}
+
+export interface ExtractionError {
+  paper: string;
+  error: string;
+}
+
+export interface SummariseResponse {
+  kind: "summary";
+  summary: SummaryBlock;
+  papers: PaperMeta[];
+  extraction_errors: ExtractionError[];
+  terms: TermInfo[];
+}
+
+export interface SummaryRequest {
+  /** Intersecting terms the summary is framed against. */
+  terms: TermInfo[];
+  /** Repository reference ids whose full texts feed the summary. */
+  referenceIds: string[];
+}

--- a/src/services/summariserClient.ts
+++ b/src/services/summariserClient.ts
@@ -1,13 +1,8 @@
 import { SUMMARISER_BASE } from "@/config";
 import { keycloak } from "@/auth/keycloak";
 import type { SummariseResponse, SummaryRequest } from "./summariser";
-import { MOCK_SUMMARY } from "./summariserMock";
 
 export type { SummariseResponse, SummaryRequest } from "./summariser";
-
-// Stand-in latency so the loading and run-in-background states are exercised
-// while the service returns placeholder data.
-const MOCK_DELAY_MS = 2500;
 
 // How often to poll a running job, and how long before giving up.
 const POLL_INTERVAL_MS = 5000;
@@ -33,17 +28,16 @@ function wait(ms: number, signal?: AbortSignal): Promise<void> {
 /**
  * Request a summary for the references at an intersection.
  *
- * Without `VITE_SUMMARISER_BASE` configured (the current default), this resolves
- * to placeholder data after a short delay. Once the service is deployed, set the
- * base URL to exercise the real submit-and-poll path below.
+ * Requires `VITE_SUMMARISER_BASE`; the UI only surfaces the feature when it's
+ * configured, so an unset base here is a programming error rather than a
+ * user-facing path.
  */
 export async function requestSummary(
   request: SummaryRequest,
   signal?: AbortSignal,
 ): Promise<SummariseResponse> {
   if (!SUMMARISER_BASE) {
-    await wait(MOCK_DELAY_MS, signal);
-    return MOCK_SUMMARY;
+    throw new Error("Summariser is not configured (VITE_SUMMARISER_BASE).");
   }
   return submitAndPoll(request, signal);
 }

--- a/src/services/summariserClient.ts
+++ b/src/services/summariserClient.ts
@@ -60,6 +60,7 @@ async function submitAndPoll(
     { method: "POST", body: JSON.stringify(request) },
     signal,
   );
+  if (!submit.ok) throw new Error(`Summary request failed (${submit.status}).`);
   const submitJson = await submit.json();
   if (submit.status === 200) return submitJson as SummariseResponse;
 
@@ -68,6 +69,7 @@ async function submitAndPoll(
   for (;;) {
     await wait(POLL_INTERVAL_MS, signal);
     const res = await summariserFetch(`/jobs/${jobId}`, {}, signal);
+    if (!res.ok) throw new Error(`Summary status check failed (${res.status}).`);
     const job = await res.json();
     if (job.status === "done") return job.result as SummariseResponse;
     if (job.status === "failed") throw new Error(job.error || "Summary failed.");

--- a/src/services/summariserClient.ts
+++ b/src/services/summariserClient.ts
@@ -17,12 +17,31 @@ class AbortError extends DOMException {
 function wait(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
     if (signal?.aborted) return reject(new AbortError());
-    const id = setTimeout(resolve, ms);
-    signal?.addEventListener("abort", () => {
+    let id: ReturnType<typeof setTimeout>;
+    const onAbort = () => {
       clearTimeout(id);
       reject(new AbortError());
-    });
+    };
+    id = setTimeout(() => {
+      // Drop the listener once the wait resolves, so a long poll loop doesn't
+      // accumulate one per interval on the shared signal.
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
   });
+}
+
+// Surface the service's error `detail` (a string, or a {error|message} object)
+// so the UI's error state is specific rather than a bare status code.
+async function summaryError(res: Response, fallback: string): Promise<Error> {
+  const body = await res.json().catch(() => null);
+  const detail = body?.detail;
+  const message =
+    typeof detail === "string" ? detail : (detail?.message ?? detail?.error);
+  return new Error(
+    message ? `${fallback} (${res.status}): ${message}` : `${fallback} (${res.status}).`,
+  );
 }
 
 /**
@@ -69,17 +88,19 @@ async function submitAndPoll(
     },
     signal,
   );
-  if (!submit.ok) throw new Error(`Summary request failed (${submit.status}).`);
+  if (!submit.ok) throw await summaryError(submit, "Summary request failed");
   const submitJson = await submit.json();
   if (submit.status === 200) return submitJson as SummariseResponse;
 
-  const jobId: string = submitJson.job_id;
+  const jobId = submitJson.job_id;
+  if (typeof jobId !== "string") {
+    throw new Error("Summary job response is missing a job_id.");
+  }
   const deadline = Date.now() + POLL_TIMEOUT_MS;
   for (;;) {
     await wait(POLL_INTERVAL_MS, signal);
     const res = await summariserFetch(`/jobs/${jobId}`, {}, signal);
-    if (!res.ok)
-      throw new Error(`Summary status check failed (${res.status}).`);
+    if (!res.ok) throw await summaryError(res, "Summary status check failed");
     const job = await res.json();
     if (job.status === "done") return job.result as SummariseResponse;
     if (job.status === "failed")
@@ -93,6 +114,9 @@ async function summariserFetch(
   init: RequestInit,
   signal?: AbortSignal,
 ): Promise<Response> {
+  // A failed refresh proceeds with the current token rather than throwing (as
+  // api/client does): a stale/expired token just yields a 401, which surfaces
+  // as the drawer's error state instead of an unhandled rejection.
   await keycloak.updateToken(30).catch(() => undefined);
   // Attaches the bearer token; callers set Content-Type when they send a body.
   return fetch(`${SUMMARISER_BASE}${path}`, {

--- a/src/services/summariserClient.ts
+++ b/src/services/summariserClient.ts
@@ -48,16 +48,31 @@ export async function requestSummary(
   return submitAndPoll(request, signal);
 }
 
-// Provisional: the reference-id request contract is finalised in
-// futureevidence/ai-evidence-summariser#1. Guarded by SUMMARISER_BASE so it
-// stays inert until the service is live.
+// POST /summarise takes form fields — repeated `reference_ids` and `terms`
+// (each "name" or "name:description") — and returns either a cached result (200)
+// or a job to poll (202).
 async function submitAndPoll(
   request: SummaryRequest,
   signal?: AbortSignal,
 ): Promise<SummariseResponse> {
+  // The endpoint reads FastAPI Form fields; URLSearchParams form-encodes them,
+  // with repeated keys mapping to list fields.
+  const body = new URLSearchParams();
+  for (const id of request.referenceIds) body.append("reference_ids", id);
+  for (const term of request.terms) {
+    body.append(
+      "terms",
+      term.description ? `${term.name}:${term.description}` : term.name,
+    );
+  }
+
   const submit = await summariserFetch(
     "/summarise",
-    { method: "POST", body: JSON.stringify(request) },
+    {
+      method: "POST",
+      body,
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    },
     signal,
   );
   if (!submit.ok) throw new Error(`Summary request failed (${submit.status}).`);
@@ -69,10 +84,12 @@ async function submitAndPoll(
   for (;;) {
     await wait(POLL_INTERVAL_MS, signal);
     const res = await summariserFetch(`/jobs/${jobId}`, {}, signal);
-    if (!res.ok) throw new Error(`Summary status check failed (${res.status}).`);
+    if (!res.ok)
+      throw new Error(`Summary status check failed (${res.status}).`);
     const job = await res.json();
     if (job.status === "done") return job.result as SummariseResponse;
-    if (job.status === "failed") throw new Error(job.error || "Summary failed.");
+    if (job.status === "failed")
+      throw new Error(job.error || "Summary failed.");
     if (Date.now() > deadline) throw new Error("Summary timed out.");
   }
 }
@@ -83,11 +100,11 @@ async function summariserFetch(
   signal?: AbortSignal,
 ): Promise<Response> {
   await keycloak.updateToken(30).catch(() => undefined);
+  // Attaches the bearer token; callers set Content-Type when they send a body.
   return fetch(`${SUMMARISER_BASE}${path}`, {
     ...init,
     signal,
     headers: {
-      "Content-Type": "application/json",
       ...(keycloak.token ? { Authorization: `Bearer ${keycloak.token}` } : {}),
       ...init.headers,
     },

--- a/src/services/summariserClient.ts
+++ b/src/services/summariserClient.ts
@@ -1,0 +1,93 @@
+import { SUMMARISER_BASE } from "@/config";
+import { keycloak } from "@/auth/keycloak";
+import type { SummariseResponse, SummaryRequest } from "./summariser";
+import { MOCK_SUMMARY } from "./summariserMock";
+
+export type { SummariseResponse, SummaryRequest } from "./summariser";
+
+// Stand-in latency so the loading and run-in-background states are exercised
+// while the service returns placeholder data.
+const MOCK_DELAY_MS = 2500;
+
+// How often to poll a running job, and how long before giving up.
+const POLL_INTERVAL_MS = 5000;
+const POLL_TIMEOUT_MS = 20 * 60 * 1000;
+
+class AbortError extends DOMException {
+  constructor() {
+    super("Aborted", "AbortError");
+  }
+}
+
+function wait(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) return reject(new AbortError());
+    const id = setTimeout(resolve, ms);
+    signal?.addEventListener("abort", () => {
+      clearTimeout(id);
+      reject(new AbortError());
+    });
+  });
+}
+
+/**
+ * Request a summary for the references at an intersection.
+ *
+ * Without `VITE_SUMMARISER_BASE` configured (the current default), this resolves
+ * to placeholder data after a short delay. Once the service is deployed, set the
+ * base URL to exercise the real submit-and-poll path below.
+ */
+export async function requestSummary(
+  request: SummaryRequest,
+  signal?: AbortSignal,
+): Promise<SummariseResponse> {
+  if (!SUMMARISER_BASE) {
+    await wait(MOCK_DELAY_MS, signal);
+    return MOCK_SUMMARY;
+  }
+  return submitAndPoll(request, signal);
+}
+
+// Provisional: the reference-id request contract is finalised in
+// futureevidence/ai-evidence-summariser#1. Guarded by SUMMARISER_BASE so it
+// stays inert until the service is live.
+async function submitAndPoll(
+  request: SummaryRequest,
+  signal?: AbortSignal,
+): Promise<SummariseResponse> {
+  const submit = await summariserFetch(
+    "/summarise",
+    { method: "POST", body: JSON.stringify(request) },
+    signal,
+  );
+  const submitJson = await submit.json();
+  if (submit.status === 200) return submitJson as SummariseResponse;
+
+  const jobId: string = submitJson.job_id;
+  const deadline = Date.now() + POLL_TIMEOUT_MS;
+  for (;;) {
+    await wait(POLL_INTERVAL_MS, signal);
+    const res = await summariserFetch(`/jobs/${jobId}`, {}, signal);
+    const job = await res.json();
+    if (job.status === "done") return job.result as SummariseResponse;
+    if (job.status === "failed") throw new Error(job.error || "Summary failed.");
+    if (Date.now() > deadline) throw new Error("Summary timed out.");
+  }
+}
+
+async function summariserFetch(
+  path: string,
+  init: RequestInit,
+  signal?: AbortSignal,
+): Promise<Response> {
+  await keycloak.updateToken(30).catch(() => undefined);
+  return fetch(`${SUMMARISER_BASE}${path}`, {
+    ...init,
+    signal,
+    headers: {
+      "Content-Type": "application/json",
+      ...(keycloak.token ? { Authorization: `Bearer ${keycloak.token}` } : {}),
+      ...init.headers,
+    },
+  });
+}

--- a/src/services/summariserMock.ts
+++ b/src/services/summariserMock.ts
@@ -1,0 +1,141 @@
+import type { SummariseResponse } from "./summariser";
+
+/**
+ * Placeholder summary returned while the summariser service is unavailable.
+ * Shaped like a real `SummariseResponse` so the UI renders authentically; the
+ * narrative sentences carry the 1-based claim indices that become footnotes.
+ */
+export const MOCK_SUMMARY: SummariseResponse = {
+  kind: "summary",
+  terms: [{ name: "Afghanistan" }, { name: "Cost-effectiveness" }],
+  extraction_errors: [],
+  papers: [
+    {
+      paper: "anwari-2019",
+      authors: ["Anwari Palwasha"],
+      affiliations: [],
+      year: 2019,
+      doi: "10.1016/vaccine.2019.4153",
+    },
+    {
+      paper: "canfell-2020",
+      authors: ["Canfell Karen"],
+      affiliations: [],
+      year: 2020,
+      doi: "10.1016/lancet.2020.0591",
+    },
+    {
+      paper: "abbas-2024",
+      authors: ["Abbas Kaja"],
+      affiliations: [],
+      year: 2024,
+      doi: "10.1016/langlo.2024.1342",
+    },
+    {
+      paper: "abbas-2018",
+      authors: ["Abbas Kaja"],
+      affiliations: [],
+      year: 2018,
+      doi: "10.1002/ijc.2018.1290",
+    },
+    {
+      paper: "brisson-2021",
+      authors: ["Brisson Marc"],
+      affiliations: [],
+      year: 2021,
+      doi: "10.1016/lanpub.2021.0398",
+    },
+  ],
+  summary: {
+    contradictions: [],
+    claims: [
+      {
+        claim:
+          "Bivalent HPV vaccination is highly cost-effective at all assessed coverage levels.",
+        quotes: [
+          {
+            quote:
+              "Bivalent HPV vaccination delivered through the national immunisation programme was highly cost-effective at all coverage levels assessed.",
+            paper: "anwari-2019",
+            terms: [1, 2],
+          },
+        ],
+      },
+      {
+        claim:
+          "Incremental cost per DALY averted stays below one times GDP per capita in every scenario.",
+        quotes: [
+          {
+            quote:
+              "Across every modelled scenario the incremental cost per DALY averted remained below one times GDP per capita.",
+            paper: "canfell-2020",
+            terms: [2],
+          },
+        ],
+      },
+      {
+        claim:
+          "Equity and health gains are greatest in the lowest income cohorts.",
+        quotes: [
+          {
+            quote:
+              "Equity impact was greatest among the lowest income quintiles, where baseline cervical-cancer burden was highest.",
+            paper: "abbas-2024",
+            terms: [1],
+          },
+        ],
+      },
+      {
+        claim:
+          "A single 9–14 cohort averts most lifetime cases; catch-up adds more at modest cost.",
+        quotes: [
+          {
+            quote:
+              "Vaccinating a single cohort of 9–14-year-old girls averted the majority of projected lifetime cervical-cancer cases; multi-cohort catch-up added further cases averted at modest additional cost.",
+            paper: "abbas-2018",
+            terms: [1, 2],
+          },
+        ],
+      },
+      {
+        claim:
+          "Estimates derive from modelling calibrated to local prevalence, not empirical trials.",
+        quotes: [
+          {
+            quote:
+              "Estimates derive from a transmission-dynamic model calibrated to local HPV prevalence rather than from empirical trial data.",
+            paper: "brisson-2021",
+            terms: [2],
+          },
+        ],
+      },
+    ],
+    narrative: [
+      {
+        header: "Cost-effectiveness in Afghanistan",
+        sentences: [
+          {
+            text: "Across the results at this intersection, bivalent HPV vaccination in Afghanistan is consistently found to be highly cost-effective at national coverage levels.",
+            claims: [1],
+          },
+          {
+            text: "Modelled programmes remain below the WHO cost-effectiveness threshold of one times GDP per capita across every scenario tested.",
+            claims: [2],
+          },
+          {
+            text: "The largest health and equity gains accrue to lower-income cohorts, where baseline cervical-cancer burden is highest.",
+            claims: [3],
+          },
+          {
+            text: "Vaccinating a single cohort of 9–14-year-old girls is projected to avert the majority of lifetime cervical-cancer cases, with multi-cohort catch-up adding further benefit at modest incremental cost.",
+            claims: [4],
+          },
+          {
+            text: "The evidence is consistent in direction but is drawn almost entirely from mathematical modelling calibrated to regional HPV prevalence rather than from in-country trials, so absolute figures should be read as projections rather than observed outcomes.",
+            claims: [5],
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/src/services/summariserMock.ts
+++ b/src/services/summariserMock.ts
@@ -9,6 +9,9 @@ export const MOCK_SUMMARY: SummariseResponse = {
   kind: "summary",
   terms: [{ name: "Afghanistan" }, { name: "Cost-effectiveness" }],
   extraction_errors: [],
+  skipped_references: [
+    { reference_id: "0196b1a0-0000-7000-8000-000000000099", reason: "no_full_text" },
+  ],
   papers: [
     {
       paper: "anwari-2019",

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -1,6 +1,8 @@
 export interface CommunityFeatures {
   // No UI yet; reserved so the evidence map can ship behind a flag (#103).
   evidenceMap: boolean;
+  // Gates the "Generate AI summary" entry point and its drawer.
+  aiSummaries: boolean;
 }
 
 // One axis of the evidence map.

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -75,6 +75,13 @@ export interface SearchResult {
   references: Reference[];
 }
 
+// Matching reference ids for a search, in result order, capped at the backend's
+// result window (`total.is_lower_bound` flags truncation).
+export interface ReferenceIdSearchResult {
+  total: SearchResultTotal;
+  reference_ids: string[];
+}
+
 export interface ConceptFacetCount {
   concept: string;
   count: number;

--- a/src/utils/searchTotal.ts
+++ b/src/utils/searchTotal.ts
@@ -1,0 +1,8 @@
+import type { SearchResultTotal } from "@/types/models";
+
+// ES caps deep pagination at 10k; when the true count exceeds that, the backend
+// returns is_lower_bound=true and count=10000. Render "10,000+" so the UI
+// doesn't understate the size.
+export function formatTotal(total: SearchResultTotal): string {
+  return `${total.count.toLocaleString()}${total.is_lower_bound ? "+" : ""}`;
+}

--- a/tests/components/ai-summary/AiSummaryButton.test.tsx
+++ b/tests/components/ai-summary/AiSummaryButton.test.tsx
@@ -7,16 +7,16 @@ afterEach(cleanup);
 describe("AiSummaryButton", () => {
   test("is enabled and clickable by default", () => {
     const onClick = vi.fn();
-    render(<AiSummaryButton onClick={onClick} />);
+    const { container } = render(<AiSummaryButton onClick={onClick} />);
     const button = screen.getByRole("button", { name: /generate ai summary/i });
     expect((button as HTMLButtonElement).disabled).toBe(false);
-    expect(button.getAttribute("title")).toBeNull();
+    expect(container.querySelector("[data-tooltip]")).toBeNull();
     fireEvent.click(button);
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
-  test("disables and surfaces the reason as a tooltip", () => {
-    render(
+  test("disables and surfaces the reason via the shared Tooltip", () => {
+    const { container } = render(
       <AiSummaryButton
         onClick={vi.fn()}
         disabled
@@ -25,6 +25,8 @@ describe("AiSummaryButton", () => {
     );
     const button = screen.getByRole("button", { name: /generate ai summary/i });
     expect((button as HTMLButtonElement).disabled).toBe(true);
-    expect(button.getAttribute("title")).toMatch(/up to 50 references/i);
+    expect(
+      container.querySelector("[data-tooltip]")?.getAttribute("data-tooltip"),
+    ).toMatch(/up to 50 references/i);
   });
 });

--- a/tests/components/ai-summary/AiSummaryButton.test.tsx
+++ b/tests/components/ai-summary/AiSummaryButton.test.tsx
@@ -1,0 +1,30 @@
+import { describe, test, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/preact";
+import { AiSummaryButton } from "@/components/ai-summary/AiSummaryButton";
+
+afterEach(cleanup);
+
+describe("AiSummaryButton", () => {
+  test("is enabled and clickable by default", () => {
+    const onClick = vi.fn();
+    render(<AiSummaryButton onClick={onClick} />);
+    const button = screen.getByRole("button", { name: /generate ai summary/i });
+    expect((button as HTMLButtonElement).disabled).toBe(false);
+    expect(button.getAttribute("title")).toBeNull();
+    fireEvent.click(button);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test("disables and surfaces the reason as a tooltip", () => {
+    render(
+      <AiSummaryButton
+        onClick={vi.fn()}
+        disabled
+        disabledReason="AI summaries cover up to 50 references — refine your search."
+      />,
+    );
+    const button = screen.getByRole("button", { name: /generate ai summary/i });
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+    expect(button.getAttribute("title")).toMatch(/up to 50 references/i);
+  });
+});

--- a/tests/components/ai-summary/AiSummaryDrawer.test.tsx
+++ b/tests/components/ai-summary/AiSummaryDrawer.test.tsx
@@ -83,6 +83,17 @@ describe("AiSummaryDrawer", () => {
     expect(link.getAttribute("target")).toBe("_blank");
   });
 
+  test("does not offer the flag link in the error state", () => {
+    render(
+      <AiSummaryDrawer
+        ai={makeAi({ status: "error", result: null, errorMessage: "boom" })}
+        context={context}
+      />,
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent("boom");
+    expect(screen.queryByRole("link", { name: /flag this summary/i })).toBeNull();
+  });
+
   test("shows a loading state with Cancel and Run in background while generating", () => {
     render(
       <AiSummaryDrawer ai={makeAi({ status: "generating", result: null })} context={context} />,

--- a/tests/components/ai-summary/AiSummaryDrawer.test.tsx
+++ b/tests/components/ai-summary/AiSummaryDrawer.test.tsx
@@ -65,6 +65,17 @@ describe("AiSummaryDrawer", () => {
     expect(claim?.classList.contains("is-flash")).toBe(true);
   });
 
+  test("surfaces a note when some papers couldn't be read", () => {
+    const ai = makeAi({
+      result: {
+        ...MOCK_SUMMARY,
+        extraction_errors: [{ paper: "x", error: "unreadable" }],
+      },
+    });
+    render(<AiSummaryDrawer ai={ai} context={context} />);
+    expect(screen.getByText(/1 paper couldn't be read/i)).toBeDefined();
+  });
+
   test("flag link points at the configured form and opens in a new tab", () => {
     render(<AiSummaryDrawer ai={makeAi()} context={context} />);
     const link = screen.getByRole("link", { name: /flag this summary/i });

--- a/tests/components/ai-summary/AiSummaryDrawer.test.tsx
+++ b/tests/components/ai-summary/AiSummaryDrawer.test.tsx
@@ -68,15 +68,31 @@ describe("AiSummaryDrawer", () => {
     expect(claim?.classList.contains("is-flash")).toBe(true);
   });
 
-  test("surfaces a note when some papers couldn't be read", () => {
+  test("coverage note reports usable references and lists those left out", () => {
     const ai = makeAi({
       result: {
         ...MOCK_SUMMARY,
+        papers: MOCK_SUMMARY.papers, // 5 summarised
+        skipped_references: [
+          { reference_id: "r1", reason: "no_full_text" },
+          { reference_id: "r2", reason: "no_full_text" },
+        ],
         extraction_errors: [{ paper: "x", error: "unreadable" }],
       },
     });
     render(<AiSummaryDrawer ai={ai} context={context} />);
-    expect(screen.getByText(/1 paper couldn't be read/i)).toBeDefined();
+    // 5 summarised + 2 no-full-text + 1 unreadable = 8 total.
+    const note = screen.getByText(/Based on 5 of 8 references/i);
+    expect(note.textContent).toMatch(/2 had no full text available/i);
+    expect(note.textContent).toMatch(/1 couldn't be read/i);
+  });
+
+  test("coverage note reads cleanly at full coverage", () => {
+    const ai = makeAi({
+      result: { ...MOCK_SUMMARY, skipped_references: [], extraction_errors: [] },
+    });
+    render(<AiSummaryDrawer ai={ai} context={context} />);
+    expect(screen.getByText(/Based on 5 references\./i)).toBeDefined();
   });
 
   test("flag link points at the configured form and opens in a new tab", () => {

--- a/tests/components/ai-summary/AiSummaryDrawer.test.tsx
+++ b/tests/components/ai-summary/AiSummaryDrawer.test.tsx
@@ -98,4 +98,28 @@ describe("AiSummaryDrawer", () => {
     fireEvent.click(screen.getByRole("button", { name: "Run in background" }));
     expect(ai.runInBackground).toHaveBeenCalledTimes(1);
   });
+
+  test("closing while generating backgrounds the job rather than aborting it", () => {
+    const ai = makeAi({ status: "generating", result: null });
+    render(<AiSummaryDrawer ai={ai} context={context} />);
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(ai.runInBackground).toHaveBeenCalledTimes(1);
+    expect(ai.dismiss).not.toHaveBeenCalled();
+  });
+
+  test("explicit Cancel while generating aborts the job", () => {
+    const ai = makeAi({ status: "generating", result: null });
+    render(<AiSummaryDrawer ai={ai} context={context} />);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(ai.dismiss).toHaveBeenCalledTimes(1);
+    expect(ai.runInBackground).not.toHaveBeenCalled();
+  });
+
+  test("closing a finished summary dismisses it", () => {
+    const ai = makeAi();
+    render(<AiSummaryDrawer ai={ai} context={context} />);
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(ai.dismiss).toHaveBeenCalledTimes(1);
+    expect(ai.runInBackground).not.toHaveBeenCalled();
+  });
 });

--- a/tests/components/ai-summary/AiSummaryDrawer.test.tsx
+++ b/tests/components/ai-summary/AiSummaryDrawer.test.tsx
@@ -9,12 +9,19 @@ import { AiSummaryDrawer } from "@/components/ai-summary/AiSummaryDrawer";
 import type { UseAiSummaryResult } from "@/hooks/useAiSummary";
 import { MOCK_SUMMARY } from "@/services/summariserMock";
 
+const context = {
+  terms: ["Afghanistan", "Cost-effectiveness"],
+  count: { count: 15, is_lower_bound: false },
+  countNoun: "references",
+};
+
 function makeAi(overrides: Partial<UseAiSummaryResult> = {}): UseAiSummaryResult {
   return {
     status: "done",
     minimized: false,
     result: MOCK_SUMMARY,
     errorMessage: null,
+    context,
     drawerOpen: true,
     generate: vi.fn(),
     open: vi.fn(),
@@ -23,11 +30,6 @@ function makeAi(overrides: Partial<UseAiSummaryResult> = {}): UseAiSummaryResult
     ...overrides,
   };
 }
-
-const context = {
-  terms: ["Afghanistan", "Cost-effectiveness"],
-  count: { count: 15, is_lower_bound: false },
-};
 
 beforeEach(() => {
   // jsdom doesn't implement scrollIntoView.
@@ -38,17 +40,17 @@ beforeEach(() => {
 describe("AiSummaryDrawer", () => {
   test("is not rendered when the drawer is closed", () => {
     const { container } = render(
-      <AiSummaryDrawer ai={makeAi({ drawerOpen: false })} context={context} />,
+      <AiSummaryDrawer ai={makeAi({ drawerOpen: false })} />,
     );
     expect(container.firstChild).toBeNull();
   });
 
   test("renders the result: prose, context chips, and claims", () => {
-    render(<AiSummaryDrawer ai={makeAi()} context={context} />);
+    render(<AiSummaryDrawer ai={makeAi()} />);
 
     expect(screen.getByText(/highly cost-effective at national coverage/i)).toBeDefined();
     expect(screen.getByText("Afghanistan")).toBeDefined();
-    expect(screen.getByText("15 results")).toBeDefined();
+    expect(screen.getByText("15 references")).toBeDefined();
     // One numbered claim per claim in the summary.
     expect(document.querySelectorAll(".ai-claim").length).toBe(
       MOCK_SUMMARY.summary.claims.length,
@@ -57,7 +59,7 @@ describe("AiSummaryDrawer", () => {
 
   test("clicking a footnote scrolls to and flashes its claim", () => {
     const { container } = render(
-      <AiSummaryDrawer ai={makeAi()} context={context} />,
+      <AiSummaryDrawer ai={makeAi()} />,
     );
     const firstFootnote = container.querySelector(".ai-fn") as HTMLElement;
     fireEvent.click(firstFootnote);
@@ -80,7 +82,7 @@ describe("AiSummaryDrawer", () => {
         extraction_errors: [{ paper: "x", error: "unreadable" }],
       },
     });
-    render(<AiSummaryDrawer ai={ai} context={context} />);
+    render(<AiSummaryDrawer ai={ai} />);
     // 5 summarised + 2 no-full-text + 1 unreadable = 8 total.
     const note = screen.getByText(/Based on 5 of 8 references/i);
     expect(note.textContent).toMatch(/2 had no full text available/i);
@@ -91,12 +93,12 @@ describe("AiSummaryDrawer", () => {
     const ai = makeAi({
       result: { ...MOCK_SUMMARY, skipped_references: [], extraction_errors: [] },
     });
-    render(<AiSummaryDrawer ai={ai} context={context} />);
+    render(<AiSummaryDrawer ai={ai} />);
     expect(screen.getByText(/Based on 5 references\./i)).toBeDefined();
   });
 
   test("flag link points at the configured form and opens in a new tab", () => {
-    render(<AiSummaryDrawer ai={makeAi()} context={context} />);
+    render(<AiSummaryDrawer ai={makeAi()} />);
     const link = screen.getByRole("link", { name: /flag this summary/i });
     expect(link.getAttribute("href")).toBe("https://forms.example/flag");
     expect(link.getAttribute("target")).toBe("_blank");
@@ -106,7 +108,7 @@ describe("AiSummaryDrawer", () => {
     render(
       <AiSummaryDrawer
         ai={makeAi({ status: "error", result: null, errorMessage: "boom" })}
-        context={context}
+       
       />,
     );
     expect(screen.getByRole("alert")).toHaveTextContent("boom");
@@ -115,23 +117,23 @@ describe("AiSummaryDrawer", () => {
 
   test("shows a loading state with Cancel and Run in background while generating", () => {
     render(
-      <AiSummaryDrawer ai={makeAi({ status: "generating", result: null })} context={context} />,
+      <AiSummaryDrawer ai={makeAi({ status: "generating", result: null })} />,
     );
-    expect(screen.getByText(/summarising 15 papers/i)).toBeDefined();
+    expect(screen.getByText(/summarising 15 references/i)).toBeDefined();
     expect(screen.getByRole("button", { name: "Cancel" })).toBeDefined();
     expect(screen.getByRole("button", { name: "Run in background" })).toBeDefined();
   });
 
   test("Run in background invokes the hook action", () => {
     const ai = makeAi({ status: "generating", result: null });
-    render(<AiSummaryDrawer ai={ai} context={context} />);
+    render(<AiSummaryDrawer ai={ai} />);
     fireEvent.click(screen.getByRole("button", { name: "Run in background" }));
     expect(ai.runInBackground).toHaveBeenCalledTimes(1);
   });
 
   test("closing while generating backgrounds the job rather than aborting it", () => {
     const ai = makeAi({ status: "generating", result: null });
-    render(<AiSummaryDrawer ai={ai} context={context} />);
+    render(<AiSummaryDrawer ai={ai} />);
     fireEvent.click(screen.getByRole("button", { name: "Close" }));
     expect(ai.runInBackground).toHaveBeenCalledTimes(1);
     expect(ai.dismiss).not.toHaveBeenCalled();
@@ -139,7 +141,7 @@ describe("AiSummaryDrawer", () => {
 
   test("explicit Cancel while generating aborts the job", () => {
     const ai = makeAi({ status: "generating", result: null });
-    render(<AiSummaryDrawer ai={ai} context={context} />);
+    render(<AiSummaryDrawer ai={ai} />);
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(ai.dismiss).toHaveBeenCalledTimes(1);
     expect(ai.runInBackground).not.toHaveBeenCalled();
@@ -147,7 +149,7 @@ describe("AiSummaryDrawer", () => {
 
   test("closing a finished summary dismisses it", () => {
     const ai = makeAi();
-    render(<AiSummaryDrawer ai={ai} context={context} />);
+    render(<AiSummaryDrawer ai={ai} />);
     fireEvent.click(screen.getByRole("button", { name: "Close" }));
     expect(ai.dismiss).toHaveBeenCalledTimes(1);
     expect(ai.runInBackground).not.toHaveBeenCalled();

--- a/tests/components/ai-summary/AiSummaryDrawer.test.tsx
+++ b/tests/components/ai-summary/AiSummaryDrawer.test.tsx
@@ -1,0 +1,90 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/preact";
+
+vi.mock("@/config", () => ({
+  AI_SUMMARY_FLAG_FORM_URL: "https://forms.example/flag",
+}));
+
+import { AiSummaryDrawer } from "@/components/ai-summary/AiSummaryDrawer";
+import type { UseAiSummaryResult } from "@/hooks/useAiSummary";
+import { MOCK_SUMMARY } from "@/services/summariserMock";
+
+function makeAi(overrides: Partial<UseAiSummaryResult> = {}): UseAiSummaryResult {
+  return {
+    status: "done",
+    minimized: false,
+    result: MOCK_SUMMARY,
+    errorMessage: null,
+    drawerOpen: true,
+    generate: vi.fn(),
+    open: vi.fn(),
+    runInBackground: vi.fn(),
+    dismiss: vi.fn(),
+    ...overrides,
+  };
+}
+
+const context = { terms: ["Afghanistan", "Cost-effectiveness"], count: 15 };
+
+beforeEach(() => {
+  // jsdom doesn't implement scrollIntoView.
+  Element.prototype.scrollIntoView = vi.fn();
+  cleanup();
+});
+
+describe("AiSummaryDrawer", () => {
+  test("is not rendered when the drawer is closed", () => {
+    const { container } = render(
+      <AiSummaryDrawer ai={makeAi({ drawerOpen: false })} context={context} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("renders the result: prose, context chips, and claims", () => {
+    render(<AiSummaryDrawer ai={makeAi()} context={context} />);
+
+    expect(screen.getByText(/highly cost-effective at national coverage/i)).toBeDefined();
+    expect(screen.getByText("Afghanistan")).toBeDefined();
+    expect(screen.getByText("15 results")).toBeDefined();
+    // One numbered claim per claim in the summary.
+    expect(document.querySelectorAll(".ai-claim").length).toBe(
+      MOCK_SUMMARY.summary.claims.length,
+    );
+  });
+
+  test("clicking a footnote scrolls to and flashes its claim", () => {
+    const { container } = render(
+      <AiSummaryDrawer ai={makeAi()} context={context} />,
+    );
+    const firstFootnote = container.querySelector(".ai-fn") as HTMLElement;
+    fireEvent.click(firstFootnote);
+
+    const claim = document.getElementById("aiClaim-1");
+    expect(claim).not.toBeNull();
+    expect((claim as HTMLElement).scrollIntoView).toHaveBeenCalled();
+    expect(claim?.classList.contains("is-flash")).toBe(true);
+  });
+
+  test("flag link points at the configured form and opens in a new tab", () => {
+    render(<AiSummaryDrawer ai={makeAi()} context={context} />);
+    const link = screen.getByRole("link", { name: /flag this summary/i });
+    expect(link.getAttribute("href")).toBe("https://forms.example/flag");
+    expect(link.getAttribute("target")).toBe("_blank");
+  });
+
+  test("shows a loading state with Cancel and Run in background while generating", () => {
+    render(
+      <AiSummaryDrawer ai={makeAi({ status: "generating", result: null })} context={context} />,
+    );
+    expect(screen.getByText(/summarising 15 papers/i)).toBeDefined();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Run in background" })).toBeDefined();
+  });
+
+  test("Run in background invokes the hook action", () => {
+    const ai = makeAi({ status: "generating", result: null });
+    render(<AiSummaryDrawer ai={ai} context={context} />);
+    fireEvent.click(screen.getByRole("button", { name: "Run in background" }));
+    expect(ai.runInBackground).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/components/ai-summary/AiSummaryDrawer.test.tsx
+++ b/tests/components/ai-summary/AiSummaryDrawer.test.tsx
@@ -24,7 +24,10 @@ function makeAi(overrides: Partial<UseAiSummaryResult> = {}): UseAiSummaryResult
   };
 }
 
-const context = { terms: ["Afghanistan", "Cost-effectiveness"], count: 15 };
+const context = {
+  terms: ["Afghanistan", "Cost-effectiveness"],
+  count: { count: 15, is_lower_bound: false },
+};
 
 beforeEach(() => {
   // jsdom doesn't implement scrollIntoView.

--- a/tests/components/ai-summary/summaryTerms.test.ts
+++ b/tests/components/ai-summary/summaryTerms.test.ts
@@ -1,0 +1,58 @@
+import { describe, test, expect } from "vitest";
+import { deriveSummaryTerms } from "@/components/ai-summary/summaryTerms";
+import { makeSearchParams } from "../../fixtures";
+
+const labels = new Map([
+  ["ex:cost", "Cost-effectiveness"],
+  ["ex:access", "Access to Education"],
+]);
+
+describe("deriveSummaryTerms", () => {
+  test("uses the free-text query when present", () => {
+    const params = makeSearchParams({ q: "phonics" });
+    expect(deriveSummaryTerms(params, labels)).toEqual(["phonics"]);
+  });
+
+  test("resolves concept-filter labels (the map-cell case, q='*')", () => {
+    const params = makeSearchParams({
+      q: "*",
+      conceptFilters: [["ex:cost"], ["ex:access"]],
+    });
+    expect(deriveSummaryTerms(params, labels)).toEqual([
+      "Cost-effectiveness",
+      "Access to Education",
+    ]);
+  });
+
+  test("combines query and concept labels", () => {
+    const params = makeSearchParams({
+      q: "afghanistan",
+      conceptFilters: [["ex:cost"]],
+    });
+    expect(deriveSummaryTerms(params, labels)).toEqual([
+      "afghanistan",
+      "Cost-effectiveness",
+    ]);
+  });
+
+  test("excludes country and year constraints from terms", () => {
+    const params = makeSearchParams({
+      q: "phonics",
+      countryCodes: ["BD", "BJ"],
+      startYear: 2015,
+      endYear: 2020,
+    });
+    expect(deriveSummaryTerms(params, labels)).toEqual(["phonics"]);
+  });
+
+  test("falls back to the URI when a label is unknown", () => {
+    const params = makeSearchParams({ q: "*", conceptFilters: [["ex:missing"]] });
+    expect(deriveSummaryTerms(params, labels)).toEqual(["ex:missing"]);
+    expect(deriveSummaryTerms(params, null)).toEqual(["ex:missing"]);
+  });
+
+  test("is empty for a bare browse-mode search", () => {
+    expect(deriveSummaryTerms(makeSearchParams({ q: "*" }), labels)).toEqual([]);
+    expect(deriveSummaryTerms(makeSearchParams({ q: "" }), labels)).toEqual([]);
+  });
+});

--- a/tests/components/filters/FilterDrawer.test.tsx
+++ b/tests/components/filters/FilterDrawer.test.tsx
@@ -116,17 +116,17 @@ describe("FilterDrawer", () => {
     });
     // Bind on the class and the query value, not the surrounding wording —
     // the prose around the query is expected to iterate.
-    const subtitle = container.querySelector(".filter-drawer__subtitle");
+    const subtitle = container.querySelector(".drawer__subtitle");
     expect(subtitle).not.toBeNull();
     expect(subtitle?.textContent).toContain("phonics");
   });
 
   test("hides the subtitle nudge in browse mode (empty q or '*')", () => {
     const { rerender, container } = renderDrawer();
-    expect(container.querySelector(".filter-drawer__subtitle")).toBeNull();
+    expect(container.querySelector(".drawer__subtitle")).toBeNull();
 
     rerender({ params: makeSearchParams({ q: "*" }) });
-    expect(container.querySelector(".filter-drawer__subtitle")).toBeNull();
+    expect(container.querySelector(".drawer__subtitle")).toBeNull();
   });
 
   test("strips a trailing ' Scheme' from the scheme label", () => {

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -11,6 +11,8 @@ import type {
   AbstractContentEnhancement,
   BibliographicMetadataEnhancement,
   Community,
+  CommunityCopy,
+  CommunityFeatures,
   Enhancement,
   LinkedDataEnhancement,
   Reference,
@@ -38,7 +40,12 @@ export function makeSearchParams(
  * behaviour without depending on the real registry in services/communities.ts.
  * `features` and `copy` merge shallowly so callers override just one field.
  */
-export function makeCommunity(overrides: Partial<Community> = {}): Community {
+type CommunityOverrides = Partial<Omit<Community, "features" | "copy">> & {
+  features?: Partial<CommunityFeatures>;
+  copy?: Partial<CommunityCopy>;
+};
+
+export function makeCommunity(overrides: CommunityOverrides = {}): Community {
   const { features, copy, ...rest } = overrides;
   return {
     slug: "test",
@@ -47,7 +54,7 @@ export function makeCommunity(overrides: Partial<Community> = {}): Community {
     vocabularyUrl: "https://vocab.example/v1",
     contextUrl: "https://vocab.example/ctx",
     filterExcludedSchemes: [],
-    features: { evidenceMap: false, ...features },
+    features: { evidenceMap: false, aiSummaries: false, ...features },
     copy: {
       searchPlaceholder: "Search the evidence",
       drawerTitle: "Refine the evidence",

--- a/tests/hooks/useAiSummary.test.tsx
+++ b/tests/hooks/useAiSummary.test.tsx
@@ -4,12 +4,17 @@ import { renderHook, act, waitFor } from "@testing-library/preact";
 vi.mock("@/services/summariserClient", () => ({
   requestSummary: vi.fn(),
 }));
+vi.mock("@/services/apiClient", () => ({
+  searchReferenceIds: vi.fn(),
+}));
 
 import { requestSummary } from "@/services/summariserClient";
-import { useAiSummary } from "@/hooks/useAiSummary";
+import { searchReferenceIds } from "@/services/apiClient";
+import { useAiSummary, type AiSummaryInput } from "@/hooks/useAiSummary";
 import { MOCK_SUMMARY } from "@/services/summariserMock";
 
 const mockRequest = vi.mocked(requestSummary);
+const mockIds = vi.mocked(searchReferenceIds);
 
 /** A promise plus its resolve/reject, so a test can drive completion timing. */
 function deferred<T>() {
@@ -22,10 +27,22 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
-const req = { terms: [{ name: "Afghanistan" }], referenceIds: ["a", "b"] };
+const input: AiSummaryInput = {
+  terms: [{ name: "Afghanistan" }],
+  query: "afghanistan",
+  filters: { annotation: ["domain-inclusion/hpv"] },
+};
+
+function resolveIds(reference_ids: string[]) {
+  mockIds.mockResolvedValue({
+    total: { count: reference_ids.length, is_lower_bound: false },
+    reference_ids,
+  });
+}
 
 beforeEach(() => {
   mockRequest.mockReset();
+  mockIds.mockReset();
 });
 
 describe("useAiSummary", () => {
@@ -36,44 +53,44 @@ describe("useAiSummary", () => {
     expect(result.current.minimized).toBe(false);
   });
 
-  test("generate opens the drawer, then resolves to the result", async () => {
-    const d = deferred<typeof MOCK_SUMMARY>();
-    mockRequest.mockReturnValue(d.promise);
+  test("gathers ids then summarises them, opening the drawer", async () => {
+    resolveIds(["a", "b", "c"]);
+    mockRequest.mockResolvedValue(MOCK_SUMMARY);
 
     const { result } = renderHook(() => useAiSummary());
-    act(() => result.current.generate(req));
+    act(() => result.current.generate(input));
 
     expect(result.current.status).toBe("generating");
     expect(result.current.drawerOpen).toBe(true);
 
-    await act(async () => {
-      d.resolve(MOCK_SUMMARY);
-      await d.promise;
-    });
-
-    expect(result.current.status).toBe("done");
+    await waitFor(() => expect(result.current.status).toBe("done"));
     expect(result.current.result).toBe(MOCK_SUMMARY);
-    expect(result.current.drawerOpen).toBe(true);
+
+    // ids endpoint queried with the search descriptor; its ids feed the summary.
+    expect(mockIds).toHaveBeenCalledWith(
+      input.query,
+      input.filters,
+      expect.anything(),
+    );
+    expect(mockRequest).toHaveBeenCalledWith(
+      { terms: input.terms, referenceIds: ["a", "b", "c"] },
+      expect.anything(),
+    );
   });
 
   test("run in background hides the drawer but keeps the result on completion", async () => {
-    const d = deferred<typeof MOCK_SUMMARY>();
-    mockRequest.mockReturnValue(d.promise);
+    resolveIds(["a"]);
+    mockRequest.mockResolvedValue(MOCK_SUMMARY);
 
     const { result } = renderHook(() => useAiSummary());
-    act(() => result.current.generate(req));
+    act(() => result.current.generate(input));
     act(() => result.current.runInBackground());
 
     expect(result.current.minimized).toBe(true);
     expect(result.current.drawerOpen).toBe(false);
 
-    await act(async () => {
-      d.resolve(MOCK_SUMMARY);
-      await d.promise;
-    });
-
+    await waitFor(() => expect(result.current.status).toBe("done"));
     // Still minimized → drawer stays closed, but the result is ready.
-    expect(result.current.status).toBe("done");
     expect(result.current.minimized).toBe(true);
     expect(result.current.drawerOpen).toBe(false);
 
@@ -82,11 +99,12 @@ describe("useAiSummary", () => {
   });
 
   test("dismiss aborts and a late resolution does not revive state", async () => {
+    resolveIds(["a"]);
     const d = deferred<typeof MOCK_SUMMARY>();
     mockRequest.mockReturnValue(d.promise);
 
     const { result } = renderHook(() => useAiSummary());
-    act(() => result.current.generate(req));
+    act(() => result.current.generate(input));
     act(() => result.current.dismiss());
 
     expect(result.current.status).toBe("idle");
@@ -96,24 +114,29 @@ describe("useAiSummary", () => {
       await d.promise;
     });
 
-    // The stale request resolved, but the run guard kept us idle.
     expect(result.current.status).toBe("idle");
     expect(result.current.result).toBeNull();
   });
 
-  test("surfaces an error message when the request rejects", async () => {
-    const d = deferred<typeof MOCK_SUMMARY>();
-    mockRequest.mockReturnValue(d.promise);
+  test("surfaces an error message when the summary request rejects", async () => {
+    resolveIds(["a"]);
+    mockRequest.mockRejectedValue(new Error("boom"));
 
     const { result } = renderHook(() => useAiSummary());
-    act(() => result.current.generate(req));
-
-    await act(async () => {
-      d.reject(new Error("boom"));
-      await d.promise.catch(() => undefined);
-    });
+    act(() => result.current.generate(input));
 
     await waitFor(() => expect(result.current.status).toBe("error"));
     expect(result.current.errorMessage).toBe("boom");
+  });
+
+  test("surfaces an error when gathering ids fails", async () => {
+    mockIds.mockRejectedValue(new Error("ids down"));
+
+    const { result } = renderHook(() => useAiSummary());
+    act(() => result.current.generate(input));
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.errorMessage).toBe("ids down");
+    expect(mockRequest).not.toHaveBeenCalled();
   });
 });

--- a/tests/hooks/useAiSummary.test.tsx
+++ b/tests/hooks/useAiSummary.test.tsx
@@ -1,0 +1,119 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/preact";
+
+vi.mock("@/services/summariserClient", () => ({
+  requestSummary: vi.fn(),
+}));
+
+import { requestSummary } from "@/services/summariserClient";
+import { useAiSummary } from "@/hooks/useAiSummary";
+import { MOCK_SUMMARY } from "@/services/summariserMock";
+
+const mockRequest = vi.mocked(requestSummary);
+
+/** A promise plus its resolve/reject, so a test can drive completion timing. */
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const req = { terms: [{ name: "Afghanistan" }], referenceIds: ["a", "b"] };
+
+beforeEach(() => {
+  mockRequest.mockReset();
+});
+
+describe("useAiSummary", () => {
+  test("starts idle with the drawer closed", () => {
+    const { result } = renderHook(() => useAiSummary());
+    expect(result.current.status).toBe("idle");
+    expect(result.current.drawerOpen).toBe(false);
+    expect(result.current.minimized).toBe(false);
+  });
+
+  test("generate opens the drawer, then resolves to the result", async () => {
+    const d = deferred<typeof MOCK_SUMMARY>();
+    mockRequest.mockReturnValue(d.promise);
+
+    const { result } = renderHook(() => useAiSummary());
+    act(() => result.current.generate(req));
+
+    expect(result.current.status).toBe("generating");
+    expect(result.current.drawerOpen).toBe(true);
+
+    await act(async () => {
+      d.resolve(MOCK_SUMMARY);
+      await d.promise;
+    });
+
+    expect(result.current.status).toBe("done");
+    expect(result.current.result).toBe(MOCK_SUMMARY);
+    expect(result.current.drawerOpen).toBe(true);
+  });
+
+  test("run in background hides the drawer but keeps the result on completion", async () => {
+    const d = deferred<typeof MOCK_SUMMARY>();
+    mockRequest.mockReturnValue(d.promise);
+
+    const { result } = renderHook(() => useAiSummary());
+    act(() => result.current.generate(req));
+    act(() => result.current.runInBackground());
+
+    expect(result.current.minimized).toBe(true);
+    expect(result.current.drawerOpen).toBe(false);
+
+    await act(async () => {
+      d.resolve(MOCK_SUMMARY);
+      await d.promise;
+    });
+
+    // Still minimized → drawer stays closed, but the result is ready.
+    expect(result.current.status).toBe("done");
+    expect(result.current.minimized).toBe(true);
+    expect(result.current.drawerOpen).toBe(false);
+
+    act(() => result.current.open());
+    expect(result.current.drawerOpen).toBe(true);
+  });
+
+  test("dismiss aborts and a late resolution does not revive state", async () => {
+    const d = deferred<typeof MOCK_SUMMARY>();
+    mockRequest.mockReturnValue(d.promise);
+
+    const { result } = renderHook(() => useAiSummary());
+    act(() => result.current.generate(req));
+    act(() => result.current.dismiss());
+
+    expect(result.current.status).toBe("idle");
+
+    await act(async () => {
+      d.resolve(MOCK_SUMMARY);
+      await d.promise;
+    });
+
+    // The stale request resolved, but the run guard kept us idle.
+    expect(result.current.status).toBe("idle");
+    expect(result.current.result).toBeNull();
+  });
+
+  test("surfaces an error message when the request rejects", async () => {
+    const d = deferred<typeof MOCK_SUMMARY>();
+    mockRequest.mockReturnValue(d.promise);
+
+    const { result } = renderHook(() => useAiSummary());
+    act(() => result.current.generate(req));
+
+    await act(async () => {
+      d.reject(new Error("boom"));
+      await d.promise.catch(() => undefined);
+    });
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.errorMessage).toBe("boom");
+  });
+});

--- a/tests/hooks/useAiSummary.test.tsx
+++ b/tests/hooks/useAiSummary.test.tsx
@@ -28,9 +28,13 @@ function deferred<T>() {
 }
 
 const input: AiSummaryInput = {
-  terms: [{ name: "Afghanistan" }],
   query: "afghanistan",
   filters: { annotation: ["domain-inclusion/hpv"] },
+  context: {
+    terms: ["Afghanistan"],
+    count: { count: 3, is_lower_bound: false },
+    countNoun: "references",
+  },
 };
 
 function resolveIds(reference_ids: string[]) {
@@ -65,6 +69,8 @@ describe("useAiSummary", () => {
 
     await waitFor(() => expect(result.current.status).toBe("done"));
     expect(result.current.result).toBe(MOCK_SUMMARY);
+    // Context is snapshotted so a later search can't make the drawer drift.
+    expect(result.current.context).toEqual(input.context);
 
     // ids endpoint queried with the search descriptor; its ids feed the summary.
     expect(mockIds).toHaveBeenCalledWith(
@@ -72,8 +78,9 @@ describe("useAiSummary", () => {
       input.filters,
       expect.anything(),
     );
+    // Summariser terms are derived from the snapshotted context labels.
     expect(mockRequest).toHaveBeenCalledWith(
-      { terms: input.terms, referenceIds: ["a", "b", "c"] },
+      { terms: [{ name: "Afghanistan" }], referenceIds: ["a", "b", "c"] },
       expect.anything(),
     );
   });

--- a/tests/pages/SearchPage.test.tsx
+++ b/tests/pages/SearchPage.test.tsx
@@ -715,7 +715,7 @@ describe("SearchPage", () => {
 
     test("facet URL → Export passes concept filter through to requestSearchExport", async () => {
       // SearchPage-layer integration: catches stale params at the call site,
-      // which the unit tests on toExportSearchQuery in isolation cannot.
+      // which the unit tests on toUnpaginatedSearchQuery in isolation cannot.
       history.replaceState(
         null,
         "",

--- a/tests/services/communities.test.ts
+++ b/tests/services/communities.test.ts
@@ -50,8 +50,15 @@ describe("communities", () => {
     expect(hpv?.codingInstitution).toBeUndefined();
   });
 
+  it("enables AI summaries only for HPV", async () => {
+    const { findCommunity } = await import("@/services/communities");
+    expect(findCommunity("hpv")?.features.aiSummaries).toBe(true);
+    expect(findCommunity("esea")?.features.aiSummaries).toBe(false);
+  });
+
   it("opts every feature out by default, leaving communities to enable them", async () => {
     const { DEFAULT_FEATURES } = await import("@/services/communities");
     expect(DEFAULT_FEATURES.evidenceMap).toBe(false);
+    expect(DEFAULT_FEATURES.aiSummaries).toBe(false);
   });
 });

--- a/tests/services/searchParams.test.ts
+++ b/tests/services/searchParams.test.ts
@@ -3,7 +3,7 @@ import {
   parseSearchParams,
   toQueryString,
   buildSearchUrl,
-  toExportSearchQuery,
+  toUnpaginatedSearchQuery,
 } from "@/services/searchParams";
 import { makeSearchParams } from "../fixtures";
 
@@ -281,26 +281,26 @@ describe("buildSearchUrl", () => {
   });
 });
 
-describe("toExportSearchQuery", () => {
+describe("toUnpaginatedSearchQuery", () => {
   test("no concept or country, non-empty q → existing behaviour preserved", () => {
     const p = makeSearchParams({ q: "phonics" });
-    expect(toExportSearchQuery(p, ["dom-x"]).query).toBe("phonics");
+    expect(toUnpaginatedSearchQuery(p, ["dom-x"]).query).toBe("phonics");
   });
 
   test("no concept or country, empty q → '*' substitution", () => {
-    expect(toExportSearchQuery(makeSearchParams(), ["dom-x"]).query).toBe("*");
+    expect(toUnpaginatedSearchQuery(makeSearchParams(), ["dom-x"]).query).toBe("*");
   });
 
   test("country filters travel as structured filter, not embedded in query", () => {
     const p = makeSearchParams({ q: "phonics", countryCodes: ["DE", "FR"] });
-    const out = toExportSearchQuery(p, ["dom-x"]);
+    const out = toUnpaginatedSearchQuery(p, ["dom-x"]);
     expect(out.query).toBe("phonics");
     expect(out.filters.countryCodes).toEqual(["DE", "FR"]);
   });
 
   test("country filters with empty q → '*' query, codes on filters", () => {
     const p = makeSearchParams({ countryCodes: ["DE"] });
-    const out = toExportSearchQuery(p, ["dom-x"]);
+    const out = toUnpaginatedSearchQuery(p, ["dom-x"]);
     expect(out.query).toBe("*");
     expect(out.filters.countryCodes).toEqual(["DE"]);
   });
@@ -310,7 +310,7 @@ describe("toExportSearchQuery", () => {
       q: "phonics",
       conceptFilters: [["https://x/A"]],
     });
-    const out = toExportSearchQuery(p, ["dom-x"]);
+    const out = toUnpaginatedSearchQuery(p, ["dom-x"]);
     expect(out.query).toBe("phonics");
     expect(out.filters.conceptFilters).toEqual([["https://x/A"]]);
   });
@@ -323,7 +323,7 @@ describe("toExportSearchQuery", () => {
       sort: "newest",
       countryCodes: ["DE"],
     });
-    expect(toExportSearchQuery(p, ["dom-x"]).filters).toEqual({
+    expect(toUnpaginatedSearchQuery(p, ["dom-x"]).filters).toEqual({
       startYear: 2010,
       endYear: 2024,
       annotation: ["dom-x"],

--- a/tests/services/summariserClient.test.ts
+++ b/tests/services/summariserClient.test.ts
@@ -100,9 +100,10 @@ describe("requestSummary", () => {
       await assertion;
     });
 
-    test("throws when the submit is rejected (e.g. a reference has no full text)", async () => {
+    test("surfaces the error detail when the submit is rejected (e.g. no full text)", async () => {
       fetchMock.mockResolvedValue(response({ detail: "no_full_text" }, 422));
-      await expect(requestSummary(request)).rejects.toThrow(/422/);
+      // The status and the service's `detail` both reach the error message.
+      await expect(requestSummary(request)).rejects.toThrow(/422.*no_full_text/);
     });
   });
 });

--- a/tests/services/summariserClient.test.ts
+++ b/tests/services/summariserClient.test.ts
@@ -1,0 +1,111 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Toggled per-test; name starts with "mock" so vitest's hoisting allows it.
+let mockBase: string | undefined;
+vi.mock("@/config", () => ({
+  get SUMMARISER_BASE() {
+    return mockBase;
+  },
+}));
+
+import { requestSummary } from "@/services/summariserClient";
+import { MOCK_SUMMARY } from "@/services/summariserMock";
+import type { SummaryRequest } from "@/services/summariser";
+
+const fetchMock = vi.fn();
+
+function response(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+const request: SummaryRequest = {
+  referenceIds: ["id-1", "id-2"],
+  terms: [
+    { name: "Health workers" },
+    { name: "Cost", description: "value for money" },
+  ],
+};
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+  mockBase = undefined;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("requestSummary", () => {
+  test("returns placeholder data without hitting the network when no base is set", async () => {
+    vi.useFakeTimers();
+    const pending = requestSummary(request);
+    await vi.advanceTimersByTimeAsync(3000);
+    await expect(pending).resolves.toBe(MOCK_SUMMARY);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  describe("with SUMMARISER_BASE configured", () => {
+    beforeEach(() => {
+      mockBase = "https://sum.test/api";
+    });
+
+    test("submits reference_ids and terms as form fields and returns a cached 200 result", async () => {
+      fetchMock.mockResolvedValue(response(MOCK_SUMMARY, 200));
+
+      const result = await requestSummary(request);
+      expect(result).toEqual(MOCK_SUMMARY);
+
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe("https://sum.test/api/summarise");
+      expect(init.method).toBe("POST");
+      const headers = init.headers as Record<string, string>;
+      expect(headers["Content-Type"]).toBe("application/x-www-form-urlencoded");
+      expect(headers["Authorization"]).toBe("Bearer test-token");
+
+      const body = init.body as URLSearchParams;
+      expect(body.getAll("reference_ids")).toEqual(["id-1", "id-2"]);
+      // A term with a description is encoded as "name:description".
+      expect(body.getAll("terms")).toEqual([
+        "Health workers",
+        "Cost:value for money",
+      ]);
+    });
+
+    test("polls the job until it is done on a 202", async () => {
+      vi.useFakeTimers();
+      fetchMock
+        .mockResolvedValueOnce(response({ job_id: "job-9", status: "running" }, 202))
+        .mockResolvedValueOnce(response({ status: "running" }, 200))
+        .mockResolvedValueOnce(response({ status: "done", result: MOCK_SUMMARY }, 200));
+
+      const pending = requestSummary(request);
+      await vi.advanceTimersByTimeAsync(11000); // two 5s poll intervals
+
+      await expect(pending).resolves.toEqual(MOCK_SUMMARY);
+      expect(fetchMock.mock.calls[1][0]).toBe("https://sum.test/api/jobs/job-9");
+    });
+
+    test("rejects when the job fails", async () => {
+      vi.useFakeTimers();
+      fetchMock
+        .mockResolvedValueOnce(response({ job_id: "job-9", status: "running" }, 202))
+        .mockResolvedValueOnce(response({ status: "failed", error: "boom" }, 200));
+
+      const pending = requestSummary(request);
+      const assertion = expect(pending).rejects.toThrow("boom");
+      await vi.advanceTimersByTimeAsync(6000);
+      await assertion;
+    });
+
+    test("throws when the submit is rejected (e.g. a reference has no full text)", async () => {
+      fetchMock.mockResolvedValue(response({ detail: "no_full_text" }, 422));
+      await expect(requestSummary(request)).rejects.toThrow(/422/);
+    });
+  });
+});

--- a/tests/services/summariserClient.test.ts
+++ b/tests/services/summariserClient.test.ts
@@ -42,11 +42,8 @@ afterEach(() => {
 });
 
 describe("requestSummary", () => {
-  test("returns placeholder data without hitting the network when no base is set", async () => {
-    vi.useFakeTimers();
-    const pending = requestSummary(request);
-    await vi.advanceTimersByTimeAsync(3000);
-    await expect(pending).resolves.toBe(MOCK_SUMMARY);
+  test("throws without hitting the network when no base is configured", async () => {
+    await expect(requestSummary(request)).rejects.toThrow(/not configured/i);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Closes #134.

Bare-minimum AI Summaries UI, built against mock data with a typed client/hook seam ready to swap to the real summariser once it's deployed.

## What's here
- **Entry point + drawer** — a "Generate AI summary `BETA`" button on the results page opens a right-side drawer: loading state → narrative prose with footnote markers linking to a numbered "Claims & sources" list (verbatim quote + citation + DOI), behind a BETA "verify before use" disclaimer.
- **Run in background** — minimizes the drawer to a chip ("Summarising…" → "Summary ready · View") so a long-running job survives the drawer closing. State lives in `useAiSummary`, above the drawer.
- **Flag for accuracy** — a Google Form link (mirrors the Feedback FAB), no modal.
- **Shared `Drawer` primitive** — extracted the slide-over mechanics (scroll-lock, focus capture/restore, Escape, backdrop, open-gate) into `components/common/Drawer`. `FilterDrawer` now composes it; a BEM `block` prop preserves each drawer's own class hooks, so the existing FilterDrawer tests pass unchanged.
- **Community gating** — new `aiSummaries` feature flag, enabled for HPV only.
- **Backend seam** — `summariser*.ts` mirror the service's `SummariseResponse`; the client returns mock data by default and has a provisional POST/poll path behind `VITE_SUMMARISER_BASE`.

## Scope / deferred
- The summary content is the summariser service's responsibility (futureevidence/ai-evidence-summariser#1); UI ships against placeholder data until that's deployed.
- User-level access gating (Keycloak group) is tracked in #132.
- Context chips use the search query as a stand-in for intersecting terms until the evidence map deep-links explicit row/column labels.

## Tests
`npm run typecheck` clean; full suite green (770 tests), including the unchanged FilterDrawer tests plus new `useAiSummary`, `AiSummaryDrawer`, and HPV-gating coverage.
