### PR TITLE
HPV reference detail: Taxonomy codes card (+ HPV map axis defaults and Countries-axis gate)

### DIFF
--- a/src/components/investigation/TaxonomyCodesCard.css
+++ b/src/components/investigation/TaxonomyCodesCard.css
@@ -9,9 +9,16 @@
 }
 .taxonomy-codes-card__subgroup {
   margin-top: var(--spacing-sm);
+  /* Indent each nesting level so sub-categories read as inside their scheme;
+     nests compound (a 3-level scheme indents twice). Schemes with direct pills
+     have no sub-group, so they stay flush. */
+  padding-left: var(--spacing-md);
 }
 .taxonomy-codes-card__subheading {
   font-size: var(--font-size-sm);
+  /* Below the scheme eyebrow's 600 (and override h4's bold default) so the
+     scheme reads as the parent and the sub-category as subordinate. */
+  font-weight: 500;
   color: var(--color-text-secondary);
   margin: 0 0 var(--spacing-xs);
 }
@@ -19,4 +26,32 @@
   font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
   margin: 0 0 var(--spacing-md);
+}
+/* Roll-up toggle: looks like a tag pill (same border/radius/size as
+   .tag-group__tag) but is an interactive disclosure with a chevron. */
+.taxonomy-codes-card__rollup {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  background: transparent;
+  border: 1px solid var(--color-border-tag);
+  border-radius: 3px;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500; /* match .tag-group__tag-child so it reads as a pill */
+  padding: 2px 8px;
+  color: inherit;
+  cursor: pointer;
+}
+.taxonomy-codes-card__rollup:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+.taxonomy-codes-card__rollup-arrow {
+  display: inline-flex;
+  align-items: center;
+  opacity: 0.7;
+}
+.taxonomy-codes-card__rollup-panel {
+  margin-top: var(--spacing-sm);
 }

--- a/src/components/investigation/TaxonomyCodesCard.css
+++ b/src/components/investigation/TaxonomyCodesCard.css
@@ -1,0 +1,26 @@
+.taxonomy-codes-card__title {
+  margin: 0;
+}
+.taxonomy-codes-card__group {
+  margin-top: var(--spacing-md);
+}
+.taxonomy-codes-card__scheme {
+  font-size: var(--font-size-sm);
+  margin: 0 0 var(--spacing-sm);
+}
+summary.taxonomy-codes-card__scheme {
+  cursor: pointer;
+}
+.taxonomy-codes-card__subgroup {
+  margin-top: var(--spacing-sm);
+}
+.taxonomy-codes-card__subheading {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin: 0 0 var(--spacing-xs);
+}
+.taxonomy-codes-card__vocab-note {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin: 0 0 var(--spacing-md);
+}

--- a/src/components/investigation/TaxonomyCodesCard.css
+++ b/src/components/investigation/TaxonomyCodesCard.css
@@ -1,26 +1,16 @@
 /* Typography for the title (.lg-kicker) and scheme headings (.lg-section-label)
    comes from the shared label utilities; this file owns only card-local spacing. */
+/* Separate the card from the one above it, matching the findings section's
+   margin-top (the detail-page container has no inter-card gap of its own). */
+.taxonomy-codes-card {
+  margin-top: var(--spacing-md);
+}
 .taxonomy-codes-card__title {
   margin: 0 0 var(--spacing-sm);
 }
 /* .lg-section-label already spaces each scheme heading from the block above. */
 .taxonomy-codes-card__scheme {
   margin: var(--spacing-md) 0 var(--spacing-sm);
-}
-.taxonomy-codes-card__subgroup {
-  margin-top: var(--spacing-sm);
-  /* Indent each nesting level so sub-categories read as inside their scheme;
-     nests compound (a 3-level scheme indents twice). Schemes with direct pills
-     have no sub-group, so they stay flush. */
-  padding-left: var(--spacing-md);
-}
-.taxonomy-codes-card__subheading {
-  font-size: var(--font-size-sm);
-  /* Below the scheme eyebrow's 600 (and override h4's bold default) so the
-     scheme reads as the parent and the sub-category as subordinate. */
-  font-weight: 500;
-  color: var(--color-text-secondary);
-  margin: 0 0 var(--spacing-xs);
 }
 .taxonomy-codes-card__vocab-note {
   font-size: var(--font-size-sm);

--- a/src/components/investigation/TaxonomyCodesCard.css
+++ b/src/components/investigation/TaxonomyCodesCard.css
@@ -27,31 +27,3 @@
   color: var(--color-text-secondary);
   margin: 0 0 var(--spacing-md);
 }
-/* Roll-up toggle: looks like a tag pill (same border/radius/size as
-   .tag-group__tag) but is an interactive disclosure with a chevron. */
-.taxonomy-codes-card__rollup {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--spacing-xs);
-  background: transparent;
-  border: 1px solid var(--color-border-tag);
-  border-radius: 3px;
-  font-family: inherit;
-  font-size: 13px;
-  font-weight: 500; /* match .tag-group__tag-child so it reads as a pill */
-  padding: 2px 8px;
-  color: inherit;
-  cursor: pointer;
-}
-.taxonomy-codes-card__rollup:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
-}
-.taxonomy-codes-card__rollup-arrow {
-  display: inline-flex;
-  align-items: center;
-  opacity: 0.7;
-}
-.taxonomy-codes-card__rollup-panel {
-  margin-top: var(--spacing-sm);
-}

--- a/src/components/investigation/TaxonomyCodesCard.css
+++ b/src/components/investigation/TaxonomyCodesCard.css
@@ -1,15 +1,11 @@
+/* Typography for the title (.lg-kicker) and scheme headings (.lg-section-label)
+   comes from the shared label utilities; this file owns only card-local spacing. */
 .taxonomy-codes-card__title {
-  margin: 0;
-}
-.taxonomy-codes-card__group {
-  margin-top: var(--spacing-md);
-}
-.taxonomy-codes-card__scheme {
-  font-size: var(--font-size-sm);
   margin: 0 0 var(--spacing-sm);
 }
