### PR TITLE
Correctly order schemes in filter drawer and concepts in evidence map

### DIFF
--- a/src/components/filters/FilterCardList.tsx
+++ b/src/components/filters/FilterCardList.tsx
@@ -6,9 +6,11 @@ import { summary } from "./conceptSchemeFilterState";
 import { summary as countrySummary } from "./countryFilterState";
 import { summary as yearSummary } from "./yearRangeFilterState";
 import { orderFilterItems, type FilterItem } from "./filterOrder";
-import { schemeDisplayLabel } from "@/services/vocabulary/vocabularyService";
-import type { FilterSlot } from "@/types/models";
-import type { ConceptScheme } from "@/services/vocabulary/vocabularyService";
+import {
+  schemeDisplayLabel,
+  type ConceptScheme,
+} from "@/services/vocabulary/vocabularyService";
+import type { PinnedFilter } from "@/types/models";
 import type { FilterDraft } from "./useFilterDraft";
 import "./FilterCardList.css";
 
@@ -17,28 +19,24 @@ interface FilterCardListProps {
   countNoun?: string;
   // Show the facet-backed country card; off where the `countries` facet is empty.
   showCountryFacetFilter?: boolean;
-  // Community filter-card ordering; absent ⇒ DEFAULT_FILTER_ORDER.
-  order?: readonly FilterSlot[];
-  // Scheme URIs grouped by the "geographicSchemes" slot (in this order).
-  geographicSchemes?: readonly string[];
+  // Filter cards pinned to the top; absent ⇒ DEFAULT_PINNED_FILTERS.
+  pinnedFilters?: readonly PinnedFilter[];
 }
 
 /**
  * The stack of filter cards (publication year, country, one per concept scheme)
  * driven by a {@link FilterDraft}. Shared by the search drawer and the
- * evidence-map config panel so both render filters identically. Card order is
- * resolved from the community's {@link FilterSlot} order (#149).
+ * evidence-map config panel so both render filters identically. Pinned cards
+ * lead; the remaining schemes follow alphabetically.
  */
 export function FilterCardList({
   draft,
   countNoun = "results",
   showCountryFacetFilter = true,
-  order,
-  geographicSchemes,
+  pinnedFilters,
 }: FilterCardListProps) {
   const items = orderFilterItems(draft.schemes, {
-    order,
-    geographicSchemes,
+    pinned: pinnedFilters,
     showCountryFacetFilter,
   });
 

--- a/src/components/filters/FilterCardList.tsx
+++ b/src/components/filters/FilterCardList.tsx
@@ -5,7 +5,10 @@ import { YearRangeFilter } from "./YearRangeFilter";
 import { summary } from "./conceptSchemeFilterState";
 import { summary as countrySummary } from "./countryFilterState";
 import { summary as yearSummary } from "./yearRangeFilterState";
+import { orderFilterItems, type FilterItem } from "./filterOrder";
 import { schemeDisplayLabel } from "@/services/vocabulary/vocabularyService";
+import type { FilterSlot } from "@/types/models";
+import type { ConceptScheme } from "@/services/vocabulary/vocabularyService";
 import type { FilterDraft } from "./useFilterDraft";
 import "./FilterCardList.css";
 
@@ -14,18 +17,31 @@ interface FilterCardListProps {
   countNoun?: string;
   // Show the facet-backed country card; off where the `countries` facet is empty.
   showCountryFacetFilter?: boolean;
+  // Community filter-card ordering; absent ⇒ DEFAULT_FILTER_ORDER.
+  order?: readonly FilterSlot[];
+  // Scheme URIs grouped by the "geographicSchemes" slot (in this order).
+  geographicSchemes?: readonly string[];
 }
 
 /**
  * The stack of filter cards (publication year, country, one per concept scheme)
  * driven by a {@link FilterDraft}. Shared by the search drawer and the
- * evidence-map config panel so both render filters identically.
+ * evidence-map config panel so both render filters identically. Card order is
+ * resolved from the community's {@link FilterSlot} order (#149).
  */
 export function FilterCardList({
   draft,
   countNoun = "results",
   showCountryFacetFilter = true,
+  order,
+  geographicSchemes,
 }: FilterCardListProps) {
+  const items = orderFilterItems(draft.schemes, {
+    order,
+    geographicSchemes,
+    showCountryFacetFilter,
+  });
+
   return (
     <>
       {draft.facetError && (
@@ -33,15 +49,31 @@ export function FilterCardList({
           Filter counts unavailable.
         </div>
       )}
-      <FilterCard
-        title="Publication year"
-        summary={yearSummary(draft.yearDraft)}
-        defaultExpanded
-      >
-        <YearRangeFilter state={draft.yearDraft} onChange={draft.setYearDraft} />
-      </FilterCard>
-      {showCountryFacetFilter && (
+      {items.map((item) => renderItem(item, draft, countNoun))}
+    </>
+  );
+}
+
+function renderItem(item: FilterItem, draft: FilterDraft, countNoun: string) {
+  switch (item.kind) {
+    case "year":
+      return (
         <FilterCard
+          key="year"
+          title="Publication year"
+          summary={yearSummary(draft.yearDraft)}
+          defaultExpanded
+        >
+          <YearRangeFilter
+            state={draft.yearDraft}
+            onChange={draft.setYearDraft}
+          />
+        </FilterCard>
+      );
+    case "country":
+      return (
+        <FilterCard
+          key="country"
           title="Country"
           summary={countrySummary(draft.countryDraft)}
           defaultExpanded
@@ -54,26 +86,42 @@ export function FilterCardList({
             onChange={draft.setCountryDraft}
           />
         </FilterCard>
-      )}
-      {draft.schemes.map((scheme) => {
-        const state = draft.conceptStateFor(scheme);
-        return (
-          <FilterCard
-            key={scheme.uri}
-            title={schemeDisplayLabel(scheme.label)}
-            summary={summary(state)}
-          >
-            <ConceptSchemeFilter
-              scheme={scheme}
-              state={state}
-              counts={draft.facetCounts?.concepts ?? null}
-              countsLoading={draft.facetCountsLoading}
-              countNoun={countNoun}
-              onChange={(next) => draft.onSchemeChange(scheme, next)}
-            />
-          </FilterCard>
-        );
-      })}
-    </>
+      );
+    case "scheme":
+      return (
+        <SchemeCard
+          key={item.scheme.uri}
+          scheme={item.scheme}
+          draft={draft}
+          countNoun={countNoun}
+        />
+      );
+  }
+}
+
+function SchemeCard({
+  scheme,
+  draft,
+  countNoun,
+}: {
+  scheme: ConceptScheme;
+  draft: FilterDraft;
+  countNoun: string;
+}) {
+  const state = draft.conceptStateFor(scheme);
+  return (
+    <FilterCard
+      title={schemeDisplayLabel(scheme.label)}
+      summary={summary(state)}
+    >
+      <ConceptSchemeFilter
+        scheme={scheme}
+        state={state}
+        counts={draft.facetCounts?.concepts ?? null}
+        countsLoading={draft.facetCountsLoading}
+        countNoun={countNoun}
+        onChange={(next) => draft.onSchemeChange(scheme, next)}
+      />
+    </FilterCard>
   );
 }

--- a/src/components/filters/FilterDrawer.css
+++ b/src/components/filters/FilterDrawer.css
@@ -5,6 +5,13 @@
   width: min(420px, 100vw);
 }
 
+/* The Cancel button is taller than the title's line box; center them so the
+   title doesn't sit pinned to the top of the row (shared header is flex-start
+   for the AI drawer's top-aligned close button). */
+.filter-drawer__header {
+  align-items: center;
+}
+
 .filter-drawer__body {
   padding: var(--spacing-sm) 0;
   display: flex;

--- a/src/components/filters/FilterDrawer.tsx
+++ b/src/components/filters/FilterDrawer.tsx
@@ -4,7 +4,7 @@ import { FilterActions } from "./FilterActions";
 import { useFilterDraft, type AppliedFilters } from "./useFilterDraft";
 import type { SearchParams } from "@/services/searchParams";
 import type { ConceptScheme } from "@/services/vocabulary/vocabularyService";
-import type { FilterSlot } from "@/types/models";
+import type { PinnedFilter } from "@/types/models";
 import "./FilterDrawer.css";
 
 export type { AppliedFilters };
@@ -15,9 +15,8 @@ interface FilterDrawerProps {
   countNoun?: string;
   // Show the facet-backed country card; off where the `countries` facet is empty.
   showCountryFacetFilter?: boolean;
-  // Community filter-card ordering; absent ⇒ DEFAULT_FILTER_ORDER.
-  order?: readonly FilterSlot[];
-  geographicSchemes?: readonly string[];
+  // Filter cards pinned to the top; absent ⇒ DEFAULT_PINNED_FILTERS.
+  pinnedFilters?: readonly PinnedFilter[];
   schemes: ConceptScheme[];
   appliedConceptFilters: readonly (readonly string[])[];
   appliedCountryCodes: readonly string[];
@@ -42,8 +41,7 @@ function FilterDrawerPanel({
   title = "Refine the evidence",
   countNoun = "results",
   showCountryFacetFilter = true,
-  order,
-  geographicSchemes,
+  pinnedFilters,
   schemes,
   appliedConceptFilters,
   appliedCountryCodes,
@@ -102,8 +100,7 @@ function FilterDrawerPanel({
         draft={draft}
         countNoun={countNoun}
         showCountryFacetFilter={showCountryFacetFilter}
-        order={order}
-        geographicSchemes={geographicSchemes}
+        pinnedFilters={pinnedFilters}
       />
     </Drawer>
   );

--- a/src/components/filters/FilterDrawer.tsx
+++ b/src/components/filters/FilterDrawer.tsx
@@ -4,6 +4,7 @@ import { FilterActions } from "./FilterActions";
 import { useFilterDraft, type AppliedFilters } from "./useFilterDraft";
 import type { SearchParams } from "@/services/searchParams";
 import type { ConceptScheme } from "@/services/vocabulary/vocabularyService";
+import type { FilterSlot } from "@/types/models";
 import "./FilterDrawer.css";
 
 export type { AppliedFilters };
@@ -14,6 +15,9 @@ interface FilterDrawerProps {
   countNoun?: string;
   // Show the facet-backed country card; off where the `countries` facet is empty.
   showCountryFacetFilter?: boolean;
+  // Community filter-card ordering; absent ⇒ DEFAULT_FILTER_ORDER.
+  order?: readonly FilterSlot[];
+  geographicSchemes?: readonly string[];
   schemes: ConceptScheme[];
   appliedConceptFilters: readonly (readonly string[])[];
   appliedCountryCodes: readonly string[];
@@ -38,6 +42,8 @@ function FilterDrawerPanel({
   title = "Refine the evidence",
   countNoun = "results",
   showCountryFacetFilter = true,
+  order,
+  geographicSchemes,
   schemes,
   appliedConceptFilters,
   appliedCountryCodes,
@@ -96,6 +102,8 @@ function FilterDrawerPanel({
         draft={draft}
         countNoun={countNoun}
         showCountryFacetFilter={showCountryFacetFilter}
+        order={order}
+        geographicSchemes={geographicSchemes}
       />
     </Drawer>
   );

--- a/src/components/filters/filterOrder.ts
+++ b/src/components/filters/filterOrder.ts
@@ -1,0 +1,89 @@
+import type { FilterSlot } from "@/types/models";
+import {
+  schemeDisplayLabel,
+  type ConceptScheme,
+} from "@/services/vocabulary/vocabularyService";
+
+export type { FilterSlot };
+
+// One filter card, in render order: the two built-in cards plus one per scheme.
+export type FilterItem =
+  | { kind: "year" }
+  | { kind: "country" }
+  | { kind: "scheme"; scheme: ConceptScheme };
+
+// Year first, then the country facet, then every scheme alphabetically.
+export const DEFAULT_FILTER_ORDER: readonly FilterSlot[] = [
+  "year",
+  "country",
+  "otherSchemes",
+];
+
+interface OrderFilterItemsOptions {
+  order?: readonly FilterSlot[];
+  // Scheme URIs grouped by the "geographicSchemes" slot, in this order.
+  geographicSchemes?: readonly string[];
+  // When false the "country" slot renders nothing (facet unavailable).
+  showCountryFacetFilter?: boolean;
+}
+
+/**
+ * Resolve a community's {@link FilterSlot} order into the concrete list of
+ * filter cards to render (#149). Each scheme appears exactly once: a slot naming
+ * its URI, or the "geographicSchemes"/"otherSchemes" group that claims it first,
+ * wins. A trailing "otherSchemes" sweep is always applied so no scheme is
+ * silently dropped, even if the configured order omits it.
+ */
+export function orderFilterItems(
+  schemes: readonly ConceptScheme[],
+  {
+    order = DEFAULT_FILTER_ORDER,
+    geographicSchemes = [],
+    showCountryFacetFilter = true,
+  }: OrderFilterItemsOptions = {},
+): FilterItem[] {
+  const byUri = new Map(schemes.map((s) => [s.uri, s]));
+  const placed = new Set<string>();
+  const items: FilterItem[] = [];
+
+  const pushScheme = (uri: string) => {
+    const scheme = byUri.get(uri);
+    if (scheme && !placed.has(uri)) {
+      placed.add(uri);
+      items.push({ kind: "scheme", scheme });
+    }
+  };
+
+  const slots = order.includes("otherSchemes")
+    ? order
+    : [...order, "otherSchemes"];
+
+  for (const slot of slots) {
+    switch (slot) {
+      case "year":
+        items.push({ kind: "year" });
+        break;
+      case "country":
+        if (showCountryFacetFilter) items.push({ kind: "country" });
+        break;
+      case "geographicSchemes":
+        for (const uri of geographicSchemes) pushScheme(uri);
+        break;
+      case "otherSchemes":
+        for (const scheme of schemes
+          .filter((s) => !placed.has(s.uri))
+          .sort((a, b) =>
+            schemeDisplayLabel(a.label).localeCompare(
+              schemeDisplayLabel(b.label),
+            ),
+          )) {
+          pushScheme(scheme.uri);
+        }
+        break;
+      default:
+        pushScheme(slot);
+    }
+  }
+
+  return items;
+}

--- a/src/components/filters/filterOrder.ts
+++ b/src/components/filters/filterOrder.ts
@@ -1,5 +1,6 @@
 import type { PinnedFilter } from "@/types/models";
 import {
+  compareLabels,
   schemeDisplayLabel,
   type ConceptScheme,
 } from "@/services/vocabulary/vocabularyService";
@@ -43,17 +44,29 @@ export function orderFilterItems(
     }
   };
 
+  // Built-in slots dedup on their kind so a config that repeats "year"/"country"
+  // can't emit two cards (and a duplicate React key).
   for (const slot of pinned) {
-    if (slot === "year") items.push({ kind: "year" });
-    else if (slot === "country") {
-      if (showCountryFacetFilter) items.push({ kind: "country" });
+    if (slot === "year") {
+      if (!placed.has("year")) {
+        placed.add("year");
+        items.push({ kind: "year" });
+      }
+    } else if (slot === "country") {
+      if (showCountryFacetFilter && !placed.has("country")) {
+        placed.add("country");
+        items.push({ kind: "country" });
+      }
     } else pushScheme(slot);
   }
 
   const rest = schemes
     .filter((s) => !placed.has(s.uri))
     .sort((a, b) =>
-      schemeDisplayLabel(a.label).localeCompare(schemeDisplayLabel(b.label)),
+      compareLabels(
+        { label: schemeDisplayLabel(a.label), uri: a.uri },
+        { label: schemeDisplayLabel(b.label), uri: b.uri },
+      ),
     );
   for (const scheme of rest) pushScheme(scheme.uri);
 

--- a/src/components/filters/filterOrder.ts
+++ b/src/components/filters/filterOrder.ts
@@ -1,10 +1,8 @@
-import type { FilterSlot } from "@/types/models";
+import type { PinnedFilter } from "@/types/models";
 import {
   schemeDisplayLabel,
   type ConceptScheme,
 } from "@/services/vocabulary/vocabularyService";
-
-export type { FilterSlot };
 
 // One filter card, in render order: the two built-in cards plus one per scheme.
 export type FilterItem =
@@ -12,33 +10,24 @@ export type FilterItem =
   | { kind: "country" }
   | { kind: "scheme"; scheme: ConceptScheme };
 
-// Year first, then the country facet, then every scheme alphabetically.
-export const DEFAULT_FILTER_ORDER: readonly FilterSlot[] = [
-  "year",
-  "country",
-  "otherSchemes",
-];
+// Year, then the country facet. Every scheme follows alphabetically.
+export const DEFAULT_PINNED_FILTERS: readonly PinnedFilter[] = ["year", "country"];
 
 interface OrderFilterItemsOptions {
-  order?: readonly FilterSlot[];
-  // Scheme URIs grouped by the "geographicSchemes" slot, in this order.
-  geographicSchemes?: readonly string[];
+  pinned?: readonly PinnedFilter[];
   // When false the "country" slot renders nothing (facet unavailable).
   showCountryFacetFilter?: boolean;
 }
 
 /**
- * Resolve a community's {@link FilterSlot} order into the concrete list of
- * filter cards to render (#149). Each scheme appears exactly once: a slot naming
- * its URI, or the "geographicSchemes"/"otherSchemes" group that claims it first,
- * wins. A trailing "otherSchemes" sweep is always applied so no scheme is
- * silently dropped, even if the configured order omits it.
+ * Resolve the filter cards to render: the pinned cards in order, then every
+ * scheme not already pinned, alphabetized by display label. A scheme pinned by
+ * URI is shown once and skipped by the trailing sweep.
  */
 export function orderFilterItems(
   schemes: readonly ConceptScheme[],
   {
-    order = DEFAULT_FILTER_ORDER,
-    geographicSchemes = [],
+    pinned = DEFAULT_PINNED_FILTERS,
     showCountryFacetFilter = true,
   }: OrderFilterItemsOptions = {},
 ): FilterItem[] {
@@ -54,36 +43,19 @@ export function orderFilterItems(
     }
   };
 
-  const slots = order.includes("otherSchemes")
-    ? order
-    : [...order, "otherSchemes"];
-
-  for (const slot of slots) {
-    switch (slot) {
-      case "year":
-        items.push({ kind: "year" });
-        break;
-      case "country":
-        if (showCountryFacetFilter) items.push({ kind: "country" });
-        break;
-      case "geographicSchemes":
-        for (const uri of geographicSchemes) pushScheme(uri);
-        break;
-      case "otherSchemes":
-        for (const scheme of schemes
-          .filter((s) => !placed.has(s.uri))
-          .sort((a, b) =>
-            schemeDisplayLabel(a.label).localeCompare(
-              schemeDisplayLabel(b.label),
-            ),
-          )) {
-          pushScheme(scheme.uri);
-        }
-        break;
-      default:
-        pushScheme(slot);
-    }
+  for (const slot of pinned) {
+    if (slot === "year") items.push({ kind: "year" });
+    else if (slot === "country") {
+      if (showCountryFacetFilter) items.push({ kind: "country" });
+    } else pushScheme(slot);
   }
+
+  const rest = schemes
+    .filter((s) => !placed.has(s.uri))
+    .sort((a, b) =>
+      schemeDisplayLabel(a.label).localeCompare(schemeDisplayLabel(b.label)),
+    );
+  for (const scheme of rest) pushScheme(scheme.uri);
 
   return items;
 }

--- a/src/components/visualise/MapConfigPanel.tsx
+++ b/src/components/visualise/MapConfigPanel.tsx
@@ -12,7 +12,11 @@ import {
   type ConceptScheme,
 } from "@/services/vocabulary/vocabularyService";
 import type { SearchParams } from "@/services/searchParams";
-import type { EvidenceMapAxis, EvidenceMapAxes } from "@/types/models";
+import type {
+  EvidenceMapAxis,
+  EvidenceMapAxes,
+  FilterSlot,
+} from "@/types/models";
 import "./MapConfigPanel.css";
 
 interface MapConfigPanelProps {
@@ -32,6 +36,9 @@ interface MapConfigPanelProps {
   // Hide the facet-backed Country card where the `countries` facet is empty;
   // the Country concept-scheme card still renders from `schemes`.
   showCountryFacetFilter?: boolean;
+  // Community filter-card ordering; absent ⇒ DEFAULT_FILTER_ORDER.
+  order?: readonly FilterSlot[];
+  geographicSchemes?: readonly string[];
   onApply: (next: { axes: EvidenceMapAxes; filters: AppliedFilters }) => void;
 }
 
@@ -87,6 +94,8 @@ export function MapConfigPanel({
   params,
   countNoun = "results",
   showCountryFacetFilter = true,
+  order,
+  geographicSchemes,
   onApply,
 }: MapConfigPanelProps) {
   const [rowDraft, setRowDraft] = useState<EvidenceMapAxis>(appliedAxes.row);
@@ -155,6 +164,8 @@ export function MapConfigPanel({
             draft={draft}
             countNoun={countNoun}
             showCountryFacetFilter={showCountryFacetFilter}
+            order={order}
+            geographicSchemes={geographicSchemes}
           />
         </section>
       </div>

--- a/src/components/visualise/MapConfigPanel.tsx
+++ b/src/components/visualise/MapConfigPanel.tsx
@@ -15,7 +15,7 @@ import type { SearchParams } from "@/services/searchParams";
 import type {
   EvidenceMapAxis,
   EvidenceMapAxes,
-  FilterSlot,
+  PinnedFilter,
 } from "@/types/models";
 import "./MapConfigPanel.css";
 
@@ -36,9 +36,8 @@ interface MapConfigPanelProps {
   // Hide the facet-backed Country card where the `countries` facet is empty;
   // the Country concept-scheme card still renders from `schemes`.
   showCountryFacetFilter?: boolean;
-  // Community filter-card ordering; absent ⇒ DEFAULT_FILTER_ORDER.
-  order?: readonly FilterSlot[];
-  geographicSchemes?: readonly string[];
+  // Filter cards pinned to the top; absent ⇒ DEFAULT_PINNED_FILTERS.
+  pinnedFilters?: readonly PinnedFilter[];
   onApply: (next: { axes: EvidenceMapAxes; filters: AppliedFilters }) => void;
 }
 
@@ -94,8 +93,7 @@ export function MapConfigPanel({
   params,
   countNoun = "results",
   showCountryFacetFilter = true,
-  order,
-  geographicSchemes,
+  pinnedFilters,
   onApply,
 }: MapConfigPanelProps) {
   const [rowDraft, setRowDraft] = useState<EvidenceMapAxis>(appliedAxes.row);
@@ -164,8 +162,7 @@ export function MapConfigPanel({
             draft={draft}
             countNoun={countNoun}
             showCountryFacetFilter={showCountryFacetFilter}
-            order={order}
-            geographicSchemes={geographicSchemes}
+            pinnedFilters={pinnedFilters}
           />
         </section>
       </div>

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -492,8 +492,7 @@ function SearchPageInner({ community }: { community: Community }) {
           title={community.copy.drawerTitle}
           countNoun={community.copy.countNoun}
           showCountryFacetFilter={community.features.countryFacetFilter}
-          order={community.filterOrder}
-          geographicSchemes={community.geographicSchemes}
+          pinnedFilters={community.pinnedFilters}
           schemes={filterableSchemes}
           appliedConceptFilters={params.conceptFilters}
           appliedCountryCodes={params.countryCodes}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -492,6 +492,8 @@ function SearchPageInner({ community }: { community: Community }) {
           title={community.copy.drawerTitle}
           countNoun={community.copy.countNoun}
           showCountryFacetFilter={community.features.countryFacetFilter}
+          order={community.filterOrder}
+          geographicSchemes={community.geographicSchemes}
           schemes={filterableSchemes}
           appliedConceptFilters={params.conceptFilters}
           appliedCountryCodes={params.countryCodes}

--- a/src/pages/VisualisePage.tsx
+++ b/src/pages/VisualisePage.tsx
@@ -366,6 +366,8 @@ function EvidenceMapView({
         key={canonical}
         schemes={filterableSchemes}
         showCountryFacetFilter={community.features.countryFacetFilter}
+        order={community.filterOrder}
+        geographicSchemes={community.geographicSchemes}
         appliedAxes={axes}
         defaultAxes={defaults}
         appliedConceptFilters={params.conceptFilters}

--- a/src/pages/VisualisePage.tsx
+++ b/src/pages/VisualisePage.tsx
@@ -366,8 +366,7 @@ function EvidenceMapView({
         key={canonical}
         schemes={filterableSchemes}
         showCountryFacetFilter={community.features.countryFacetFilter}
-        order={community.filterOrder}
-        geographicSchemes={community.geographicSchemes}
+        pinnedFilters={community.pinnedFilters}
         appliedAxes={axes}
         defaultAxes={defaults}
         appliedConceptFilters={params.conceptFilters}

--- a/src/services/communities.ts
+++ b/src/services/communities.ts
@@ -25,15 +25,20 @@ export const DEFAULT_FEATURES: CommunityFeatures = {
   countryFacetFilter: true,
 };
 
-// The HPV geographic ConceptSchemes (country + regional/classification). Full scheme
-// URIs to match inScheme.
+// The HPV geographic ConceptSchemes (country + regional/classification). Full
+// scheme URIs to match inScheme. Ordered specific → broad: the country itself,
+// then its classification, then the regional groupings (alphabetical) — the
+// order they group in as filter cards (#149).
 const HPV_GEO_SCHEMES = [
   "https://vocab.aliveevidence.org/hpv/Country",
   "https://vocab.aliveevidence.org/hpv/CountryClassification",
   "https://vocab.aliveevidence.org/hpv/UNICEFRegion",
-  "https://vocab.aliveevidence.org/hpv/WorldBankRegion",
   "https://vocab.aliveevidence.org/hpv/WHORegion",
+  "https://vocab.aliveevidence.org/hpv/WorldBankRegion",
 ];
+
+// "Learning Convening" scheme — pinned to the top of the HPV filter list (#149).
+const HPV_CONVENING_THEME = "https://vocab.aliveevidence.org/hpv/ConveningTheme";
 
 // Shared copy fallbacks; a community overrides only what diverges.
 function buildCopy(
@@ -110,6 +115,14 @@ const COMMUNITIES: Community[] = [
     filterExcludedSchemes: [],
     pillExcludedSchemes: HPV_GEO_SCHEMES,
     geographicSchemes: HPV_GEO_SCHEMES,
+    // Learning Convening, then year, then the geographic schemes, then the
+    // remaining schemes alphabetically (#149).
+    filterOrder: [
+      HPV_CONVENING_THEME,
+      "year",
+      "geographicSchemes",
+      "otherSchemes",
+    ],
     features: {
       ...DEFAULT_FEATURES,
       evidenceMap: true,

--- a/src/services/communities.ts
+++ b/src/services/communities.ts
@@ -26,9 +26,9 @@ export const DEFAULT_FEATURES: CommunityFeatures = {
 };
 
 // The HPV geographic ConceptSchemes (country + regional/classification). Full
-// scheme URIs to match inScheme. Ordered specific → broad: the country itself,
-// then its classification, then the regional groupings (alphabetical) — the
-// order they group in as filter cards (#149).
+// scheme URIs to match inScheme. Ordered specific → broad: the country, then its
+// classification, then the regional groupings (alphabetical) — the order they
+// group in as filter cards.
 const HPV_GEO_SCHEMES = [
   "https://vocab.aliveevidence.org/hpv/Country",
   "https://vocab.aliveevidence.org/hpv/CountryClassification",
@@ -36,9 +36,6 @@ const HPV_GEO_SCHEMES = [
   "https://vocab.aliveevidence.org/hpv/WHORegion",
   "https://vocab.aliveevidence.org/hpv/WorldBankRegion",
 ];
-
-// "Learning Convening" scheme — pinned to the top of the HPV filter list (#149).
-const HPV_CONVENING_THEME = "https://vocab.aliveevidence.org/hpv/ConveningTheme";
 
 // Shared copy fallbacks; a community overrides only what diverges.
 function buildCopy(
@@ -102,7 +99,6 @@ const COMMUNITIES: Community[] = [
   {
     slug: "hpv",
     name: "HPV Vaccine Delivery",
-    // TODO: placeholder annotation, pending the backend's HPV domain inclusion.
     defaultAnnotations: ["domain-inclusion/hpv"],
     vocabularyUrl: requireEnv(
       "VITE_HPV_VOCABULARY_URL",
@@ -115,13 +111,10 @@ const COMMUNITIES: Community[] = [
     filterExcludedSchemes: [],
     pillExcludedSchemes: HPV_GEO_SCHEMES,
     geographicSchemes: HPV_GEO_SCHEMES,
-    // Learning Convening, then year, then the geographic schemes, then the
-    // remaining schemes alphabetically (#149).
-    filterOrder: [
-      HPV_CONVENING_THEME,
+    pinnedFilters: [
+      "https://vocab.aliveevidence.org/hpv/ConveningTheme",
       "year",
-      "geographicSchemes",
-      "otherSchemes",
+      ...HPV_GEO_SCHEMES,
     ],
     features: {
       ...DEFAULT_FEATURES,

--- a/src/services/evidenceMap.ts
+++ b/src/services/evidenceMap.ts
@@ -115,11 +115,13 @@ export function resolveMapAxis(
   };
 }
 
-// The backend treats every concept in a scheme as a sibling regardless of depth.
+// Flatten the scheme to a depth-first preorder list: each concept immediately
+// followed by its descendants, so a parent and its children sit adjacent in the
+// grid (#148). Siblings at every level are alphabetized by label.
 function flattenScheme(scheme: ConceptScheme): AxisCategory[] {
   const out: AxisCategory[] = [];
   const walk = (concepts: readonly Concept[]) => {
-    for (const concept of concepts) {
+    for (const concept of [...concepts].sort(byLabelThenKey)) {
       out.push({ key: concept.uri, label: concept.label });
       if (concept.narrower) walk(concept.narrower);
     }
@@ -128,18 +130,28 @@ function flattenScheme(scheme: ConceptScheme): AxisCategory[] {
   return out;
 }
 
+const byLabelThenKey = (
+  a: { label: string; uri?: string; key?: string },
+  b: { label: string; uri?: string; key?: string },
+): number =>
+  a.label.localeCompare(b.label) ||
+  (a.uri ?? a.key ?? "").localeCompare(b.uri ?? b.key ?? "");
+
+// Axis categories keep their given order — a scheme's hierarchy (#148), or the
+// empty list for a countries axis. Cell-only keys the axis doesn't enumerate
+// trail them, alphabetized; a countries axis (no categories) is thus fully
+// alphabetical.
 function mergeCategories(
   axis: AxisInput,
   cellKeys: Set<string>,
 ): AxisCategory[] {
-  const byKey = new Map<string, AxisCategory>();
-  for (const category of axis.categories) byKey.set(category.key, category);
+  const known = new Set(axis.categories.map((c) => c.key));
+  const extras: AxisCategory[] = [];
   for (const key of cellKeys) {
-    if (!byKey.has(key)) byKey.set(key, { key, label: axis.labelFor(key) });
+    if (!known.has(key)) extras.push({ key, label: axis.labelFor(key) });
   }
-  return [...byKey.values()].sort(
-    (a, b) => a.label.localeCompare(b.label) || a.key.localeCompare(b.key),
-  );
+  extras.sort(byLabelThenKey);
+  return [...axis.categories, ...extras];
 }
 
 /**

--- a/src/services/evidenceMap.ts
+++ b/src/services/evidenceMap.ts
@@ -5,6 +5,7 @@ import type {
 } from "@/types/models";
 import type { SearchParams } from "@/services/searchParams";
 import {
+  compareLabels,
   schemeDisplayLabel,
   type Concept,
   type ConceptScheme,
@@ -117,11 +118,16 @@ export function resolveMapAxis(
 
 // Flatten the scheme to a depth-first preorder list — each concept immediately
 // followed by its descendants — so a parent and its children sit adjacent in the
-// grid. Siblings at every level are alphabetized by label.
+// grid. Siblings are already alpha-numerically ordered by the vocabulary build.
+// A concept reachable twice (e.g. a top concept also declared `broader` into
+// another subtree) is emitted once: a repeat key would warn and double the row.
 function flattenScheme(scheme: ConceptScheme): AxisCategory[] {
   const out: AxisCategory[] = [];
+  const seen = new Set<string>();
   const walk = (concepts: readonly Concept[]) => {
-    for (const concept of [...concepts].sort(byLabelThenKey)) {
+    for (const concept of concepts) {
+      if (seen.has(concept.uri)) continue;
+      seen.add(concept.uri);
       out.push({ key: concept.uri, label: concept.label });
       if (concept.narrower) walk(concept.narrower);
     }
@@ -129,13 +135,6 @@ function flattenScheme(scheme: ConceptScheme): AxisCategory[] {
   walk(scheme.topConcepts);
   return out;
 }
-
-const byLabelThenKey = (
-  a: { label: string; uri?: string; key?: string },
-  b: { label: string; uri?: string; key?: string },
-): number =>
-  a.label.localeCompare(b.label) ||
-  (a.uri ?? a.key ?? "").localeCompare(b.uri ?? b.key ?? "");
 
 // Axis categories keep their given order — a scheme's hierarchy, or the empty
 // list for a countries axis. Cell-only keys the axis doesn't enumerate trail
@@ -149,7 +148,7 @@ function mergeCategories(
   for (const key of cellKeys) {
     if (!known.has(key)) extras.push({ key, label: axis.labelFor(key) });
   }
-  extras.sort(byLabelThenKey);
+  extras.sort((a, b) => compareLabels({ label: a.label, uri: a.key }, { label: b.label, uri: b.key }));
   return [...axis.categories, ...extras];
 }
 

--- a/src/services/evidenceMap.ts
+++ b/src/services/evidenceMap.ts
@@ -115,9 +115,9 @@ export function resolveMapAxis(
   };
 }
 
-// Flatten the scheme to a depth-first preorder list: each concept immediately
-// followed by its descendants, so a parent and its children sit adjacent in the
-// grid (#148). Siblings at every level are alphabetized by label.
+// Flatten the scheme to a depth-first preorder list — each concept immediately
+// followed by its descendants — so a parent and its children sit adjacent in the
+// grid. Siblings at every level are alphabetized by label.
 function flattenScheme(scheme: ConceptScheme): AxisCategory[] {
   const out: AxisCategory[] = [];
   const walk = (concepts: readonly Concept[]) => {
@@ -137,10 +137,9 @@ const byLabelThenKey = (
   a.label.localeCompare(b.label) ||
   (a.uri ?? a.key ?? "").localeCompare(b.uri ?? b.key ?? "");
 
-// Axis categories keep their given order — a scheme's hierarchy (#148), or the
-// empty list for a countries axis. Cell-only keys the axis doesn't enumerate
-// trail them, alphabetized; a countries axis (no categories) is thus fully
-// alphabetical.
+// Axis categories keep their given order — a scheme's hierarchy, or the empty
+// list for a countries axis. Cell-only keys the axis doesn't enumerate trail
+// them, alphabetized; a countries axis (no categories) is thus fully alphabetical.
 function mergeCategories(
   axis: AxisInput,
   cellKeys: Set<string>,

--- a/src/services/vocabulary/vocabularyService.ts
+++ b/src/services/vocabulary/vocabularyService.ts
@@ -43,6 +43,19 @@ export function schemeDisplayLabel(label: string): string {
   return label.replace(/\s+Scheme$/i, "");
 }
 
+// Alpha-numeral collation for labels: `numeric` so "9–14 years" precedes
+// "15–20 years" rather than sorting "15" before "9". Ties break on URI for a
+// stable order. Used wherever concepts/schemes are ordered for display.
+export function compareLabels(
+  a: { label: string; uri?: string },
+  b: { label: string; uri?: string },
+): number {
+  return (
+    a.label.localeCompare(b.label, undefined, { numeric: true }) ||
+    (a.uri ?? "").localeCompare(b.uri ?? "")
+  );
+}
+
 export interface VocabularyData {
   labels: Map<string, string>;
   broader: Map<string, string>;
@@ -181,7 +194,8 @@ export function buildVocabularyData(doc: VocabularyJsonLd): VocabularyData {
 
     const narrower = (childrenByUri.get(uri) ?? [])
       .map((childUri) => buildConcept(childUri, visited))
-      .filter((c): c is Concept => c !== null);
+      .filter((c): c is Concept => c !== null)
+      .sort(compareLabels);
     if (narrower.length > 0) concept.narrower = narrower;
 
     return concept;
@@ -192,7 +206,8 @@ export function buildVocabularyData(doc: VocabularyJsonLd): VocabularyData {
     label: raw.label,
     topConcepts: raw.topConceptUris
       .map((uri) => buildConcept(uri, new Set()))
-      .filter((c): c is Concept => c !== null),
+      .filter((c): c is Concept => c !== null)
+      .sort(compareLabels),
   }));
 
   return { labels, broader, definitions, inScheme, schemes };

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -24,6 +24,21 @@ export interface EvidenceMapAxes {
   column: EvidenceMapAxis;
 }
 
+// A slot in a community's filter-card ordering (see orderFilterItems). Besides
+// the built-in cards and group tokens, any concept-scheme URI pins that scheme
+// to a position. The `string & {}` arm keeps the named tokens auto-completable
+// while still accepting arbitrary scheme URIs.
+export type FilterSlot =
+  // The publication-year card.
+  | "year"
+  // The facet-backed country card (omitted where countryFacetFilter is off).
+  | "country"
+  // Expands to the community's geographicSchemes, in their configured order.
+  | "geographicSchemes"
+  // All schemes not placed by another slot, alphabetized by display label.
+  | "otherSchemes"
+  | (string & {});
+
 // See buildCopy() in services/communities.ts for the shared fallbacks.
 export interface CommunityCopy {
   searchPlaceholder: string;
@@ -59,9 +74,13 @@ export interface Community {
   // filterable in the drawer, they just aren't pills). HPV lists its geo schemes here.
   pillExcludedSchemes: string[];
   // Geographic concept schemes (country + regional/classification); shown first
-  // (prioritized) on the detail page's Taxonomy codes card. Empty for communities
+  // (prioritized) on the detail page's Taxonomy codes card, and grouped together
+  // (in this order) by the "geographicSchemes" filter slot. Empty for communities
   // with no geo schemes.
   geographicSchemes: string[];
+  // Order of the filter cards (see orderFilterItems). Absent ⇒ DEFAULT_FILTER_ORDER
+  // (year, country, then every scheme alphabetically).
+  filterOrder?: FilterSlot[];
   features: CommunityFeatures;
   // Default evidence-map axes; absent ⇒ the map shows a "not configured" notice
   // even where features.evidenceMap is on (e.g. before a vocabulary is published).

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -24,20 +24,10 @@ export interface EvidenceMapAxes {
   column: EvidenceMapAxis;
 }
 
-// A slot in a community's filter-card ordering (see orderFilterItems). Besides
-// the built-in cards and group tokens, any concept-scheme URI pins that scheme
-// to a position. The `string & {}` arm keeps the named tokens auto-completable
+// A pinned filter card: the built-in "year"/"country" cards, or any concept
+// scheme by URI. The `string & {}` arm keeps the named tokens auto-completable
 // while still accepting arbitrary scheme URIs.
-export type FilterSlot =
-  // The publication-year card.
-  | "year"
-  // The facet-backed country card (omitted where countryFacetFilter is off).
-  | "country"
-  // Expands to the community's geographicSchemes, in their configured order.
-  | "geographicSchemes"
-  // All schemes not placed by another slot, alphabetized by display label.
-  | "otherSchemes"
-  | (string & {});
+export type PinnedFilter = "year" | "country" | (string & {});
 
 // See buildCopy() in services/communities.ts for the shared fallbacks.
 export interface CommunityCopy {
@@ -78,9 +68,9 @@ export interface Community {
   // (in this order) by the "geographicSchemes" filter slot. Empty for communities
   // with no geo schemes.
   geographicSchemes: string[];
-  // Order of the filter cards (see orderFilterItems). Absent ⇒ DEFAULT_FILTER_ORDER
-  // (year, country, then every scheme alphabetically).
-  filterOrder?: FilterSlot[];
+  // Filter cards pinned to the top, in order; every remaining scheme follows
+  // alphabetically. Absent ⇒ DEFAULT_PINNED_FILTERS (year, then country).
+  pinnedFilters?: PinnedFilter[];
   features: CommunityFeatures;
   // Default evidence-map axes; absent ⇒ the map shows a "not configured" notice
   // even where features.evidenceMap is on (e.g. before a vocabulary is published).

--- a/tests/components/filters/filterOrder.test.ts
+++ b/tests/components/filters/filterOrder.test.ts
@@ -30,15 +30,9 @@ describe("orderFilterItems", () => {
     expect(kinds(items)).toEqual(["year", "u:apple"]);
   });
 
-  test("pins a scheme by URI and groups geographic schemes in config order", () => {
+  test("pins schemes by URI in order, then appends the rest alphabetically", () => {
     const items = orderFilterItems([zebra, apple, country, region, convening], {
-      order: [
-        "u:convening",
-        "year",
-        "geographicSchemes",
-        "otherSchemes",
-      ],
-      geographicSchemes: ["u:country", "u:region"],
+      pinned: ["u:convening", "year", "u:country", "u:region"],
       showCountryFacetFilter: false,
     });
     expect(kinds(items)).toEqual([
@@ -51,25 +45,17 @@ describe("orderFilterItems", () => {
     ]);
   });
 
-  test("never places a scheme twice; the first slot claiming it wins", () => {
-    const items = orderFilterItems([country], {
-      order: ["u:country", "geographicSchemes", "otherSchemes"],
-      geographicSchemes: ["u:country"],
+  test("a pinned scheme isn't repeated by the trailing alphabetical sweep", () => {
+    const items = orderFilterItems([zebra, apple], {
+      pinned: ["u:zebra"],
       showCountryFacetFilter: false,
     });
-    expect(kinds(items)).toEqual(["u:country"]);
+    expect(kinds(items)).toEqual(["u:zebra", "u:apple"]);
   });
 
-  test("appends a trailing otherSchemes sweep so no scheme is dropped", () => {
-    const items = orderFilterItems([zebra, apple], {
-      order: ["year"],
-    });
-    expect(kinds(items)).toEqual(["year", "u:apple", "u:zebra"]);
-  });
-
-  test("ignores order tokens for schemes not present", () => {
+  test("ignores pinned URIs for schemes not present", () => {
     const items = orderFilterItems([apple], {
-      order: ["u:missing", "year", "otherSchemes"],
+      pinned: ["u:missing", "year"],
       showCountryFacetFilter: false,
     });
     expect(kinds(items)).toEqual(["year", "u:apple"]);

--- a/tests/components/filters/filterOrder.test.ts
+++ b/tests/components/filters/filterOrder.test.ts
@@ -60,4 +60,20 @@ describe("orderFilterItems", () => {
     });
     expect(kinds(items)).toEqual(["year", "u:apple"]);
   });
+
+  test("alphabetizes schemes alpha-numerically, not lexically", () => {
+    const phase10 = scheme("u:p10", "Phase 10");
+    const phase2 = scheme("u:p2", "Phase 2");
+    const items = orderFilterItems([phase10, phase2], {
+      pinned: [],
+    });
+    expect(kinds(items)).toEqual(["u:p2", "u:p10"]);
+  });
+
+  test("a repeated built-in slot is emitted once", () => {
+    const items = orderFilterItems([apple], {
+      pinned: ["year", "country", "year"],
+    });
+    expect(kinds(items)).toEqual(["year", "country", "u:apple"]);
+  });
 });

--- a/tests/components/filters/filterOrder.test.ts
+++ b/tests/components/filters/filterOrder.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "vitest";
+import { orderFilterItems } from "@/components/filters/filterOrder";
+import type { ConceptScheme } from "@/services/vocabulary/vocabularyService";
+
+function scheme(uri: string, label: string): ConceptScheme {
+  return { uri, label, topConcepts: [] };
+}
+
+// Display labels strip a trailing "Scheme"; alphabetizing must use that form.
+const zebra = scheme("u:zebra", "Zebra Scheme");
+const apple = scheme("u:apple", "Apple Scheme");
+const country = scheme("u:country", "Country");
+const region = scheme("u:region", "Region");
+const convening = scheme("u:convening", "Learning Convening");
+
+function kinds(items: ReturnType<typeof orderFilterItems>): string[] {
+  return items.map((i) =>
+    i.kind === "scheme" ? i.scheme.uri : i.kind,
+  );
+}
+
+describe("orderFilterItems", () => {
+  test("default order: year, country, then schemes alphabetically by display label", () => {
+    const items = orderFilterItems([zebra, apple]);
+    expect(kinds(items)).toEqual(["year", "country", "u:apple", "u:zebra"]);
+  });
+
+  test("omits the country card when the facet filter is hidden", () => {
+    const items = orderFilterItems([apple], { showCountryFacetFilter: false });
+    expect(kinds(items)).toEqual(["year", "u:apple"]);
+  });
+
+  test("pins a scheme by URI and groups geographic schemes in config order", () => {
+    const items = orderFilterItems([zebra, apple, country, region, convening], {
+      order: [
+        "u:convening",
+        "year",
+        "geographicSchemes",
+        "otherSchemes",
+      ],
+      geographicSchemes: ["u:country", "u:region"],
+      showCountryFacetFilter: false,
+    });
+    expect(kinds(items)).toEqual([
+      "u:convening",
+      "year",
+      "u:country",
+      "u:region",
+      "u:apple",
+      "u:zebra",
+    ]);
+  });
+
+  test("never places a scheme twice; the first slot claiming it wins", () => {
+    const items = orderFilterItems([country], {
+      order: ["u:country", "geographicSchemes", "otherSchemes"],
+      geographicSchemes: ["u:country"],
+      showCountryFacetFilter: false,
+    });
+    expect(kinds(items)).toEqual(["u:country"]);
+  });
+
+  test("appends a trailing otherSchemes sweep so no scheme is dropped", () => {
+    const items = orderFilterItems([zebra, apple], {
+      order: ["year"],
+    });
+    expect(kinds(items)).toEqual(["year", "u:apple", "u:zebra"]);
+  });
+
+  test("ignores order tokens for schemes not present", () => {
+    const items = orderFilterItems([apple], {
+      order: ["u:missing", "year", "otherSchemes"],
+      showCountryFacetFilter: false,
+    });
+    expect(kinds(items)).toEqual(["year", "u:apple"]);
+  });
+});

--- a/tests/services/evidenceMap.test.ts
+++ b/tests/services/evidenceMap.test.ts
@@ -89,17 +89,31 @@ describe("buildEvidenceMapModel", () => {
     expect(model.columns.find((c) => c.key === "cX")?.label).toBe("label:cX");
   });
 
-  test("sorts categories by label, not raw key", () => {
+  test("preserves the axis category order (the scheme hierarchy), unsorted", () => {
     const model = buildEvidenceMapModel(
       [cell("u:a", "x", 1), cell("u:b", "x", 1)],
+      // Given in hierarchy order (parent "Zebra" before its sorted children),
+      // not alphabetical — that order must survive unchanged.
       axisOf([
-        { key: "u:b", label: "Apple" },
-        { key: "u:a", label: "Banana" },
+        { key: "u:z", label: "Zebra" },
+        { key: "u:a", label: "Apple" },
+        { key: "u:b", label: "Banana" },
       ]),
       axisOf(),
     );
-    // u:b ("Apple") sorts before u:a ("Banana") despite key order.
-    expect(model.rows.map((r) => r.label)).toEqual(["Apple", "Banana"]);
+    expect(model.rows.map((r) => r.label)).toEqual(["Zebra", "Apple", "Banana"]);
+  });
+
+  test("appends cell-only keys after the axis categories, alphabetized", () => {
+    const model = buildEvidenceMapModel(
+      [cell("u:z", "x", 1), cell("u:b", "x", 1), cell("u:a", "x", 1)],
+      axisOf([{ key: "u:z", label: "Zebra" }], (k) =>
+        k === "u:a" ? "Apple" : k === "u:b" ? "Banana" : k,
+      ),
+      axisOf(),
+    );
+    // Enumerated "Zebra" stays first; the two cell-only keys trail it in label order.
+    expect(model.rows.map((r) => r.label)).toEqual(["Zebra", "Apple", "Banana"]);
   });
 
   test("looks up counts by pair, reports the maximum, and leaves empties undefined", () => {
@@ -179,6 +193,37 @@ describe("resolveMapAxis", () => {
     expect(axis.labelFor("https://vocab.esea.education/OutcomeScheme/C1")).toBe(
       "Access to Education",
     );
+  });
+
+  test("alphabetizes siblings at each level, keeping children under their parent", () => {
+    const unsorted: ConceptScheme = {
+      uri: "https://vocab.esea.education/RegionScheme",
+      label: "Region Scheme",
+      topConcepts: [
+        {
+          uri: "u:europe",
+          label: "Europe",
+          narrower: [
+            { uri: "u:spain", label: "Spain" },
+            { uri: "u:france", label: "France" },
+          ],
+        },
+        { uri: "u:africa", label: "Africa" },
+      ],
+    };
+    const axis = resolveMapAxis(
+      { kind: "scheme", schemeUri: "https://vocab.esea.education/RegionScheme" },
+      [unsorted],
+      null,
+    );
+    // Top concepts alphabetized (Africa before Europe); Europe's children
+    // alphabetized (France before Spain) and nested directly under it.
+    expect(axis.categories.map((c) => c.label)).toEqual([
+      "Africa",
+      "Europe",
+      "France",
+      "Spain",
+    ]);
   });
 
   test("falls back to the local name and no categories when the scheme is absent", () => {

--- a/tests/services/evidenceMap.test.ts
+++ b/tests/services/evidenceMap.test.ts
@@ -195,34 +195,38 @@ describe("resolveMapAxis", () => {
     );
   });
 
-  test("alphabetizes siblings at each level, keeping children under their parent", () => {
-    const unsorted: ConceptScheme = {
+  test("emits each concept once, even when reachable under two parents", () => {
+    // The vocabulary build orders siblings; flattenScheme preserves that order
+    // but must not double-emit a concept that is both a top concept and a
+    // narrower of another subtree (a malformed-but-possible vocab).
+    const europe = {
+      uri: "u:europe",
+      label: "Europe",
+      narrower: [
+        { uri: "u:france", label: "France" },
+        { uri: "u:spain", label: "Spain" },
+      ],
+    };
+    const scheme: ConceptScheme = {
       uri: "https://vocab.esea.education/RegionScheme",
       label: "Region Scheme",
       topConcepts: [
-        {
-          uri: "u:europe",
-          label: "Europe",
-          narrower: [
-            { uri: "u:spain", label: "Spain" },
-            { uri: "u:france", label: "France" },
-          ],
-        },
-        { uri: "u:africa", label: "Africa" },
+        { uri: "u:africa", label: "Africa", narrower: [europe] },
+        europe,
       ],
     };
     const axis = resolveMapAxis(
       { kind: "scheme", schemeUri: "https://vocab.esea.education/RegionScheme" },
-      [unsorted],
+      [scheme],
       null,
     );
-    // Top concepts alphabetized (Africa before Europe); Europe's children
-    // alphabetized (France before Spain) and nested directly under it.
-    expect(axis.categories.map((c) => c.label)).toEqual([
-      "Africa",
-      "Europe",
-      "France",
-      "Spain",
+    // Europe (and its children) is emitted under Africa; its second appearance
+    // as a top concept is skipped — no duplicate keys.
+    expect(axis.categories.map((c) => c.key)).toEqual([
+      "u:africa",
+      "u:europe",
+      "u:france",
+      "u:spain",
     ]);
   });
 

--- a/tests/services/vocabulary/vocabularyService.test.ts
+++ b/tests/services/vocabulary/vocabularyService.test.ts
@@ -174,7 +174,7 @@ describe("buildVocabularyData", () => {
     expect(schemes).toEqual([]);
   });
 
-  it("nests narrower concepts under their broader parent", () => {
+  it("nests narrower concepts under their broader parent, alphabetized", () => {
     const { schemes } = buildVocabularyData(SAMPLE_VOCABULARY);
     const theme = schemes.find(
       (s) => s.uri === "https://vocab.esea.education/EducationThemeScheme",
@@ -184,15 +184,42 @@ describe("buildVocabularyData", () => {
     expect(top?.uri).toBe(
       "https://vocab.esea.education/EducationThemeScheme/C00022",
     );
+    // Source order is C00074 then C00075; the build sorts siblings by label, so
+    // "Class Size" leads "Literacy and Reading Interventions".
     expect(top?.narrower).toEqual([
-      {
-        uri: "https://vocab.esea.education/EducationThemeScheme/C00074",
-        label: "Literacy and Reading Interventions",
-      },
       {
         uri: "https://vocab.esea.education/EducationThemeScheme/C00075",
         label: "Class Size",
       },
+      {
+        uri: "https://vocab.esea.education/EducationThemeScheme/C00074",
+        label: "Literacy and Reading Interventions",
+      },
+    ]);
+  });
+
+  it("orders siblings alpha-numerically (e.g. age ranges, not lexically)", () => {
+    const ages = ["21+ years", "9–14 years", "0–8 years", "15–20 years"];
+    const { schemes } = buildVocabularyData({
+      "@graph": [
+        {
+          "@id": "u:targetPopulation",
+          "@type": "skos:ConceptScheme",
+          "dct:title": "Target Population",
+          "skos:hasTopConcept": ages.map((_, i) => ({ "@id": `u:age${i}` })),
+        },
+        ...ages.map((label, i) => ({
+          "@id": `u:age${i}`,
+          "@type": "skos:Concept",
+          "skos:prefLabel": label,
+        })),
+      ],
+    });
+    expect(schemes[0]?.topConcepts.map((c) => c.label)).toEqual([
+      "0–8 years",
+      "9–14 years",
+      "15–20 years",
+      "21+ years",
     ]);
   });
 


### PR DESCRIPTION
Closes #148 - orders evidence map concepts by hierarchy level first, so parents always appear before children. Then ordered alphabetically.
Before & after:
<img width="867" height="813" alt="image" src="https://github.com/user-attachments/assets/733d0b95-1d51-438f-b8d6-ddaf9489789c" />
<img width="864" height="811" alt="image" src="https://github.com/user-attachments/assets/c189261d-6666-41fa-a956-65048057369a" />


Closes #149 - adds `pinnedFilters` to communities that display those filters first in given order, before the rest alphabetically.
Before & after:
<img width="422" height="901" alt="image" src="https://github.com/user-attachments/assets/b5eea412-74ae-4744-916e-2a7e878bf381" />
<img width="417" height="898" alt="image" src="https://github.com/user-attachments/assets/ad23f290-2eea-4ae0-a6ef-235732ce5dfb" />
