### PR TITLE
Add landing page for unauthenticated hpv community users

### DIFF
--- a/public/silent-check-sso.html
+++ b/public/silent-check-sso.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <body>
+    <script>
+      parent.postMessage(location.href, location.origin);
+    </script>
+  </body>
+</html>

--- a/src/auth/AuthGate.tsx
+++ b/src/auth/AuthGate.tsx
@@ -1,3 +1,27 @@
+import { login, register } from "./keycloak";
+
+export function Landing() {
+  return (
+    <div class="auth-gate">
+      <div class="auth-gate__panel">
+        <p>Welcome to the Evidence Repository.</p>
+        <div class="auth-gate__actions">
+          <button
+            type="button"
+            class="auth-gate__button auth-gate__button--primary"
+            onClick={login}
+          >
+            Sign in
+          </button>
+          <button type="button" class="auth-gate__button" onClick={register}>
+            Create account
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function Loading() {
   return (
     <div class="auth-gate">

--- a/src/auth/keycloak.ts
+++ b/src/auth/keycloak.ts
@@ -1,5 +1,6 @@
 import Keycloak from "keycloak-js";
 import { KEYCLOAK_CLIENT_ID, KEYCLOAK_REALM, KEYCLOAK_URL } from "@/config";
+import { findCommunity } from "@/services/communities";
 
 function requireEnv(name: string, value: string | undefined): string {
   if (!value) {
@@ -18,13 +19,9 @@ keycloak.onTokenExpired = () => {
   keycloak.updateToken(30).catch(() => keycloak.login());
 };
 
-// Communities that allow self-service registration: visitors land on a
-// Sign in / Create account screen instead of being forced straight to login.
-const SELF_SIGNUP_COMMUNITIES = new Set(["hpv"]);
-
 function allowsSelfSignup(): boolean {
   const slug = window.location.pathname.split("/").filter(Boolean)[0];
-  return slug !== undefined && SELF_SIGNUP_COMMUNITIES.has(slug);
+  return slug !== undefined && !!findCommunity(slug)?.features.selfSignup;
 }
 
 export async function initKeycloak(): Promise<boolean> {

--- a/src/auth/keycloak.ts
+++ b/src/auth/keycloak.ts
@@ -18,10 +18,27 @@ keycloak.onTokenExpired = () => {
   keycloak.updateToken(30).catch(() => keycloak.login());
 };
 
-export async function initKeycloak(): Promise<void> {
-  await keycloak.init({
-    onLoad: "login-required",
+// Communities that allow self-service registration: visitors land on a
+// Sign in / Create account screen instead of being forced straight to login.
+const SELF_SIGNUP_COMMUNITIES = new Set(["hpv"]);
+
+function allowsSelfSignup(): boolean {
+  const slug = window.location.pathname.split("/").filter(Boolean)[0];
+  return slug !== undefined && SELF_SIGNUP_COMMUNITIES.has(slug);
+}
+
+export async function initKeycloak(): Promise<boolean> {
+  return keycloak.init({
+    onLoad: allowsSelfSignup() ? "check-sso" : "login-required",
     pkceMethod: "S256",
     checkLoginIframe: false,
   });
+}
+
+export function login(): void {
+  keycloak.login();
+}
+
+export function register(): void {
+  keycloak.register();
 }

--- a/src/auth/keycloak.ts
+++ b/src/auth/keycloak.ts
@@ -25,8 +25,18 @@ function allowsSelfSignup(): boolean {
 }
 
 export async function initKeycloak(): Promise<boolean> {
+  const selfSignup = allowsSelfSignup();
+  // Self-signup communities are an open front door. check-sso detects an
+  // existing session via a hidden iframe — so a logged-in user skips the
+  // landing — without the full-page Keycloak bounce a plain check-sso does.
+  // silentCheckSsoFallback:false keeps cookie-restricted browsers from
+  // bouncing too: they just see the landing and click Sign in once.
   return keycloak.init({
-    onLoad: allowsSelfSignup() ? "check-sso" : "login-required",
+    onLoad: selfSignup ? "check-sso" : "login-required",
+    ...(selfSignup && {
+      silentCheckSsoRedirectUri: `${window.location.origin}/silent-check-sso.html`,
+      silentCheckSsoFallback: false,
+    }),
     pkceMethod: "S256",
     checkLoginIframe: false,
   });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import { render } from "preact";
 import { App } from "./App";
 import { initMatomo } from "./analytics/matomo";
-import { AuthError, Loading } from "./auth/AuthGate";
+import { AuthError, Landing, Loading } from "./auth/AuthGate";
 import { initKeycloak } from "./auth/keycloak";
 import { MATOMO_CONTAINER_URL } from "./config";
 import "./styles/reset.css";
@@ -16,7 +16,9 @@ render(<Loading />, root);
 initMatomo(MATOMO_CONTAINER_URL);
 
 initKeycloak()
-  .then(() => render(<App />, root))
+  .then((authenticated) =>
+    render(authenticated ? <App /> : <Landing />, root),
+  )
   .catch((err) => {
     console.error("Authentication initialization failed", err);
     render(<AuthError />, root);

--- a/src/services/communities.ts
+++ b/src/services/communities.ts
@@ -17,6 +17,7 @@ function requireEnv(name: string, value: string | undefined): string {
 
 export const DEFAULT_FEATURES: CommunityFeatures = {
   evidenceMap: false,
+  selfSignup: false,
 };
 
 // Shared copy fallbacks; a community overrides only what diverges.
@@ -90,7 +91,7 @@ const COMMUNITIES: Community[] = [
       import.meta.env.VITE_HPV_CONTEXT_URL,
     ),
     filterExcludedSchemes: [],
-    features: { ...DEFAULT_FEATURES, evidenceMap: true },
+    features: { ...DEFAULT_FEATURES, evidenceMap: true, selfSignup: true },
     copy: buildCopy("HPV Vaccine Delivery", {
       countNoun: "references",
       corpusDescriptor: "HPV vaccine delivery research",

--- a/src/styles/auth-gate.css
+++ b/src/styles/auth-gate.css
@@ -16,26 +16,7 @@
   text-align: center;
 }
 
-.auth-gate__retry {
-  font-size: var(--font-size-base);
-  color: var(--color-text);
-  background: transparent;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  padding: var(--spacing-sm) var(--spacing-md);
-  cursor: pointer;
-}
-
-.auth-gate__retry:hover {
-  color: var(--color-primary);
-  border-color: var(--color-primary);
-}
-
-.auth-gate__actions {
-  display: flex;
-  gap: var(--spacing-sm);
-}
-
+.auth-gate__retry,
 .auth-gate__button {
   font-size: var(--font-size-base);
   color: var(--color-text);
@@ -46,9 +27,15 @@
   cursor: pointer;
 }
 
+.auth-gate__retry:hover,
 .auth-gate__button:hover {
   color: var(--color-primary);
   border-color: var(--color-primary);
+}
+
+.auth-gate__actions {
+  display: flex;
+  gap: var(--spacing-sm);
 }
 
 .auth-gate__button--primary {

--- a/src/styles/auth-gate.css
+++ b/src/styles/auth-gate.css
@@ -30,3 +30,34 @@
   color: var(--color-primary);
   border-color: var(--color-primary);
 }
+
+.auth-gate__actions {
+  display: flex;
+  gap: var(--spacing-sm);
+}
+
+.auth-gate__button {
+  font-size: var(--font-size-base);
+  color: var(--color-text);
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  cursor: pointer;
+}
+
+.auth-gate__button:hover {
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.auth-gate__button--primary {
+  color: var(--color-bg);
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.auth-gate__button--primary:hover {
+  color: var(--color-bg);
+  opacity: 0.9;
+}

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -1,6 +1,8 @@
 export interface CommunityFeatures {
   // No UI yet; reserved so the evidence map can ship behind a flag (#103).
   evidenceMap: boolean;
+  // Offer a Sign in / Create account choice on entry instead of forcing login.
+  selfSignup: boolean;
 }
 
 // One axis of the evidence map.

--- a/tests/auth/AuthGate.test.tsx
+++ b/tests/auth/AuthGate.test.tsx
@@ -1,11 +1,33 @@
-import { describe, test, expect, vi } from "vitest";
+import { describe, test, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/preact";
-import { AuthError, Loading } from "@/auth/AuthGate";
+import { AuthError, Landing, Loading } from "@/auth/AuthGate";
+import { login, register } from "@/auth/keycloak";
 
 describe("AuthGate", () => {
   test("Loading shows the signing-in message", () => {
     render(<Loading />);
     expect(screen.getByText("Signing you in…")).toBeInTheDocument();
+  });
+
+  describe("Landing", () => {
+    beforeEach(() => {
+      vi.mocked(login).mockClear();
+      vi.mocked(register).mockClear();
+    });
+
+    test("Sign in triggers keycloak login", () => {
+      render(<Landing />);
+      screen.getByRole("button", { name: "Sign in" }).click();
+      expect(login).toHaveBeenCalledOnce();
+      expect(register).not.toHaveBeenCalled();
+    });
+
+    test("Create account triggers keycloak registration", () => {
+      render(<Landing />);
+      screen.getByRole("button", { name: "Create account" }).click();
+      expect(register).toHaveBeenCalledOnce();
+      expect(login).not.toHaveBeenCalled();
+    });
   });
 
   test("AuthError shows the failure message and a retry button", () => {

--- a/tests/auth/keycloak.test.ts
+++ b/tests/auth/keycloak.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+// The global setup mocks @/auth/keycloak wholesale; here we want the REAL
+// module (via importActual) with only keycloak-js stubbed, so we can assert
+// which onLoad mode initKeycloak() picks per community.
+const initSpy = vi.fn().mockResolvedValue(true);
+vi.mock("keycloak-js", () => ({
+  default: vi.fn(() => ({ init: initSpy })),
+}));
+
+async function realInitKeycloak() {
+  const mod =
+    await vi.importActual<typeof import("@/auth/keycloak")>("@/auth/keycloak");
+  return mod.initKeycloak;
+}
+
+function setPathname(pathname: string) {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { ...window.location, pathname },
+  });
+}
+
+describe("initKeycloak onLoad selection", () => {
+  beforeEach(() => initSpy.mockClear());
+
+  test("self-signup community (hpv) uses silent check-sso so a logged-in user skips the landing without a full-page bounce", async () => {
+    setPathname("/hpv/references/abc");
+    await (await realInitKeycloak())();
+    const opts = initSpy.mock.calls[0][0];
+    expect(opts.onLoad).toBe("check-sso");
+    expect(opts.silentCheckSsoRedirectUri).toMatch(/\/silent-check-sso\.html$/);
+    expect(opts.silentCheckSsoFallback).toBe(false);
+  });
+
+  test("non-self-signup community (esea) stays gated behind login-required with no silent check", async () => {
+    setPathname("/esea");
+    await (await realInitKeycloak())();
+    const opts = initSpy.mock.calls[0][0];
+    expect(opts.onLoad).toBe("login-required");
+    expect(opts.silentCheckSsoRedirectUri).toBeUndefined();
+  });
+
+  test("root / unknown path falls back to login-required", async () => {
+    setPathname("/");
+    await (await realInitKeycloak())();
+    expect(initSpy.mock.calls[0][0].onLoad).toBe("login-required");
+  });
+});

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -11,6 +11,8 @@ import type {
   AbstractContentEnhancement,
   BibliographicMetadataEnhancement,
   Community,
+  CommunityCopy,
+  CommunityFeatures,
   Enhancement,
   LinkedDataEnhancement,
   Reference,
@@ -38,7 +40,12 @@ export function makeSearchParams(
  * behaviour without depending on the real registry in services/communities.ts.
  * `features` and `copy` merge shallowly so callers override just one field.
  */
-export function makeCommunity(overrides: Partial<Community> = {}): Community {
+type CommunityOverrides = Partial<Omit<Community, "features" | "copy">> & {
+  features?: Partial<CommunityFeatures>;
+  copy?: Partial<CommunityCopy>;
+};
+
+export function makeCommunity(overrides: CommunityOverrides = {}): Community {
   const { features, copy, ...rest } = overrides;
   return {
     slug: "test",
@@ -47,7 +54,7 @@ export function makeCommunity(overrides: Partial<Community> = {}): Community {
     vocabularyUrl: "https://vocab.example/v1",
     contextUrl: "https://vocab.example/ctx",
     filterExcludedSchemes: [],
-    features: { evidenceMap: false, ...features },
+    features: { evidenceMap: false, selfSignup: false, ...features },
     copy: {
       searchPlaceholder: "Search the evidence",
       drawerTitle: "Refine the evidence",

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -6,6 +6,9 @@ vi.stubEnv("VITE_ESEA_VOCABULARY_URL", "https://test.example/vocab");
 vi.stubEnv("VITE_ESEA_CONTEXT_URL", "https://test.example/context");
 vi.stubEnv("VITE_HPV_VOCABULARY_URL", "https://test.example/hpv-vocab");
 vi.stubEnv("VITE_HPV_CONTEXT_URL", "https://test.example/hpv-context");
+vi.stubEnv("VITE_KEYCLOAK_URL", "https://kc.test.example");
+vi.stubEnv("VITE_KEYCLOAK_REALM", "test-realm");
+vi.stubEnv("VITE_KEYCLOAK_CLIENT_ID", "test-client");
 
 const defaultTokenParsed = () => ({
   name: "Test User",
@@ -28,6 +31,8 @@ vi.mock("@/auth/keycloak", () => {
   return {
     keycloak,
     initKeycloak: vi.fn().mockResolvedValue(undefined),
+    login: vi.fn(),
+    register: vi.fn(),
   };
 });
 


### PR DESCRIPTION
Adds a landing page for anyone that accesses `/hpv` (or its sub-paths) without being logged in. The login button takes them to the normal flow, `Create Account` goes directly to the keycloak registration form.

`/esea` or `/` autodirect to the keycloak login page (existing behaviour).

<img width="1439" height="847" alt="image" src="https://github.com/user-attachments/assets/dc08771a-e32a-4716-aa3f-eccd7b2cf893" />