-summary.taxonomy-codes-card__scheme {
-  cursor: pointer;
+/* .lg-section-label already spaces each scheme heading from the block above. */
+.taxonomy-codes-card__scheme {
+  margin: var(--spacing-md) 0 var(--spacing-sm);
 }
 .taxonomy-codes-card__subgroup {
   margin-top: var(--spacing-sm);

--- a/src/components/investigation/TaxonomyCodesCard.tsx
+++ b/src/components/investigation/TaxonomyCodesCard.tsx
@@ -45,22 +45,27 @@ function Nodes({ nodes }: { nodes: TaxoNode[] }) {
   );
 }
 
+// "Country" → "countries". Lower-cased plural for the roll-up summary pill.
+// Already-plural / sibilant labels are left alone; only the geo Country scheme
+// floods past the threshold today, so the y→ies case is the one that matters.
+function pluralLower(label: string): string {
+  const lower = label.toLowerCase();
+  if (lower.endsWith("s")) return lower;
+  if (lower.endsWith("y")) return `${lower.slice(0, -1)}ies`;
+  return `${lower}s`;
+}
+
 function SchemeBlock({ group }: { group: TaxonomyGroup }) {
-  const body = <Nodes nodes={group.nodes} />;
-  if (group.collapsedByDefault) {
-    return (
-      <details class="taxonomy-codes-card__group">
-        <summary class="taxonomy-codes-card__scheme">
-          {group.schemeLabel} ({group.appliedCount})
-        </summary>
-        {body}
-      </details>
-    );
-  }
   return (
     <section class="taxonomy-codes-card__group">
-      <h3 class="taxonomy-codes-card__scheme">{group.schemeLabel}</h3>
-      {body}
+      <h3 class="taxonomy-codes-card__scheme lg-section-label">
+        {group.schemeLabel}
+      </h3>
+      {group.rolledUp ? (
+        <TagGroup tags={[{ label: `Multiple ${pluralLower(group.schemeLabel)}` }]} />
+      ) : (
+        <Nodes nodes={group.nodes} />
+      )}
     </section>
   );
 }
@@ -72,7 +77,7 @@ export function TaxonomyCodesCard({
   if (groups.length === 0) return null;
   return (
     <article class="taxonomy-codes-card lg-card">
-      <h2 class="taxonomy-codes-card__title">Taxonomy codes</h2>
+      <h2 class="taxonomy-codes-card__title lg-kicker">Taxonomy codes</h2>
       {vocabUnavailable && (
         <p class="taxonomy-codes-card__vocab-note" role="status">
           Vocabulary unavailable — codes are shown as raw identifiers.

--- a/src/components/investigation/TaxonomyCodesCard.tsx
+++ b/src/components/investigation/TaxonomyCodesCard.tsx
@@ -8,41 +8,19 @@ interface TaxonomyCodesCardProps {
   vocabUnavailable?: boolean;
 }
 
-// Split one nesting level into chips (applied concepts) and sub-heading blocks
-// (non-applied ancestors). An applied node's own children are hoisted up to its
-// level, so a coded parent and its coded child both render — neither is dropped.
-function partition(nodes: readonly TaxoNode[]): {
-  tags: HierarchicalTag[];
-  subheadings: TaxoNode[];
-} {
+// Flatten a scheme's pruned tree into one tag per coded concept, carrying its
+// immediate ancestor's label as a breadcrumb (rendered "Parent › Child" inline,
+// matching the findings cards). Non-applied ancestors are not tags themselves;
+// they only supply the breadcrumb for their coded descendants.
+function flatten(nodes: readonly TaxoNode[], parent?: string): HierarchicalTag[] {
   const tags: HierarchicalTag[] = [];
-  const subheadings: TaxoNode[] = [];
   for (const n of nodes) {
     if (n.applied) {
-      tags.push({ label: n.label, definition: n.definition });
-      const hoisted = partition(n.children);
-      tags.push(...hoisted.tags);
-      subheadings.push(...hoisted.subheadings);
-    } else {
-      subheadings.push(n);
+      tags.push({ label: n.label, definition: n.definition, parent });
     }
+    tags.push(...flatten(n.children, n.label));
   }
-  return { tags, subheadings };
-}
-
-function Nodes({ nodes }: { nodes: TaxoNode[] }) {
-  const { tags, subheadings } = partition(nodes);
-  return (
-    <>
-      {tags.length > 0 && <TagGroup tags={tags} />}
-      {subheadings.map((a) => (
-        <div key={a.uri} class="taxonomy-codes-card__subgroup">
-          <h4 class="taxonomy-codes-card__subheading">{a.label}</h4>
-          <Nodes nodes={a.children} />
-        </div>
-      ))}
-    </>
-  );
+  return tags;
 }
 
 function SchemeBlock({ group }: { group: TaxonomyGroup }) {
@@ -51,7 +29,7 @@ function SchemeBlock({ group }: { group: TaxonomyGroup }) {
       <h3 class="taxonomy-codes-card__scheme lg-section-label">
         {group.schemeLabel}
       </h3>
-      <Nodes nodes={group.nodes} />
+      <TagGroup tags={flatten(group.nodes)} />
     </section>
   );
 }

--- a/src/components/investigation/TaxonomyCodesCard.tsx
+++ b/src/components/investigation/TaxonomyCodesCard.tsx
@@ -1,7 +1,5 @@
-import { useId, useState } from "preact/hooks";
 import { TagGroup } from "../common/TagGroup";
 import type { HierarchicalTag } from "../common/TagGroup";
-import { ChevronDownIcon, ChevronRightIcon } from "@/components/common/icons";
 import type { TaxonomyGroup, TaxoNode } from "@/services/taxonomyCodesUtils";
 import "./TaxonomyCodesCard.css";
 
@@ -47,61 +45,13 @@ function Nodes({ nodes }: { nodes: TaxoNode[] }) {
   );
 }
 
-// "Country" → "countries". Lower-cased plural for the roll-up summary pill.
-// Already-plural / sibilant labels are left alone; only the geo Country scheme
-// floods past the threshold today, so the y→ies case is the one that matters.
-function pluralLower(label: string): string {
-  const lower = label.toLowerCase();
-  if (lower.endsWith("s")) return lower;
-  if (lower.endsWith("y")) return `${lower.slice(0, -1)}ies`;
-  return `${lower}s`;
-}
-
-// A flooded scheme (appliedCount > threshold) collapses to a count toggle so it
-// reads as a summary, not a literal code; its members live in an always-mounted
-// panel revealed on click. Button + hidden panel (not a native <details>), to
-// match the FilterCard disclosure pattern and keep aria-controls stable.
-function RolledUpGroup({ group }: { group: TaxonomyGroup }) {
-  const [expanded, setExpanded] = useState(false);
-  const panelId = useId();
-  return (
-    <>
-      <button
-        type="button"
-        class="taxonomy-codes-card__rollup"
-        aria-expanded={expanded}
-        aria-controls={panelId}
-        onClick={() => setExpanded((v) => !v)}
-      >
-        <span class="taxonomy-codes-card__rollup-label">
-          Multiple {pluralLower(group.schemeLabel)} ({group.appliedCount})
-        </span>
-        <span class="taxonomy-codes-card__rollup-arrow" aria-hidden="true">
-          {expanded ? <ChevronDownIcon /> : <ChevronRightIcon />}
-        </span>
-      </button>
-      <div
-        id={panelId}
-        class="taxonomy-codes-card__rollup-panel"
-        hidden={!expanded}
-      >
-        <Nodes nodes={group.nodes} />
-      </div>
-    </>
-  );
-}
-
 function SchemeBlock({ group }: { group: TaxonomyGroup }) {
   return (
     <section class="taxonomy-codes-card__group">
       <h3 class="taxonomy-codes-card__scheme lg-section-label">
         {group.schemeLabel}
       </h3>
-      {group.rolledUp ? (
-        <RolledUpGroup group={group} />
-      ) : (
-        <Nodes nodes={group.nodes} />
-      )}
+      <Nodes nodes={group.nodes} />
     </section>
   );
 }

--- a/src/components/investigation/TaxonomyCodesCard.tsx
+++ b/src/components/investigation/TaxonomyCodesCard.tsx
@@ -1,0 +1,86 @@
+import { TagGroup } from "../common/TagGroup";
+import type { HierarchicalTag } from "../common/TagGroup";
+import type { TaxonomyGroup, TaxoNode } from "@/services/taxonomyCodesUtils";
+import "./TaxonomyCodesCard.css";
+
+interface TaxonomyCodesCardProps {
+  groups: TaxonomyGroup[];
+  vocabUnavailable?: boolean;
+}
+
+// Split one nesting level into chips (applied concepts) and sub-heading blocks
+// (non-applied ancestors). An applied node's own children are hoisted up to its
+// level, so a coded parent and its coded child both render — neither is dropped.
+function partition(nodes: readonly TaxoNode[]): {
+  tags: HierarchicalTag[];
+  subheadings: TaxoNode[];
+} {
+  const tags: HierarchicalTag[] = [];
+  const subheadings: TaxoNode[] = [];
+  for (const n of nodes) {
+    if (n.applied) {
+      tags.push({ label: n.label, definition: n.definition });
+      const hoisted = partition(n.children);
+      tags.push(...hoisted.tags);
+      subheadings.push(...hoisted.subheadings);
+    } else {
+      subheadings.push(n);
+    }
+  }
+  return { tags, subheadings };
+}
+
+function Nodes({ nodes }: { nodes: TaxoNode[] }) {
+  const { tags, subheadings } = partition(nodes);
+  return (
+    <>
+      {tags.length > 0 && <TagGroup tags={tags} />}
+      {subheadings.map((a) => (
+        <div key={a.uri} class="taxonomy-codes-card__subgroup">
+          <h4 class="taxonomy-codes-card__subheading">{a.label}</h4>
+          <Nodes nodes={a.children} />
+        </div>
+      ))}
+    </>
+  );
+}
+
+function SchemeBlock({ group }: { group: TaxonomyGroup }) {
+  const body = <Nodes nodes={group.nodes} />;
+  if (group.collapsedByDefault) {
+    return (
+      <details class="taxonomy-codes-card__group">
+        <summary class="taxonomy-codes-card__scheme">
+          {group.schemeLabel} ({group.appliedCount})
+        </summary>
+        {body}
+      </details>
+    );
+  }
+  return (
+    <section class="taxonomy-codes-card__group">
+      <h3 class="taxonomy-codes-card__scheme">{group.schemeLabel}</h3>
+      {body}
+    </section>
+  );
+}
+
+export function TaxonomyCodesCard({
+  groups,
+  vocabUnavailable = false,
+}: TaxonomyCodesCardProps) {
+  if (groups.length === 0) return null;
+  return (
+    <article class="taxonomy-codes-card lg-card">
+      <h2 class="taxonomy-codes-card__title">Taxonomy codes</h2>
+      {vocabUnavailable && (
+        <p class="taxonomy-codes-card__vocab-note" role="status">
+          Vocabulary unavailable — codes are shown as raw identifiers.
+        </p>
+      )}
+      {groups.map((g) => (
+        <SchemeBlock key={g.schemeUri} group={g} />
+      ))}
+    </article>
+  );
+}

--- a/src/components/investigation/TaxonomyCodesCard.tsx
+++ b/src/components/investigation/TaxonomyCodesCard.tsx
@@ -1,5 +1,7 @@
+import { useId, useState } from "preact/hooks";
 import { TagGroup } from "../common/TagGroup";
 import type { HierarchicalTag } from "../common/TagGroup";
+import { ChevronDownIcon, ChevronRightIcon } from "@/components/common/icons";
 import type { TaxonomyGroup, TaxoNode } from "@/services/taxonomyCodesUtils";
 import "./TaxonomyCodesCard.css";
 
@@ -55,6 +57,40 @@ function pluralLower(label: string): string {
   return `${lower}s`;
 }
 
+// A flooded scheme (appliedCount > threshold) collapses to a count toggle so it
+// reads as a summary, not a literal code; its members live in an always-mounted
+// panel revealed on click. Button + hidden panel (not a native <details>), to
+// match the FilterCard disclosure pattern and keep aria-controls stable.
+function RolledUpGroup({ group }: { group: TaxonomyGroup }) {
+  const [expanded, setExpanded] = useState(false);
+  const panelId = useId();
+  return (
+    <>
+      <button
+        type="button"
+        class="taxonomy-codes-card__rollup"
+        aria-expanded={expanded}
+        aria-controls={panelId}
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <span class="taxonomy-codes-card__rollup-label">
+          Multiple {pluralLower(group.schemeLabel)} ({group.appliedCount})
+        </span>
+        <span class="taxonomy-codes-card__rollup-arrow" aria-hidden="true">
+          {expanded ? <ChevronDownIcon /> : <ChevronRightIcon />}
+        </span>
+      </button>
+      <div
+        id={panelId}
+        class="taxonomy-codes-card__rollup-panel"
+        hidden={!expanded}
+      >
+        <Nodes nodes={group.nodes} />
+      </div>
+    </>
+  );
+}
+
 function SchemeBlock({ group }: { group: TaxonomyGroup }) {
   return (
     <section class="taxonomy-codes-card__group">
@@ -62,7 +98,7 @@ function SchemeBlock({ group }: { group: TaxonomyGroup }) {
         {group.schemeLabel}
       </h3>
       {group.rolledUp ? (
-        <TagGroup tags={[{ label: `Multiple ${pluralLower(group.schemeLabel)}` }]} />
+        <RolledUpGroup group={group} />
       ) : (
         <Nodes nodes={group.nodes} />
       )}

--- a/src/components/visualise/MapConfigPanel.tsx
+++ b/src/components/visualise/MapConfigPanel.tsx
@@ -45,12 +45,15 @@ interface AxisOption {
 function buildAxisOptions(
   schemes: ConceptScheme[],
   drafted: EvidenceMapAxis[],
+  includeCountries: boolean,
 ): AxisOption[] {
   const byValue = new Map<string, string>();
   for (const scheme of schemes) {
     byValue.set(scheme.uri, schemeDisplayLabel(scheme.label));
   }
-  byValue.set(AXIS_COUNTRIES, "Countries");
+  // Only offer Countries where the facet is populated; against an empty
+  // country facet the cross-facet query for that axis fails.
+  if (includeCountries) byValue.set(AXIS_COUNTRIES, "Countries");
   for (const axis of drafted) {
     const token = axisToken(axis);
     if (!byValue.has(token)) byValue.set(token, localName(token));
@@ -101,8 +104,8 @@ export function MapConfigPanel({
   });
 
   const options = useMemo(
-    () => buildAxisOptions(schemes, [rowDraft, columnDraft]),
-    [schemes, rowDraft, columnDraft],
+    () => buildAxisOptions(schemes, [rowDraft, columnDraft], showCountryFacetFilter),
+    [schemes, rowDraft, columnDraft, showCountryFacetFilter],
   );
 
   const draftAxes: EvidenceMapAxes = { row: rowDraft, column: columnDraft };

--- a/src/pages/RecordDetailPage.tsx
+++ b/src/pages/RecordDetailPage.tsx
@@ -16,6 +16,8 @@ import { useVocabulary } from "@/hooks/useVocabulary";
 import { useContextPrefixes } from "@/hooks/useContextPrefixes";
 import { InvestigationCard } from "@/components/investigation/InvestigationCard";
 import { FindingsSection } from "@/components/investigation/FindingsSection";
+import { TaxonomyCodesCard } from "@/components/investigation/TaxonomyCodesCard";
+import { groupAppliedConcepts } from "@/services/taxonomyCodesUtils";
 import { NotFoundPage } from "./NotFoundPage";
 import "./RecordDetailPage.css";
 
@@ -35,6 +37,8 @@ export function RecordDetailPage({ id }: RecordDetailPageProps) {
     labels,
     broader,
     definitions,
+    inScheme,
+    schemes,
     loading: vocabLoading,
     error: vocabError,
   } = useVocabulary(linkedData?.vocabulary_uri);
@@ -56,6 +60,19 @@ export function RecordDetailPage({ id }: RecordDetailPageProps) {
     return parseInvestigation(linkedData.data, prefixes, ls);
   }, [linkedData, context, labels]);
 
+  // Applied concepts grouped by scheme for the HPV Taxonomy codes card.
+  // Data-gated downstream on length > 0, so ESEA (no applied concepts) is untouched.
+  const taxonomyGroups = useMemo(
+    () =>
+      groupAppliedConcepts(
+        investigation?.appliedConcepts ?? [],
+        inScheme ?? new Map(),
+        schemes ?? [],
+        community?.geographicSchemes ?? [],
+      ),
+    [investigation, inScheme, schemes, community],
+  );
+
   // isRetracted is extracted directly from the data dict so it's available
   // even when vocabulary/context resolution fails
   const isRetracted = linkedData?.data
@@ -63,8 +80,18 @@ export function RecordDetailPage({ id }: RecordDetailPageProps) {
     : false;
 
   const hasLinkedData = linkedData !== null;
-  const vocabUnavailable =
-    hasLinkedData && !vocabLoading && !ctxLoading && (vocabError || ctxError);
+  // Don't read a transient load state as a failure.
+  const resolutionSettled = hasLinkedData && !vocabLoading && !ctxLoading;
+
+  // Full-URI concepts (HPV: hpv/Country/KE) resolve from the SKOS vocab alone, so
+  // only a vocab fetch failure leaves them unlabelled.
+  const vocabUnavailable = resolutionSettled && !!vocabError;
+
+  // CURIE-prefixed concepts (ESEA: esea:C00008) ALSO need the @context to expand
+  // the prefix before the vocab can label them, so a context failure breaks them
+  // on top of everything vocabUnavailable already covers.
+  const curieLabelsUnavailable =
+    vocabUnavailable || (resolutionSettled && !!ctxError);
 
   if (!community) return <NotFoundPage />;
 
@@ -112,11 +139,17 @@ export function RecordDetailPage({ id }: RecordDetailPageProps) {
           codingInstitution={codingInstitution}
           isRetracted={isRetracted}
           hasInvestigation={hasLinkedData}
-          vocabUnavailable={!!vocabUnavailable}
+          vocabUnavailable={curieLabelsUnavailable}
         />
+        {taxonomyGroups.length > 0 && (
+          <TaxonomyCodesCard
+            groups={taxonomyGroups}
+            vocabUnavailable={vocabUnavailable}
+          />
+        )}
         {investigation && investigation.findings.length > 0 && (
           <>
-            {vocabUnavailable && (
+            {curieLabelsUnavailable && (
               <p class="record-detail-page__vocab-banner" role="status">
                 Vocabulary unavailable — concept labels couldn't be loaded.
                 Findings below show raw concept identifiers in place of readable

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -410,7 +410,7 @@ function SearchPageInner({ community }: { community: Community }) {
               reference={ref}
               codingInstitution={community.codingInstitution}
               findingsAndEstimates={community.features.findingsAndEstimates}
-              pillExcludedSchemes={community.pillExcludedSchemes}
+              pillExcludedSchemes={community.geographicSchemes}
             />
           ))}
         </div>

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -410,7 +410,7 @@ function SearchPageInner({ community }: { community: Community }) {
               reference={ref}
               codingInstitution={community.codingInstitution}
               findingsAndEstimates={community.features.findingsAndEstimates}
-              pillExcludedSchemes={community.geographicSchemes}
+              pillExcludedSchemes={community.pillExcludedSchemes}
             />
           ))}
         </div>

--- a/src/services/communities.ts
+++ b/src/services/communities.ts
@@ -64,6 +64,7 @@ const COMMUNITIES: Community[] = [
     filterExcludedSchemes: [
       "https://vocab.esea.education/ImplementationDescriptionScheme",
     ],
+    pillExcludedSchemes: [],
     geographicSchemes: [],
     features: { ...DEFAULT_FEATURES, evidenceMap: true, exportExcel: true },
     defaultEvidenceMapAxes: {
@@ -106,6 +107,7 @@ const COMMUNITIES: Community[] = [
       import.meta.env.VITE_HPV_CONTEXT_URL,
     ),
     filterExcludedSchemes: [],
+    pillExcludedSchemes: HPV_GEO_SCHEMES,
     geographicSchemes: HPV_GEO_SCHEMES,
     features: {
       ...DEFAULT_FEATURES,

--- a/src/services/communities.ts
+++ b/src/services/communities.ts
@@ -117,11 +117,11 @@ const COMMUNITIES: Community[] = [
     defaultEvidenceMapAxes: {
       row: {
         kind: "scheme",
-        schemeUri: "https://vocab.aliveevidence.org/hpv/TargetPopulation",
+        schemeUri: "https://vocab.aliveevidence.org/hpv/WHORegion",
       },
       column: {
         kind: "scheme",
-        schemeUri: "https://vocab.aliveevidence.org/hpv/DeliveryActor",
+        schemeUri: "https://vocab.aliveevidence.org/hpv/ThematicFocusPrimary",
       },
     },
     copy: buildCopy("HPV Vaccine Delivery", {

--- a/src/services/communities.ts
+++ b/src/services/communities.ts
@@ -24,8 +24,8 @@ export const DEFAULT_FEATURES: CommunityFeatures = {
   countryFacetFilter: true,
 };
 
-// HPV geo ConceptSchemes dropped from result-card pills (#125): they swamp the
-// pill cap and geo has dedicated filters. Full scheme URIs to match inScheme.
+// The HPV geographic ConceptSchemes (country + regional/classification). Full scheme
+// URIs to match inScheme.
 const HPV_GEO_SCHEMES = [
   "https://vocab.aliveevidence.org/hpv/Country",
   "https://vocab.aliveevidence.org/hpv/CountryClassification",
@@ -64,7 +64,7 @@ const COMMUNITIES: Community[] = [
     filterExcludedSchemes: [
       "https://vocab.esea.education/ImplementationDescriptionScheme",
     ],
-    pillExcludedSchemes: [],
+    geographicSchemes: [],
     features: { ...DEFAULT_FEATURES, evidenceMap: true, exportExcel: true },
     defaultEvidenceMapAxes: {
       row: {
@@ -106,7 +106,7 @@ const COMMUNITIES: Community[] = [
       import.meta.env.VITE_HPV_CONTEXT_URL,
     ),
     filterExcludedSchemes: [],
-    pillExcludedSchemes: HPV_GEO_SCHEMES,
+    geographicSchemes: HPV_GEO_SCHEMES,
     features: {
       ...DEFAULT_FEATURES,
       evidenceMap: true,

--- a/src/services/taxonomyCodesUtils.ts
+++ b/src/services/taxonomyCodesUtils.ts
@@ -1,0 +1,140 @@
+import type {
+  Concept,
+  ConceptScheme,
+} from "@/services/vocabulary/vocabularyService";
+import { schemeDisplayLabel } from "@/services/vocabulary/vocabularyService";
+import type { ResolvedConcept } from "@/types/investigation";
+
+export interface TaxoNode {
+  uri: string;
+  label: string;
+  definition?: string;
+  // true ⇒ the record codes this concept (renders as a tag); false ⇒ an
+  // ancestor kept only to anchor a coded descendant (renders as a sub-heading).
+  applied: boolean;
+  children: TaxoNode[];
+}
+
+export interface TaxonomyGroup {
+  schemeUri: string;
+  schemeLabel: string;
+  isGeo: boolean;
+  collapsedByDefault: boolean;
+  appliedCount: number;
+  nodes: TaxoNode[];
+}
+
+const OTHER_SCHEME_URI = "__other_codes__";
+
+// Keep only branches that reach an applied concept; ancestors of an applied
+// node are retained (applied: false) so they can render as sub-headings.
+function pruneTree(
+  concepts: readonly Concept[],
+  applied: ReadonlySet<string>,
+): TaxoNode[] {
+  const out: TaxoNode[] = [];
+  for (const c of concepts) {
+    const children = pruneTree(c.narrower ?? [], applied);
+    const isApplied = applied.has(c.uri);
+    if (isApplied || children.length > 0) {
+      out.push({
+        uri: c.uri,
+        label: c.label,
+        definition: c.definition,
+        applied: isApplied,
+        children,
+      });
+    }
+  }
+  return out;
+}
+
+function collectUris(nodes: TaxoNode[], acc: Set<string>): void {
+  for (const n of nodes) {
+    acc.add(n.uri);
+    collectUris(n.children, acc);
+  }
+}
+
+export function groupAppliedConcepts(
+  applied: readonly ResolvedConcept[],
+  inScheme: Map<string, string>,
+  schemes: readonly ConceptScheme[],
+  geographicSchemes: readonly string[],
+): TaxonomyGroup[] {
+  if (applied.length === 0) return [];
+
+  const labelOf = new Map<string, string | undefined>();
+  const bySchemeUri = new Map<string, Set<string>>();
+  const knownSchemes = new Set(schemes.map((s) => s.uri));
+  const unknown = new Set<string>();
+
+  for (const c of applied) {
+    labelOf.set(c.uri, c.label);
+    const s = inScheme.get(c.uri);
+    if (s && knownSchemes.has(s)) {
+      let set = bySchemeUri.get(s);
+      if (!set) {
+        set = new Set();
+        bySchemeUri.set(s, set);
+      }
+      set.add(c.uri);
+    } else {
+      unknown.add(c.uri);
+    }
+  }
+
+  const geo = new Set(geographicSchemes);
+  const ordered: (TaxonomyGroup & { order: number })[] = [];
+
+  schemes.forEach((scheme, idx) => {
+    const appliedInScheme = bySchemeUri.get(scheme.uri);
+    if (!appliedInScheme || appliedInScheme.size === 0) return;
+    const nodes = pruneTree(scheme.topConcepts, appliedInScheme);
+    // Applied concepts the scheme tree doesn't carry (drift, or a concept coded
+    // but absent from topConcepts) still belong here — append them flat.
+    const inTree = new Set<string>();
+    collectUris(nodes, inTree);
+    for (const uri of appliedInScheme) {
+      if (!inTree.has(uri)) {
+        nodes.push({
+          uri,
+          label: labelOf.get(uri) ?? uri,
+          applied: true,
+          children: [],
+        });
+      }
+    }
+    const isGeo = geo.has(scheme.uri);
+    ordered.push({
+      schemeUri: scheme.uri,
+      schemeLabel: schemeDisplayLabel(scheme.label),
+      isGeo,
+      collapsedByDefault: isGeo,
+      appliedCount: appliedInScheme.size,
+      nodes,
+      order: idx,
+    });
+  });
+
+  // Topical (isGeo false) before geo; within each, published-vocab order.
+  ordered.sort((a, b) => Number(a.isGeo) - Number(b.isGeo) || a.order - b.order);
+  const result: TaxonomyGroup[] = ordered.map(({ order: _order, ...g }) => g);
+
+  if (unknown.size > 0) {
+    result.push({
+      schemeUri: OTHER_SCHEME_URI,
+      schemeLabel: "Other codes",
+      isGeo: false,
+      collapsedByDefault: false,
+      appliedCount: unknown.size,
+      nodes: [...unknown].map((uri) => ({
+        uri,
+        label: labelOf.get(uri) ?? uri,
+        applied: true,
+        children: [],
+      })),
+    });
+  }
+  return result;
+}

--- a/src/services/taxonomyCodesUtils.ts
+++ b/src/services/taxonomyCodesUtils.ts
@@ -18,13 +18,19 @@ export interface TaxoNode {
 export interface TaxonomyGroup {
   schemeUri: string;
   schemeLabel: string;
+  // drives ordering only (geo first); not a collapse/summary signal
   isGeo: boolean;
-  collapsedByDefault: boolean;
+  // appliedCount > ROLLUP_THRESHOLD: render one "Multiple …" summary pill
+  // instead of every member. Scheme-agnostic; only Country floods today.
+  rolledUp: boolean;
   appliedCount: number;
   nodes: TaxoNode[];
 }
 
 const OTHER_SCHEME_URI = "__other_codes__";
+
+// Largest block the mockup lists in full (Age = 10 pills); past it, summarize.
+const ROLLUP_THRESHOLD = 10;
 
 // Keep only branches that reach an applied concept; ancestors of an applied
 // node are retained (applied: false) so they can render as sub-headings.
@@ -110,15 +116,15 @@ export function groupAppliedConcepts(
       schemeUri: scheme.uri,
       schemeLabel: schemeDisplayLabel(scheme.label),
       isGeo,
-      collapsedByDefault: isGeo,
+      rolledUp: appliedInScheme.size > ROLLUP_THRESHOLD,
       appliedCount: appliedInScheme.size,
       nodes,
       order: idx,
     });
   });
 
-  // Topical (isGeo false) before geo; within each, published-vocab order.
-  ordered.sort((a, b) => Number(a.isGeo) - Number(b.isGeo) || a.order - b.order);
+  // Geo (isGeo true) before topical; within each, published-vocab order.
+  ordered.sort((a, b) => Number(b.isGeo) - Number(a.isGeo) || a.order - b.order);
   const result: TaxonomyGroup[] = ordered.map(({ order: _order, ...g }) => g);
 
   if (unknown.size > 0) {
@@ -126,7 +132,8 @@ export function groupAppliedConcepts(
       schemeUri: OTHER_SCHEME_URI,
       schemeLabel: "Other codes",
       isGeo: false,
-      collapsedByDefault: false,
+      // never rolled up: this is the drift surface, must stay fully visible
+      rolledUp: false,
       appliedCount: unknown.size,
       nodes: [...unknown].map((uri) => ({
         uri,

--- a/src/services/taxonomyCodesUtils.ts
+++ b/src/services/taxonomyCodesUtils.ts
@@ -18,19 +18,12 @@ export interface TaxoNode {
 export interface TaxonomyGroup {
   schemeUri: string;
   schemeLabel: string;
-  // drives ordering only (geo first); not a collapse/summary signal
+  // drives ordering only (geo first)
   isGeo: boolean;
-  // appliedCount > ROLLUP_THRESHOLD: render one "Multiple …" summary pill
-  // instead of every member. Scheme-agnostic; only Country floods today.
-  rolledUp: boolean;
-  appliedCount: number;
   nodes: TaxoNode[];
 }
 
 const OTHER_SCHEME_URI = "__other_codes__";
-
-// Largest block the mockup lists in full (Age = 10 pills); past it, summarize.
-const ROLLUP_THRESHOLD = 10;
 
 // Keep only branches that reach an applied concept; ancestors of an applied
 // node are retained (applied: false) so they can render as sub-headings.
@@ -116,8 +109,6 @@ export function groupAppliedConcepts(
       schemeUri: scheme.uri,
       schemeLabel: schemeDisplayLabel(scheme.label),
       isGeo,
-      rolledUp: appliedInScheme.size > ROLLUP_THRESHOLD,
-      appliedCount: appliedInScheme.size,
       nodes,
       order: idx,
     });
@@ -132,9 +123,6 @@ export function groupAppliedConcepts(
       schemeUri: OTHER_SCHEME_URI,
       schemeLabel: "Other codes",
       isGeo: false,
-      // never rolled up: this is the drift surface, must stay fully visible
-      rolledUp: false,
-      appliedCount: unknown.size,
       nodes: [...unknown].map((uri) => ({
         uri,
         label: labelOf.get(uri) ?? uri,

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -53,9 +53,10 @@ export interface Community {
   vocabularyUrl: string;
   contextUrl: string;
   filterExcludedSchemes: string[];
-  // Concept schemes dropped from result-card pills (e.g. geo). Distinct from
-  // filterExcludedSchemes (drawer): geo stays filterable, just isn't a pill.
-  pillExcludedSchemes: string[];
+  // Geographic concept schemes (country + regional/classification): excluded from
+  // result-card pills and deprioritized on the detail page. Distinct from
+  // filterExcludedSchemes — geo stays filterable in the drawer, it just isn't a pill.
+  geographicSchemes: string[];
   features: CommunityFeatures;
   // Default evidence-map axes; absent ⇒ the map shows a "not configured" notice
   // even where features.evidenceMap is on (e.g. before a vocabulary is published).

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -53,9 +53,12 @@ export interface Community {
   vocabularyUrl: string;
   contextUrl: string;
   filterExcludedSchemes: string[];
-  // Geographic concept schemes (country + regional/classification): excluded from
-  // result-card pills and deprioritized on the detail page. Distinct from
-  // filterExcludedSchemes — geo stays filterable in the drawer, it just isn't a pill.
+  // Concept schemes whose concepts are dropped from result-card pills (they stay
+  // filterable in the drawer, they just aren't pills). HPV lists its geo schemes here.
+  pillExcludedSchemes: string[];
+  // Geographic concept schemes (country + regional/classification); shown first
+  // (prioritized) on the detail page's Taxonomy codes card. Empty for communities
+  // with no geo schemes.
   geographicSchemes: string[];
   features: CommunityFeatures;
   // Default evidence-map axes; absent ⇒ the map shows a "not configured" notice

--- a/tests/components/investigation/TaxonomyCodesCard.test.tsx
+++ b/tests/components/investigation/TaxonomyCodesCard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/preact";
+import { render, screen } from "@testing-library/preact";
 import { TaxonomyCodesCard } from "@/components/investigation/TaxonomyCodesCard";
 import type { TaxonomyGroup } from "@/services/taxonomyCodesUtils";
 
@@ -7,8 +7,6 @@ const topical: TaxonomyGroup = {
   schemeUri: "s:study",
   schemeLabel: "Study Design",
   isGeo: false,
-  rolledUp: false,
-  appliedCount: 1,
   nodes: [
     {
       uri: "q",
@@ -22,19 +20,6 @@ const geo: TaxonomyGroup = {
   schemeUri: "s:country",
   schemeLabel: "Country",
   isGeo: true,
-  rolledUp: false,
-  appliedCount: 2,
-  nodes: [
-    { uri: "ke", label: "Kenya", applied: true, children: [] },
-    { uri: "ug", label: "Uganda", applied: true, children: [] },
-  ],
-};
-const flooded: TaxonomyGroup = {
-  schemeUri: "s:country",
-  schemeLabel: "Country",
-  isGeo: true,
-  rolledUp: true,
-  appliedCount: 24,
   nodes: [
     { uri: "ke", label: "Kenya", applied: true, children: [] },
     { uri: "ug", label: "Uganda", applied: true, children: [] },
@@ -67,8 +52,6 @@ describe("TaxonomyCodesCard", () => {
       schemeUri: "s:study",
       schemeLabel: "Study Design",
       isGeo: false,
-      rolledUp: false,
-      appliedCount: 2,
       nodes: [
         {
           uri: "q",
@@ -103,68 +86,24 @@ describe("TaxonomyCodesCard", () => {
     expect(screen.getByText("Uganda")).toBeInTheDocument();
   });
 
-  test("collapses a flooded group by default: a 'Multiple … (count)' toggle, members in a hidden panel", () => {
-    const { container } = render(<TaxonomyCodesCard groups={[flooded]} />);
-    expect(
-      screen.getByRole("heading", { name: "Country" }),
-    ).toBeInTheDocument();
-    const toggle = screen.getByRole("button", { name: /Multiple countries/ });
-    expect(toggle.textContent).toMatch(/Multiple countries \(24\)/);
-    expect(toggle.getAttribute("aria-expanded")).toBe("false");
-    const panel = container.querySelector<HTMLElement>(
-      ".taxonomy-codes-card__rollup-panel",
-    );
-    expect(panel?.hidden).toBe(true);
-  });
-
-  test("expands a flooded group on click, revealing its members", () => {
-    const { container } = render(<TaxonomyCodesCard groups={[flooded]} />);
-    const toggle = screen.getByRole("button", { name: /Multiple countries/ });
-    fireEvent.click(toggle);
-    expect(toggle.getAttribute("aria-expanded")).toBe("true");
-    const panel = container.querySelector<HTMLElement>(
-      ".taxonomy-codes-card__rollup-panel",
-    );
-    expect(panel?.hidden).toBe(false);
-    expect(screen.getByText("Kenya")).toBeInTheDocument();
-    expect(screen.getByText("Uganda")).toBeInTheDocument();
-  });
-
-  test("collapses a flooded group again on a second click", () => {
-    const { container } = render(<TaxonomyCodesCard groups={[flooded]} />);
-    const toggle = screen.getByRole("button", { name: /Multiple countries/ });
-    fireEvent.click(toggle);
-    fireEvent.click(toggle);
-    expect(toggle.getAttribute("aria-expanded")).toBe("false");
-    const panel = container.querySelector<HTMLElement>(
-      ".taxonomy-codes-card__rollup-panel",
-    );
-    expect(panel?.hidden).toBe(true);
-  });
-
-  test("the rollup toggle's aria-controls points at a panel present in the DOM while collapsed", () => {
-    render(<TaxonomyCodesCard groups={[flooded]} />);
-    const toggle = screen.getByRole("button", { name: /Multiple countries/ });
-    const controlsId = toggle.getAttribute("aria-controls");
-    expect(controlsId).toBeTruthy();
-    expect(document.getElementById(controlsId!)).not.toBeNull();
-  });
-
-  test("rolls a flooded topical scheme up too (geo-agnostic), pluralizing its label with a count", () => {
-    const floodedTopical: TaxonomyGroup = {
-      schemeUri: "s:outcome",
-      schemeLabel: "Outcome",
-      isGeo: false,
-      rolledUp: true,
-      appliedCount: 15,
-      nodes: [{ uri: "x", label: "Some outcome", applied: true, children: [] }],
+  test("lists every member of a large group, with no roll-up toggle", () => {
+    const labels = Array.from({ length: 12 }, (_, i) => `Country ${i}`);
+    const largeGeo: TaxonomyGroup = {
+      schemeUri: "s:country",
+      schemeLabel: "Country",
+      isGeo: true,
+      nodes: labels.map((label, i) => ({
+        uri: `c${i}`,
+        label,
+        applied: true,
+        children: [],
+      })),
     };
-    render(<TaxonomyCodesCard groups={[floodedTopical]} />);
-    const toggle = screen.getByRole("button", { name: /Multiple outcomes/ });
-    expect(toggle.textContent).toMatch(/Multiple outcomes \(15\)/);
-    fireEvent.click(toggle);
-    expect(toggle.getAttribute("aria-expanded")).toBe("true");
-    expect(screen.getByText("Some outcome")).toBeInTheDocument();
+    render(<TaxonomyCodesCard groups={[largeGeo]} />);
+    for (const label of labels) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+    expect(screen.queryByRole("button")).toBeNull();
   });
 
   test("shows the vocab-unavailable note when flagged", () => {

--- a/tests/components/investigation/TaxonomyCodesCard.test.tsx
+++ b/tests/components/investigation/TaxonomyCodesCard.test.tsx
@@ -43,11 +43,11 @@ describe("TaxonomyCodesCard", () => {
     expect(
       screen.getByRole("heading", { name: "Study Design" }),
     ).toBeInTheDocument();
-    expect(screen.getByText("Quantitative")).toBeInTheDocument(); // sub-heading
+    expect(screen.getByText("Quantitative")).toBeInTheDocument(); // breadcrumb parent
     expect(screen.getByText("RCT")).toBeInTheDocument(); // applied tag
   });
 
-  test("renders applied descendants of an applied node (does not drop them)", () => {
+  test("renders nested concepts inline as breadcrumbs, not indented sub-headings", () => {
     const nested: TaxonomyGroup = {
       schemeUri: "s:study",
       schemeLabel: "Study Design",
@@ -70,10 +70,16 @@ describe("TaxonomyCodesCard", () => {
         },
       ],
     };
-    render(<TaxonomyCodesCard groups={[nested]} />);
-    expect(screen.getByText("Quantitative")).toBeInTheDocument(); // ancestor sub-heading
-    expect(screen.getByText("RCT")).toBeInTheDocument(); // applied parent
-    expect(screen.getByText("Cluster RCT")).toBeInTheDocument(); // applied child, not dropped
+    const { container } = render(<TaxonomyCodesCard groups={[nested]} />);
+    // hierarchy is inlined like the findings cards: no indented sub-heading blocks
+    expect(container.querySelector(".taxonomy-codes-card__subgroup")).toBeNull();
+    expect(container.querySelector(".taxonomy-codes-card__subheading")).toBeNull();
+    // each coded concept is a pill carrying its immediate ancestor as a breadcrumb
+    const tags = [...container.querySelectorAll(".tag-group__tag")].map(
+      (t) => t.textContent,
+    );
+    expect(tags).toContain("Quantitative › RCT"); // non-applied ancestor as breadcrumb
+    expect(tags).toContain("RCT › Cluster RCT"); // applied child not dropped
   });
 
   test("renders a geo group expanded (no <details>) listing its members", () => {

--- a/tests/components/investigation/TaxonomyCodesCard.test.tsx
+++ b/tests/components/investigation/TaxonomyCodesCard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { render, screen } from "@testing-library/preact";
+import { render, screen, fireEvent } from "@testing-library/preact";
 import { TaxonomyCodesCard } from "@/components/investigation/TaxonomyCodesCard";
 import type { TaxonomyGroup } from "@/services/taxonomyCodesUtils";
 
@@ -103,17 +103,54 @@ describe("TaxonomyCodesCard", () => {
     expect(screen.getByText("Uganda")).toBeInTheDocument();
   });
 
-  test("rolls a flooded group up to a single 'Multiple …' pill, hiding members", () => {
-    render(<TaxonomyCodesCard groups={[flooded]} />);
+  test("collapses a flooded group by default: a 'Multiple … (count)' toggle, members in a hidden panel", () => {
+    const { container } = render(<TaxonomyCodesCard groups={[flooded]} />);
     expect(
       screen.getByRole("heading", { name: "Country" }),
     ).toBeInTheDocument();
-    expect(screen.getByText("Multiple countries")).toBeInTheDocument();
-    expect(screen.queryByText("Kenya")).toBeNull();
-    expect(screen.queryByText("Uganda")).toBeNull();
+    const toggle = screen.getByRole("button", { name: /Multiple countries/ });
+    expect(toggle.textContent).toMatch(/Multiple countries \(24\)/);
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    const panel = container.querySelector<HTMLElement>(
+      ".taxonomy-codes-card__rollup-panel",
+    );
+    expect(panel?.hidden).toBe(true);
   });
 
-  test("rolls a flooded topical scheme up too (geo-agnostic), pluralizing its label", () => {
+  test("expands a flooded group on click, revealing its members", () => {
+    const { container } = render(<TaxonomyCodesCard groups={[flooded]} />);
+    const toggle = screen.getByRole("button", { name: /Multiple countries/ });
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    const panel = container.querySelector<HTMLElement>(
+      ".taxonomy-codes-card__rollup-panel",
+    );
+    expect(panel?.hidden).toBe(false);
+    expect(screen.getByText("Kenya")).toBeInTheDocument();
+    expect(screen.getByText("Uganda")).toBeInTheDocument();
+  });
+
+  test("collapses a flooded group again on a second click", () => {
+    const { container } = render(<TaxonomyCodesCard groups={[flooded]} />);
+    const toggle = screen.getByRole("button", { name: /Multiple countries/ });
+    fireEvent.click(toggle);
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    const panel = container.querySelector<HTMLElement>(
+      ".taxonomy-codes-card__rollup-panel",
+    );
+    expect(panel?.hidden).toBe(true);
+  });
+
+  test("the rollup toggle's aria-controls points at a panel present in the DOM while collapsed", () => {
+    render(<TaxonomyCodesCard groups={[flooded]} />);
+    const toggle = screen.getByRole("button", { name: /Multiple countries/ });
+    const controlsId = toggle.getAttribute("aria-controls");
+    expect(controlsId).toBeTruthy();
+    expect(document.getElementById(controlsId!)).not.toBeNull();
+  });
+
+  test("rolls a flooded topical scheme up too (geo-agnostic), pluralizing its label with a count", () => {
     const floodedTopical: TaxonomyGroup = {
       schemeUri: "s:outcome",
       schemeLabel: "Outcome",
@@ -123,8 +160,11 @@ describe("TaxonomyCodesCard", () => {
       nodes: [{ uri: "x", label: "Some outcome", applied: true, children: [] }],
     };
     render(<TaxonomyCodesCard groups={[floodedTopical]} />);
-    expect(screen.getByText("Multiple outcomes")).toBeInTheDocument();
-    expect(screen.queryByText("Some outcome")).toBeNull();
+    const toggle = screen.getByRole("button", { name: /Multiple outcomes/ });
+    expect(toggle.textContent).toMatch(/Multiple outcomes \(15\)/);
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByText("Some outcome")).toBeInTheDocument();
   });
 
   test("shows the vocab-unavailable note when flagged", () => {

--- a/tests/components/investigation/TaxonomyCodesCard.test.tsx
+++ b/tests/components/investigation/TaxonomyCodesCard.test.tsx
@@ -7,7 +7,7 @@ const topical: TaxonomyGroup = {
   schemeUri: "s:study",
   schemeLabel: "Study Design",
   isGeo: false,
-  collapsedByDefault: false,
+  rolledUp: false,
   appliedCount: 1,
   nodes: [
     {
@@ -22,8 +22,19 @@ const geo: TaxonomyGroup = {
   schemeUri: "s:country",
   schemeLabel: "Country",
   isGeo: true,
-  collapsedByDefault: true,
+  rolledUp: false,
   appliedCount: 2,
+  nodes: [
+    { uri: "ke", label: "Kenya", applied: true, children: [] },
+    { uri: "ug", label: "Uganda", applied: true, children: [] },
+  ],
+};
+const flooded: TaxonomyGroup = {
+  schemeUri: "s:country",
+  schemeLabel: "Country",
+  isGeo: true,
+  rolledUp: true,
+  appliedCount: 24,
   nodes: [
     { uri: "ke", label: "Kenya", applied: true, children: [] },
     { uri: "ug", label: "Uganda", applied: true, children: [] },
@@ -56,7 +67,7 @@ describe("TaxonomyCodesCard", () => {
       schemeUri: "s:study",
       schemeLabel: "Study Design",
       isGeo: false,
-      collapsedByDefault: false,
+      rolledUp: false,
       appliedCount: 2,
       nodes: [
         {
@@ -82,13 +93,38 @@ describe("TaxonomyCodesCard", () => {
     expect(screen.getByText("Cluster RCT")).toBeInTheDocument(); // applied child, not dropped
   });
 
-  test("renders a geo group as a collapsed details with a count summary", () => {
+  test("renders a geo group expanded (no <details>) listing its members", () => {
     const { container } = render(<TaxonomyCodesCard groups={[geo]} />);
-    const details = container.querySelector("details");
-    expect(details).not.toBeNull();
-    expect(details!.open).toBe(false);
-    expect(screen.getByText("Country (2)")).toBeInTheDocument();
+    expect(container.querySelector("details")).toBeNull();
+    expect(
+      screen.getByRole("heading", { name: "Country" }),
+    ).toBeInTheDocument();
     expect(screen.getByText("Kenya")).toBeInTheDocument();
+    expect(screen.getByText("Uganda")).toBeInTheDocument();
+  });
+
+  test("rolls a flooded group up to a single 'Multiple …' pill, hiding members", () => {
+    render(<TaxonomyCodesCard groups={[flooded]} />);
+    expect(
+      screen.getByRole("heading", { name: "Country" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Multiple countries")).toBeInTheDocument();
+    expect(screen.queryByText("Kenya")).toBeNull();
+    expect(screen.queryByText("Uganda")).toBeNull();
+  });
+
+  test("rolls a flooded topical scheme up too (geo-agnostic), pluralizing its label", () => {
+    const floodedTopical: TaxonomyGroup = {
+      schemeUri: "s:outcome",
+      schemeLabel: "Outcome",
+      isGeo: false,
+      rolledUp: true,
+      appliedCount: 15,
+      nodes: [{ uri: "x", label: "Some outcome", applied: true, children: [] }],
+    };
+    render(<TaxonomyCodesCard groups={[floodedTopical]} />);
+    expect(screen.getByText("Multiple outcomes")).toBeInTheDocument();
+    expect(screen.queryByText("Some outcome")).toBeNull();
   });
 
   test("shows the vocab-unavailable note when flagged", () => {

--- a/tests/components/investigation/TaxonomyCodesCard.test.tsx
+++ b/tests/components/investigation/TaxonomyCodesCard.test.tsx
@@ -1,0 +1,100 @@
+import { describe, test, expect } from "vitest";
+import { render, screen } from "@testing-library/preact";
+import { TaxonomyCodesCard } from "@/components/investigation/TaxonomyCodesCard";
+import type { TaxonomyGroup } from "@/services/taxonomyCodesUtils";
+
+const topical: TaxonomyGroup = {
+  schemeUri: "s:study",
+  schemeLabel: "Study Design",
+  isGeo: false,
+  collapsedByDefault: false,
+  appliedCount: 1,
+  nodes: [
+    {
+      uri: "q",
+      label: "Quantitative",
+      applied: false,
+      children: [{ uri: "rct", label: "RCT", applied: true, children: [] }],
+    },
+  ],
+};
+const geo: TaxonomyGroup = {
+  schemeUri: "s:country",
+  schemeLabel: "Country",
+  isGeo: true,
+  collapsedByDefault: true,
+  appliedCount: 2,
+  nodes: [
+    { uri: "ke", label: "Kenya", applied: true, children: [] },
+    { uri: "ug", label: "Uganda", applied: true, children: [] },
+  ],
+};
+
+describe("TaxonomyCodesCard", () => {
+  test("returns null when there are no groups", () => {
+    const { container } = render(<TaxonomyCodesCard groups={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("renders the lg-card chrome, card title, and a topical scheme heading + tag", () => {
+    const { container } = render(<TaxonomyCodesCard groups={[topical]} />);
+    expect(
+      container.querySelector("article.taxonomy-codes-card.lg-card"),
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("heading", { name: "Taxonomy codes" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Study Design" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Quantitative")).toBeInTheDocument(); // sub-heading
+    expect(screen.getByText("RCT")).toBeInTheDocument(); // applied tag
+  });
+
+  test("renders applied descendants of an applied node (does not drop them)", () => {
+    const nested: TaxonomyGroup = {
+      schemeUri: "s:study",
+      schemeLabel: "Study Design",
+      isGeo: false,
+      collapsedByDefault: false,
+      appliedCount: 2,
+      nodes: [
+        {
+          uri: "q",
+          label: "Quantitative",
+          applied: false,
+          children: [
+            {
+              uri: "rct",
+              label: "RCT",
+              applied: true,
+              children: [
+                { uri: "crct", label: "Cluster RCT", applied: true, children: [] },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    render(<TaxonomyCodesCard groups={[nested]} />);
+    expect(screen.getByText("Quantitative")).toBeInTheDocument(); // ancestor sub-heading
+    expect(screen.getByText("RCT")).toBeInTheDocument(); // applied parent
+    expect(screen.getByText("Cluster RCT")).toBeInTheDocument(); // applied child, not dropped
+  });
+
+  test("renders a geo group as a collapsed details with a count summary", () => {
+    const { container } = render(<TaxonomyCodesCard groups={[geo]} />);
+    const details = container.querySelector("details");
+    expect(details).not.toBeNull();
+    expect(details!.open).toBe(false);
+    expect(screen.getByText("Country (2)")).toBeInTheDocument();
+    expect(screen.getByText("Kenya")).toBeInTheDocument();
+  });
+
+  test("shows the vocab-unavailable note when flagged", () => {
+    render(<TaxonomyCodesCard groups={[topical]} vocabUnavailable />);
+    expect(screen.getByRole("status").textContent).toMatch(
+      /Vocabulary unavailable/,
+    );
+  });
+});

--- a/tests/components/visualise/MapConfigPanel.test.tsx
+++ b/tests/components/visualise/MapConfigPanel.test.tsx
@@ -72,6 +72,20 @@ describe("MapConfigPanel", () => {
     expect(row.getByRole("option", { name: "Countries" })).toBeInTheDocument();
   });
 
+  test("omits the Countries axis option where the country facet is unsupported", () => {
+    renderPanel({ showCountryFacetFilter: false });
+    // Scheme axes are still offered...
+    const row = within(rowSelect());
+    expect(row.getByRole("option", { name: "Outcome" })).toBeInTheDocument();
+    expect(row.getByRole("option", { name: "Document type" })).toBeInTheDocument();
+    // ...but Countries is gone: with an empty country facet a Countries-axis
+    // map issues a cross-facet query against a missing facet and fails.
+    expect(row.queryByRole("option", { name: "Countries" })).toBeNull();
+    expect(
+      within(columnSelect()).queryByRole("option", { name: "Countries" }),
+    ).toBeNull();
+  });
+
   test("sorts the dropdown options alphabetically by label", () => {
     renderPanel();
     const labels = within(rowSelect())

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -55,7 +55,7 @@ export function makeCommunity(
     vocabularyUrl: "https://vocab.example/v1",
     contextUrl: "https://vocab.example/ctx",
     filterExcludedSchemes: [],
-    pillExcludedSchemes: [],
+    geographicSchemes: [],
     features: {
       evidenceMap: false,
       selfSignup: false,

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -55,6 +55,7 @@ export function makeCommunity(
     vocabularyUrl: "https://vocab.example/v1",
     contextUrl: "https://vocab.example/ctx",
     filterExcludedSchemes: [],
+    pillExcludedSchemes: [],
     geographicSchemes: [],
     features: {
       evidenceMap: false,

--- a/tests/pages/RecordDetailPage.integration.test.tsx
+++ b/tests/pages/RecordDetailPage.integration.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/preact";
 import { RecordDetailPage } from "@/pages/RecordDetailPage";
 import { CommunityProvider } from "@/community/CommunityContext";
 import { makeReference, makeVocabResult } from "../fixtures";
+import type { ConceptScheme } from "@/services/vocabulary/vocabularyService";
 
 function renderRecordDetail(id: string) {
   return render(
@@ -32,6 +33,11 @@ const PREFIXES = new Map([
 const mockLabels = new Map([
   ["https://vocab.esea.education/C00008", "Journal Article"],
 ]);
+
+const HPV_COUNTRY = "https://vocab.aliveevidence.org/hpv/Country";
+// A non-geographic (topical) scheme. Deliberately a placeholder, not a real HPV
+// scheme, so it can't read as standing in for a specific concept or map axis.
+const NON_GEO_SCHEME = "https://vocab.aliveevidence.org/hpv/NonGeoScheme";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -204,5 +210,179 @@ describe("RecordDetailPage", () => {
     expect(screen.getByText("Bibliographic Only")).toBeDefined();
     expect(screen.getByText("Jones, K. (2023)")).toBeDefined();
     expect(screen.queryByText("Doc Type")).toBeNull();
+  });
+
+  test("HPV record renders the Taxonomy codes card, geo first and expanded, no findings", () => {
+    history.replaceState(null, "", "/hpv");
+    mockUseReference.mockReturnValue({
+      reference: makeReference({
+        bibliographic: { title: "HPV ref" },
+        investigation: {
+          hasAppliedConcept: [
+            { "@id": NON_GEO_SCHEME + "/concept" },
+            { "@id": HPV_COUNTRY + "/KE" },
+          ],
+        },
+      }),
+      loading: false,
+      error: null,
+    });
+    const schemes: ConceptScheme[] = [
+      {
+        uri: NON_GEO_SCHEME,
+        label: "Topical Focus",
+        topConcepts: [{ uri: NON_GEO_SCHEME + "/concept", label: "Sample Concept" }],
+      },
+      {
+        uri: HPV_COUNTRY,
+        label: "Country",
+        topConcepts: [{ uri: HPV_COUNTRY + "/KE", label: "Kenya" }],
+      },
+    ];
+    mockUseVocabulary.mockReturnValue(
+      makeVocabResult({
+        labels: new Map([
+          [NON_GEO_SCHEME + "/concept", "Sample Concept"],
+          [HPV_COUNTRY + "/KE", "Kenya"],
+        ]),
+        inScheme: new Map([
+          [NON_GEO_SCHEME + "/concept", NON_GEO_SCHEME],
+          [HPV_COUNTRY + "/KE", HPV_COUNTRY],
+        ]),
+        schemes,
+      }),
+    );
+    mockUseContextPrefixes.mockReturnValue({
+      context: { prefixes: new Map() },
+      loading: false,
+      error: null,
+    });
+
+    renderRecordDetail("abc");
+    expect(
+      screen.getByRole("heading", { name: "Taxonomy codes" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Topical Focus" }),
+    ).toBeInTheDocument(); // topical
+    expect(
+      screen.getByRole("heading", { name: "Country" }),
+    ).toBeInTheDocument(); // geo, expanded (1 code, below roll-up threshold)
+    expect(screen.getByText("Kenya")).toBeInTheDocument(); // geo member listed, not rolled up
+    expect(screen.getByText("Sample Concept")).toBeInTheDocument(); // topical member
+    expect(screen.queryByText("Finding 1")).toBeNull();
+  });
+
+  test("ESEA record (no appliedConcepts) renders no Taxonomy codes card", () => {
+    history.replaceState(null, "", "/esea");
+    mockUseReference.mockReturnValue({
+      reference: makeReference({
+        bibliographic: { title: "ESEA ref" },
+        investigation: { hasFinding: [] },
+      }),
+      loading: false,
+      error: null,
+    });
+    renderRecordDetail("abc");
+    expect(screen.getByText("ESEA ref")).toBeInTheDocument();
+    expect(screen.queryByText("Taxonomy codes")).toBeNull();
+  });
+
+  // Data-gated, not community-gated: any community with applied concepts gets the
+  // card. ESEA has none today; that's data, not a gate.
+  test("ESEA record with appliedConcepts renders the card too (data-gated, not community-gated)", () => {
+    history.replaceState(null, "", "/esea");
+    const ESEA_SCHEME = "https://vocab.esea.education/EducationTheme";
+    mockUseReference.mockReturnValue({
+      reference: makeReference({
+        bibliographic: { title: "ESEA coded ref" },
+        investigation: {
+          hasAppliedConcept: [{ "@id": ESEA_SCHEME + "/concept" }],
+        },
+      }),
+      loading: false,
+      error: null,
+    });
+    const schemes: ConceptScheme[] = [
+      {
+        uri: ESEA_SCHEME,
+        label: "Education Theme",
+        topConcepts: [{ uri: ESEA_SCHEME + "/concept", label: "Numeracy" }],
+      },
+    ];
+    mockUseVocabulary.mockReturnValue(
+      makeVocabResult({
+        labels: new Map([[ESEA_SCHEME + "/concept", "Numeracy"]]),
+        inScheme: new Map([[ESEA_SCHEME + "/concept", ESEA_SCHEME]]),
+        schemes,
+      }),
+    );
+    mockUseContextPrefixes.mockReturnValue({
+      context: { prefixes: new Map() },
+      loading: false,
+      error: null,
+    });
+    renderRecordDetail("abc");
+    expect(
+      screen.getByRole("heading", { name: "Taxonomy codes" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Numeracy")).toBeInTheDocument();
+  });
+
+  test("HPV bibliographic-only record (no codes) renders no Taxonomy codes card", () => {
+    history.replaceState(null, "", "/hpv");
+    mockUseReference.mockReturnValue({
+      reference: makeReference({ bibliographic: { title: "Shell" } }),
+      loading: false,
+      error: null,
+    });
+    renderRecordDetail("abc");
+    expect(screen.getByText("Shell")).toBeInTheDocument();
+    expect(screen.queryByText("Taxonomy codes")).toBeNull();
+  });
+
+  test("HPV record with context-only failure resolves labels and shows no raw-identifier note", () => {
+    history.replaceState(null, "", "/hpv");
+    mockUseReference.mockReturnValue({
+      reference: makeReference({
+        bibliographic: { title: "HPV ctx-fail ref" },
+        investigation: {
+          hasAppliedConcept: [{ "@id": NON_GEO_SCHEME + "/concept" }],
+        },
+      }),
+      loading: false,
+      error: null,
+    });
+    const schemes: ConceptScheme[] = [
+      {
+        uri: NON_GEO_SCHEME,
+        label: "Topical Focus",
+        topConcepts: [{ uri: NON_GEO_SCHEME + "/concept", label: "Sample Concept" }],
+      },
+    ];
+    mockUseVocabulary.mockReturnValue(
+      makeVocabResult({
+        labels: new Map([[NON_GEO_SCHEME + "/concept", "Sample Concept"]]),
+        inScheme: new Map([[NON_GEO_SCHEME + "/concept", NON_GEO_SCHEME]]),
+        schemes,
+        // vocab loaded fine — only context (prefixes) fails below
+      }),
+    );
+    mockUseContextPrefixes.mockReturnValue({
+      context: null,
+      loading: false,
+      error: new Error("context fetch failed"),
+    });
+
+    renderRecordDetail("abc");
+    // HPV concepts are full URIs, so they resolve without the context/prefixes.
+    expect(
+      screen.getByRole("heading", { name: "Taxonomy codes" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Sample Concept")).toBeInTheDocument();
+    // Context-only failure must NOT trip the card's raw-identifier note.
+    expect(
+      screen.queryByText(/codes are shown as raw identifiers/),
+    ).toBeNull();
   });
 });

--- a/tests/services/communities.test.ts
+++ b/tests/services/communities.test.ts
@@ -107,4 +107,14 @@ describe("communities", () => {
       ]),
     );
   });
+
+  it("excludes the HPV geographic schemes from result-card pills, none for ESEA", async () => {
+    const { findCommunity } = await import("@/services/communities");
+    expect(findCommunity("esea")?.pillExcludedSchemes).toEqual([]);
+    const hpv = findCommunity("hpv");
+    // HPV drops its geo schemes from pills; same set as geographicSchemes today,
+    // but a distinct field so the pill-exclusion intent is explicit in config.
+    expect(hpv?.pillExcludedSchemes).toEqual(hpv?.geographicSchemes);
+    expect(hpv?.pillExcludedSchemes).toHaveLength(5);
+  });
 });

--- a/tests/services/communities.test.ts
+++ b/tests/services/communities.test.ts
@@ -78,12 +78,12 @@ describe("communities", () => {
     expect(findCommunity("hpv")?.features.countryFacetFilter).toBe(false);
   });
 
-  it("excludes exactly the 5 HPV geo schemes from card pills, none for ESEA", async () => {
+  it("declares exactly the 5 HPV geographic schemes, none for ESEA", async () => {
     const { findCommunity } = await import("@/services/communities");
-    expect(findCommunity("esea")?.pillExcludedSchemes).toEqual([]);
-    const hpvExcluded = findCommunity("hpv")?.pillExcludedSchemes ?? [];
-    expect(hpvExcluded).toHaveLength(5);
-    expect(hpvExcluded).toEqual(
+    expect(findCommunity("esea")?.geographicSchemes).toEqual([]);
+    const hpvGeo = findCommunity("hpv")?.geographicSchemes ?? [];
+    expect(hpvGeo).toHaveLength(5);
+    expect(hpvGeo).toEqual(
       expect.arrayContaining([
         "https://vocab.aliveevidence.org/hpv/Country",
         "https://vocab.aliveevidence.org/hpv/CountryClassification",

--- a/tests/services/communities.test.ts
+++ b/tests/services/communities.test.ts
@@ -78,6 +78,20 @@ describe("communities", () => {
     expect(findCommunity("hpv")?.features.countryFacetFilter).toBe(false);
   });
 
+  it("defaults HPV's evidence map to WHO Region rows x Thematic Focus — Primary columns", async () => {
+    const { findCommunity } = await import("@/services/communities");
+    expect(findCommunity("hpv")?.defaultEvidenceMapAxes).toEqual({
+      row: {
+        kind: "scheme",
+        schemeUri: "https://vocab.aliveevidence.org/hpv/WHORegion",
+      },
+      column: {
+        kind: "scheme",
+        schemeUri: "https://vocab.aliveevidence.org/hpv/ThematicFocusPrimary",
+      },
+    });
+  });
+
   it("declares exactly the 5 HPV geographic schemes, none for ESEA", async () => {
     const { findCommunity } = await import("@/services/communities");
     expect(findCommunity("esea")?.geographicSchemes).toEqual([]);

--- a/tests/services/taxonomyCodesUtils.test.ts
+++ b/tests/services/taxonomyCodesUtils.test.ts
@@ -1,0 +1,146 @@
+import { describe, test, expect } from "vitest";
+import { groupAppliedConcepts } from "@/services/taxonomyCodesUtils";
+import type { ConceptScheme } from "@/services/vocabulary/vocabularyService";
+
+const TARGET = "https://v/TargetPopulation";
+const STUDY = "https://v/StudyDesign";
+const COUNTRY = "https://v/Country";
+
+const schemes: ConceptScheme[] = [
+  {
+    uri: TARGET,
+    label: "Target Population",
+    topConcepts: [
+      {
+        uri: "tp:adult",
+        label: "Adults",
+        narrower: [{ uri: "tp:21plus", label: "21+ years" }],
+      },
+    ],
+  },
+  {
+    uri: STUDY,
+    label: "Study Design Scheme",
+    topConcepts: [
+      {
+        uri: "sd:quant",
+        label: "Quantitative",
+        narrower: [
+          {
+            uri: "sd:rct",
+            label: "RCT",
+            narrower: [{ uri: "sd:crct", label: "Cluster RCT" }],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    uri: COUNTRY,
+    label: "Country",
+    topConcepts: [
+      { uri: "c:KE", label: "Kenya" },
+      { uri: "c:UG", label: "Uganda" },
+    ],
+  },
+];
+
+const inScheme = new Map<string, string>([
+  ["tp:21plus", TARGET],
+  ["sd:rct", STUDY],
+  ["sd:crct", STUDY],
+  ["c:KE", COUNTRY],
+  ["c:UG", COUNTRY],
+]);
+
+const GEO = [COUNTRY];
+
+const applied = (...uris: string[]) =>
+  uris.map((uri) => ({ uri, label: undefined }));
+
+describe("groupAppliedConcepts", () => {
+  test("returns [] for no applied concepts", () => {
+    expect(groupAppliedConcepts([], inScheme, schemes, GEO)).toEqual([]);
+  });
+
+  test("orders topical first then geo; geo is collapsedByDefault with a count", () => {
+    const g = groupAppliedConcepts(
+      applied("tp:21plus", "c:KE", "c:UG"),
+      inScheme,
+      schemes,
+      GEO,
+    );
+    expect(g.map((x) => x.schemeLabel)).toEqual(["Target Population", "Country"]);
+    const country = g[1];
+    expect(country.isGeo).toBe(true);
+    expect(country.collapsedByDefault).toBe(true);
+    expect(country.appliedCount).toBe(2);
+    expect(g[0].collapsedByDefault).toBe(false);
+  });
+
+  test("strips a trailing 'Scheme' from the label", () => {
+    expect(
+      groupAppliedConcepts(applied("sd:crct"), inScheme, schemes, GEO)[0]
+        .schemeLabel,
+    ).toBe("Study Design");
+  });
+
+  test("nests applied concepts under ancestor sub-headings to depth 2", () => {
+    const [study] = groupAppliedConcepts(
+      applied("sd:crct"),
+      inScheme,
+      schemes,
+      GEO,
+    );
+    const quant = study.nodes[0];
+    expect(quant).toMatchObject({ label: "Quantitative", applied: false });
+    const rct = quant.children[0];
+    expect(rct).toMatchObject({ label: "RCT", applied: false });
+    expect(rct.children[0]).toMatchObject({
+      label: "Cluster RCT",
+      applied: true,
+      children: [],
+    });
+  });
+
+  test("marks a parent applied when both it and a descendant are coded", () => {
+    const [study] = groupAppliedConcepts(
+      applied("sd:rct", "sd:crct"),
+      inScheme,
+      schemes,
+      GEO,
+    );
+    const rct = study.nodes[0].children[0];
+    expect(rct.applied).toBe(true);
+    expect(rct.children[0].applied).toBe(true);
+  });
+
+  test("unknown-scheme / scheme-level codes go to a trailing 'Other codes' group", () => {
+    const g = groupAppliedConcepts(
+      applied("tp:21plus", "https://v/mystery/X"),
+      inScheme,
+      schemes,
+      GEO,
+    );
+    expect(g[g.length - 1]).toMatchObject({
+      schemeLabel: "Other codes",
+      appliedCount: 1,
+    });
+  });
+
+  test("appends applied concepts absent from the scheme tree as flat nodes", () => {
+    const im = new Map(inScheme).set("tp:orphan", TARGET);
+    const [tp] = groupAppliedConcepts(
+      [{ uri: "tp:orphan", label: "Orphan" }],
+      im,
+      schemes,
+      GEO,
+    );
+    expect(tp.nodes).toContainEqual({
+      uri: "tp:orphan",
+      label: "Orphan",
+      applied: true,
+      children: [],
+    });
+  });
+});

--- a/tests/services/taxonomyCodesUtils.test.ts
+++ b/tests/services/taxonomyCodesUtils.test.ts
@@ -58,7 +58,7 @@ const GEO = [COUNTRY];
 const applied = (...uris: string[]) =>
   uris.map((uri) => ({ uri, label: undefined }));
 
-// A single-scheme fixture with `n` leaf codes, for exercising the roll-up threshold.
+// A single-scheme fixture with `n` leaf codes.
 const schemeWithCodes = (uri: string, label: string, n: number) => {
   const codes = Array.from({ length: n }, (_, i) => `${uri}#${i}`);
   const scheme: ConceptScheme = {
@@ -75,7 +75,7 @@ describe("groupAppliedConcepts", () => {
     expect(groupAppliedConcepts([], inScheme, schemes, GEO)).toEqual([]);
   });
 
-  test("orders geo first then topical; small groups are not rolled up", () => {
+  test("orders geo first then topical", () => {
     const g = groupAppliedConcepts(
       applied("tp:21plus", "c:KE", "c:UG"),
       inScheme,
@@ -83,12 +83,8 @@ describe("groupAppliedConcepts", () => {
       GEO,
     );
     expect(g.map((x) => x.schemeLabel)).toEqual(["Country", "Target Population"]);
-    const country = g[0];
-    expect(country.isGeo).toBe(true);
-    expect(country.appliedCount).toBe(2);
-    expect(country.rolledUp).toBe(false);
+    expect(g[0].isGeo).toBe(true);
     expect(g[1].isGeo).toBe(false);
-    expect(g[1].rolledUp).toBe(false);
   });
 
   test("strips a trailing 'Scheme' from the label", () => {
@@ -135,49 +131,20 @@ describe("groupAppliedConcepts", () => {
       schemes,
       GEO,
     );
-    expect(g[g.length - 1]).toMatchObject({
-      schemeLabel: "Other codes",
-      appliedCount: 1,
-    });
-  });
-
-  test("rolls up any group with more than 10 applied codes, geo or not", () => {
-    const { codes, scheme, inScheme } = schemeWithCodes(
-      TARGET,
-      "Target Population",
-      11,
-    );
-    const [g] = groupAppliedConcepts(applied(...codes), inScheme, [scheme], GEO);
-    expect(g.isGeo).toBe(false);
-    expect(g.appliedCount).toBe(11);
-    expect(g.rolledUp).toBe(true);
-  });
-
-  test("does not roll up a group sitting exactly at the threshold of 10", () => {
-    const { codes, scheme, inScheme } = schemeWithCodes(
-      TARGET,
-      "Target Population",
-      10,
-    );
-    const [g] = groupAppliedConcepts(applied(...codes), inScheme, [scheme], GEO);
-    expect(g.appliedCount).toBe(10);
-    expect(g.rolledUp).toBe(false);
-  });
-
-  test("rolls up the geo Country scheme once it floods past the threshold", () => {
-    const { codes, scheme, inScheme } = schemeWithCodes(COUNTRY, "Country", 12);
-    const [g] = groupAppliedConcepts(applied(...codes), inScheme, [scheme], GEO);
-    expect(g.isGeo).toBe(true);
-    expect(g.rolledUp).toBe(true);
-  });
-
-  test("never rolls up the 'Other codes' bucket, so drift stays visible", () => {
-    const { codes, inScheme } = schemeWithCodes("https://v/unknown", "X", 12);
-    const g = groupAppliedConcepts(applied(...codes), inScheme, schemes, GEO);
     const other = g[g.length - 1];
     expect(other.schemeLabel).toBe("Other codes");
-    expect(other.appliedCount).toBe(12);
-    expect(other.rolledUp).toBe(false);
+    expect(other.nodes).toHaveLength(1);
+  });
+
+  test("lists every member of a large group (no summarization)", () => {
+    const { codes, scheme, inScheme } = schemeWithCodes(
+      COUNTRY,
+      "Country",
+      30,
+    );
+    const [g] = groupAppliedConcepts(applied(...codes), inScheme, [scheme], GEO);
+    expect(g.isGeo).toBe(true);
+    expect(g.nodes).toHaveLength(30);
   });
 
   test("appends applied concepts absent from the scheme tree as flat nodes", () => {

--- a/tests/services/taxonomyCodesUtils.test.ts
+++ b/tests/services/taxonomyCodesUtils.test.ts
@@ -58,24 +58,37 @@ const GEO = [COUNTRY];
 const applied = (...uris: string[]) =>
   uris.map((uri) => ({ uri, label: undefined }));
 
+// A single-scheme fixture with `n` leaf codes, for exercising the roll-up threshold.
+const schemeWithCodes = (uri: string, label: string, n: number) => {
+  const codes = Array.from({ length: n }, (_, i) => `${uri}#${i}`);
+  const scheme: ConceptScheme = {
+    uri,
+    label,
+    topConcepts: codes.map((u) => ({ uri: u, label: u })),
+  };
+  const inScheme = new Map(codes.map((u) => [u, uri] as const));
+  return { codes, scheme, inScheme };
+};
+
 describe("groupAppliedConcepts", () => {
   test("returns [] for no applied concepts", () => {
     expect(groupAppliedConcepts([], inScheme, schemes, GEO)).toEqual([]);
   });
 
-  test("orders topical first then geo; geo is collapsedByDefault with a count", () => {
+  test("orders geo first then topical; small groups are not rolled up", () => {
     const g = groupAppliedConcepts(
       applied("tp:21plus", "c:KE", "c:UG"),
       inScheme,
       schemes,
       GEO,
     );
-    expect(g.map((x) => x.schemeLabel)).toEqual(["Target Population", "Country"]);
-    const country = g[1];
+    expect(g.map((x) => x.schemeLabel)).toEqual(["Country", "Target Population"]);
+    const country = g[0];
     expect(country.isGeo).toBe(true);
-    expect(country.collapsedByDefault).toBe(true);
     expect(country.appliedCount).toBe(2);
-    expect(g[0].collapsedByDefault).toBe(false);
+    expect(country.rolledUp).toBe(false);
+    expect(g[1].isGeo).toBe(false);
+    expect(g[1].rolledUp).toBe(false);
   });
 
   test("strips a trailing 'Scheme' from the label", () => {
@@ -126,6 +139,45 @@ describe("groupAppliedConcepts", () => {
       schemeLabel: "Other codes",
       appliedCount: 1,
     });
+  });
+
+  test("rolls up any group with more than 10 applied codes, geo or not", () => {
+    const { codes, scheme, inScheme } = schemeWithCodes(
+      TARGET,
+      "Target Population",
+      11,
+    );
+    const [g] = groupAppliedConcepts(applied(...codes), inScheme, [scheme], GEO);
+    expect(g.isGeo).toBe(false);
+    expect(g.appliedCount).toBe(11);
+    expect(g.rolledUp).toBe(true);
+  });
+
+  test("does not roll up a group sitting exactly at the threshold of 10", () => {
+    const { codes, scheme, inScheme } = schemeWithCodes(
+      TARGET,
+      "Target Population",
+      10,
+    );
+    const [g] = groupAppliedConcepts(applied(...codes), inScheme, [scheme], GEO);
+    expect(g.appliedCount).toBe(10);
+    expect(g.rolledUp).toBe(false);
+  });
+
+  test("rolls up the geo Country scheme once it floods past the threshold", () => {
+    const { codes, scheme, inScheme } = schemeWithCodes(COUNTRY, "Country", 12);
+    const [g] = groupAppliedConcepts(applied(...codes), inScheme, [scheme], GEO);
+    expect(g.isGeo).toBe(true);
+    expect(g.rolledUp).toBe(true);
+  });
+
+  test("never rolls up the 'Other codes' bucket, so drift stays visible", () => {
+    const { codes, inScheme } = schemeWithCodes("https://v/unknown", "X", 12);
+    const g = groupAppliedConcepts(applied(...codes), inScheme, schemes, GEO);
+    const other = g[g.length - 1];
+    expect(other.schemeLabel).toBe("Other codes");
+    expect(other.appliedCount).toBe(12);
+    expect(other.rolledUp).toBe(false);
   });
 
   test("appends applied concepts absent from the scheme tree as flat nodes", () => {


### PR DESCRIPTION
Closes #126.

## Summary

Adds a **Taxonomy codes** card to the `/hpv` reference detail page, below the bibliographic card. It lists every applied concept grouped by concept scheme, geo schemes first, with each scheme shown in full. ESEA reference detail is unchanged.

The branch also folds in two small HPV evidence-map changes that surfaced while enabling the HPV community, cherry-picked from the map fix work and verified together:
- HPV evidence-map default axes changed to WHO Region (rows) x Thematic Focus - Primary (columns), per the PM's directive, replacing the earlier Target Population x Delivery Actor placeholder.
- The map config panel now hides the "Countries" axis option when a community's country facet is empty (HPV). Previously it was offered unconditionally; selecting it ran a cross-facet query against a missing facet and failed the whole map. Mirrors the existing country filter-card gate.

## What changed

Reference detail card (the issue):
- New pure transform `groupAppliedConcepts` (`src/services/taxonomyCodesUtils.ts`): buckets applied concepts by `inScheme`, prunes each scheme's `topConcepts` tree to the branches that reach a coded concept (ancestors kept as sub-headings, arbitrary depth), and orders geo schemes first then topical (published-vocab order within each). Concepts whose scheme is unknown fall to a trailing "Other codes" bucket.
- New presentational `TaxonomyCodesCard` (`src/components/investigation/TaxonomyCodesCard.tsx`): renders `.lg-card` inline (no shared Card primitive), one section per scheme listing all its members as tags via the existing `TagGroup`.
- Wired into `RecordDetailPage`, data-gated on `appliedConcepts.length > 0`.

Supporting:
- Consolidated `Community.pillExcludedSchemes` into a single `Community.geographicSchemes` field. One source of truth for "what is geo": it drives both result-card pill exclusion (at the SearchPage seam) and detail-page ordering, so the two cannot drift.
- Split the page's label-failure flag in two: `vocabUnavailable` (vocab fetch only) for the HPV-only Taxonomy codes card, and `curieLabelsUnavailable` (vocab or context) for the InvestigationCard and findings banner. HPV concepts are full URIs and resolve from the vocab alone; ESEA concepts are CURIEs that also need the `@context` to expand the prefix, so a context-only failure must not trip the HPV card's raw-identifier note.

## Design notes

- **Data-gated, not community-gated (deliberate).** The card renders for any community with applied concepts. ESEA emits none today (it builds tags from its findings walk, a disjoint data path), so ESEA never shows the card. This keeps the gate data-driven and mirrors how the result-card pills already work, rather than hard-coding an HPV slug check. An integration test pins this: an ESEA record that did carry applied concepts would get the card.
- **Every concept is shown in full (no roll-up).** Country coding can flood (one gold-set ref carries 83 countries). An earlier revision compacted any scheme past 10 codes to an expand-on-click "Multiple {plural} (N)" summary; the team reversed that call: they want all codes shown, and even 25 countries reads as about three wrapped lines. The summary path and its threshold were removed, so each scheme lists every member, however many. The grouping transform already built the full node tree, so this was a presentation-only deletion.
- **Ordering follows published-vocab order** within the geo-first / topical split. It is not yet aligned to the Refine drawer's ordering.
- **Sub-category nesting is kept vocab-faithful.** Where the vocab asserts `broader` (e.g. World Bank income tier and Gavi status under Country Classification), the card renders the ancestor as a sub-heading. The mockup drew these flat; keeping them nested is a deliberate fidelity-to-vocab choice, flagged for design awareness.

## Validation performed

- Full suite green: 800 tests across 71 files; `tsc --noEmit` clean.
- Live-verified locally (dev server on `:3000` to a local destiny-repository on `:8000`, 6 seeded HPV records):
  - All 6 HPV reference-detail pages render the Taxonomy codes card; the 133 applied-concept URIs across the 6 records resolve to readable labels with zero misses (country codes show as full names, e.g. "Afghanistan", not "AF").
  - HPV evidence map: the WHO Region x Thematic Focus - Primary defaults render populated bubbles (African Region, European Region, Region of the Americas) against staging data; the Countries axis option is correctly absent for HPV, so the map no longer fails on that selection.
- Live-verified against the staging backend on genuinely robot-mapped HPV references (not just local fixtures): a mapped record renders the card correctly, geo schemes first (Country Classification, Country), with multi-level vocab nesting (e.g. World Bank income tier under Country Classification). The Octavilia literature review codes 12 countries and lists all 12 inline with no summary toggle, confirming the roll-up removal; `read_page` finds no disclosure control on the page and the console is clean. Un-mapped references correctly show no card (bibliographic only).
- ESEA reference detail is unaffected by design (the card is data-gated on applied concepts, which ESEA does not emit) and is covered by integration tests; the ESEA search and visualise pages were confirmed unchanged during the HPV map enablement.
