### PR TITLE
Persist AI summary runs in background

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import Router from "preact-router";
 import { AuthProvider } from "./auth/AuthContext";
 import { CommunityProvider } from "./community/CommunityContext";
+import { AiSummaryProvider } from "./components/ai-summary/AiSummaryProvider";
 import { AppShell } from "./components/layout/AppShell";
 import { SearchPage } from "./pages/SearchPage";
 import { VisualisePage } from "./pages/VisualisePage";
@@ -20,14 +21,16 @@ export function App() {
   return (
     <AuthProvider>
       <CommunityProvider>
-        <AppShell>
-          <Router onChange={emitUrlChange}>
-            <RecordDetailPage path="/:community/references/:id" />
-            <VisualisePage path="/:community/visualise" />
-            <SearchPage path="/:community" />
-            <NotFoundPage default />
-          </Router>
-        </AppShell>
+        <AiSummaryProvider>
+          <AppShell>
+            <Router onChange={emitUrlChange}>
+              <RecordDetailPage path="/:community/references/:id" />
+              <VisualisePage path="/:community/visualise" />
+              <SearchPage path="/:community" />
+              <NotFoundPage default />
+            </Router>
+          </AppShell>
+        </AiSummaryProvider>
       </CommunityProvider>
     </AuthProvider>
   );

--- a/src/components/ai-summary/AiSummaryDrawer.tsx
+++ b/src/components/ai-summary/AiSummaryDrawer.tsx
@@ -1,6 +1,8 @@
+import { useEffect, useState } from "preact/hooks";
 import { Drawer } from "@/components/common/Drawer";
 import { WarningIcon } from "@/components/common/icons";
 import { AI_SUMMARY_FLAG_FORM_URL } from "@/config";
+import { URL_CHANGE_EVENT } from "@/services/navigation";
 import type { AiSummaryContext, UseAiSummaryResult } from "@/hooks/useAiSummary";
 import type { SkipReason, SummariseResponse } from "@/services/summariser";
 import { formatTotal } from "@/utils/searchTotal";
@@ -138,7 +140,30 @@ function Disclaimer() {
   );
 }
 
+// Reactive path + query, so the footer knows whether we're already on the
+// summary's own search page.
+function useCurrentUrl(): string {
+  const [url, setUrl] = useState(
+    () => window.location.pathname + window.location.search,
+  );
+  useEffect(() => {
+    const onChange = () =>
+      setUrl(window.location.pathname + window.location.search);
+    window.addEventListener("popstate", onChange);
+    window.addEventListener(URL_CHANGE_EVENT, onChange);
+    return () => {
+      window.removeEventListener("popstate", onChange);
+      window.removeEventListener(URL_CHANGE_EVENT, onChange);
+    };
+  }, []);
+  return url;
+}
+
 function DrawerFooter({ ai }: { ai: UseAiSummaryResult }) {
+  const currentUrl = useCurrentUrl();
+  // Only worth offering "Open this search" from a different page.
+  const showOpenSearch = ai.originUrl !== null && ai.originUrl !== currentUrl;
+
   if (ai.status === "generating") {
     return (
       <footer class="ai-drawer__footer">
@@ -156,18 +181,26 @@ function DrawerFooter({ ai }: { ai: UseAiSummaryResult }) {
     );
   }
 
-  // Flagging only applies to a produced summary — not the error state.
-  if (ai.status !== "done" || !AI_SUMMARY_FLAG_FORM_URL) return null;
+  // The footer only applies to a produced summary — not the error state.
+  if (ai.status !== "done") return null;
+  if (!showOpenSearch && !AI_SUMMARY_FLAG_FORM_URL) return null;
   return (
     <footer class="ai-drawer__footer">
-      <a
-        class="ai-btn ai-btn--flag ai-btn--push"
-        href={AI_SUMMARY_FLAG_FORM_URL}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        ⚑ Flag this summary
-      </a>
+      {showOpenSearch && (
+        <a class="ai-btn" href={ai.originUrl ?? undefined}>
+          Open this search ↗
+        </a>
+      )}
+      {AI_SUMMARY_FLAG_FORM_URL && (
+        <a
+          class="ai-btn ai-btn--flag ai-btn--push"
+          href={AI_SUMMARY_FLAG_FORM_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          ⚑ Flag this summary
+        </a>
+      )}
     </footer>
   );
 }

--- a/src/components/ai-summary/AiSummaryMiniChip.tsx
+++ b/src/components/ai-summary/AiSummaryMiniChip.tsx
@@ -11,30 +11,37 @@ interface AiSummaryMiniChipProps {
  */
 export function AiSummaryMiniChip({ ai }: AiSummaryMiniChipProps) {
   if (!ai.minimized) return null;
+  const done = ai.status === "done";
 
-  if (ai.status === "done") {
-    return (
-      <div class="ai-mini is-ready">
-        <span class="ai-mini__dot-ready" aria-hidden="true">
-          ✓
-        </span>
-        <span>Summary ready</span>
-        <span class="ai-mini__sep" aria-hidden="true" />
+  // The whole chip reopens the drawer; the trailing action is View (done) or
+  // Cancel — the only way to stop a running job.
+  return (
+    <div class={`ai-mini${done ? " is-ready" : ""}`}>
+      <button
+        type="button"
+        class="ai-mini__reopen"
+        onClick={ai.open}
+        title="Reopen summary"
+      >
+        {done ? (
+          <span class="ai-mini__dot-ready" aria-hidden="true">
+            ✓
+          </span>
+        ) : (
+          <span class="ai-spinner" aria-hidden="true" />
+        )}
+        <span>{done ? "Summary ready" : "Summarising…"}</span>
+      </button>
+      <span class="ai-mini__sep" aria-hidden="true" />
+      {done ? (
         <button type="button" class="ai-mini__view" onClick={ai.open}>
           View
         </button>
-      </div>
-    );
-  }
-
-  return (
-    <div class="ai-mini">
-      <span class="ai-spinner" aria-hidden="true" />
-      <span>Summarising…</span>
-      <span class="ai-mini__sep" aria-hidden="true" />
-      <button type="button" class="ai-mini__cancel" onClick={ai.dismiss}>
-        Cancel
-      </button>
+      ) : (
+        <button type="button" class="ai-mini__cancel" onClick={ai.dismiss}>
+          Cancel
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/ai-summary/AiSummaryProvider.tsx
+++ b/src/components/ai-summary/AiSummaryProvider.tsx
@@ -1,0 +1,57 @@
+import { createContext, type ComponentChildren } from "preact";
+import { useContext, useEffect, useRef } from "preact/hooks";
+import { useAuth } from "@/auth/AuthContext";
+import { useCommunity } from "@/community/CommunityContext";
+import { useAiSummary, type UseAiSummaryResult } from "@/hooks/useAiSummary";
+import { AiSummaryDrawer } from "./AiSummaryDrawer";
+import { AiSummaryMiniChip } from "./AiSummaryMiniChip";
+import { aiSummariesEnabled } from "./aiSummariesEnabled";
+
+const AiSummaryCtx = createContext<UseAiSummaryResult | undefined>(undefined);
+
+/**
+ * Owns AI-summary state above the router, so a summary (and its chip) survives
+ * navigation and can be reopened on any page. The summary belongs to the
+ * community it started in; switching communities drops it.
+ */
+export function AiSummaryProvider({ children }: { children: ComponentChildren }) {
+  const ai = useAiSummary();
+  const community = useCommunity();
+  const { aiSummaryWriter } = useAuth();
+  const currentSlug = community?.slug ?? null;
+
+  // Drop the summary when the community changes out from under it.
+  const ownerSlug = useRef<string | null>(null);
+  useEffect(() => {
+    if (ai.status === "idle") {
+      ownerSlug.current = null;
+    } else if (ownerSlug.current === null) {
+      ownerSlug.current = currentSlug;
+    } else if (ownerSlug.current !== currentSlug) {
+      ai.dismiss();
+    }
+  }, [ai.status, ai.dismiss, currentSlug]);
+
+  // Drawer + chip render here (fixed-position overlays) so they show on any page.
+  return (
+    <AiSummaryCtx.Provider value={ai}>
+      {children}
+      {aiSummariesEnabled(community, aiSummaryWriter) && (
+        <>
+          <AiSummaryDrawer ai={ai} />
+          <AiSummaryMiniChip ai={ai} />
+        </>
+      )}
+    </AiSummaryCtx.Provider>
+  );
+}
+
+export function useAiSummaryContext(): UseAiSummaryResult {
+  const value = useContext(AiSummaryCtx);
+  if (value === undefined) {
+    throw new Error(
+      "useAiSummaryContext must be used within an AiSummaryProvider",
+    );
+  }
+  return value;
+}

--- a/src/components/ai-summary/ai-summary.css
+++ b/src/components/ai-summary/ai-summary.css
@@ -349,6 +349,21 @@
   justify-content: center;
   font-size: 11px;
 }
+.ai-mini__reopen {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+.ai-mini__reopen:hover {
+  color: var(--color-accent);
+}
 .ai-mini__view {
   font-family: var(--font-body);
   font-weight: 500;

--- a/src/components/ai-summary/aiSummariesEnabled.ts
+++ b/src/components/ai-summary/aiSummariesEnabled.ts
@@ -1,0 +1,18 @@
+import { SUMMARISER_BASE, SUMMARISER_MOCK } from "@/config";
+import type { Community } from "@/types/models";
+
+/**
+ * Whether the AI-summary feature should be offered: the community opts in, a
+ * summariser (real or mock) is configured, and the user holds the writer role
+ * (#145). Shared by the search-page entry point and the app-wide drawer/chip.
+ */
+export function aiSummariesEnabled(
+  community: Community | null,
+  aiSummaryWriter: boolean,
+): boolean {
+  return Boolean(
+    community?.features.aiSummaries &&
+      (Boolean(SUMMARISER_BASE) || SUMMARISER_MOCK) &&
+      aiSummaryWriter,
+  );
+}

--- a/src/hooks/useAiSummary.ts
+++ b/src/hooks/useAiSummary.ts
@@ -22,6 +22,8 @@ export interface AiSummaryInput {
   filters: Omit<SearchFilters, "page">;
   /** Display context, captured now so a later search can't make it drift. */
   context: AiSummaryContext;
+  /** URL of the originating search, so the drawer can link back to it. */
+  originUrl: string;
 }
 
 export interface UseAiSummaryResult {
@@ -32,6 +34,8 @@ export interface UseAiSummaryResult {
   errorMessage: string | null;
   /** Context for the active summary, frozen at generate time (null when idle). */
   context: AiSummaryContext | null;
+  /** URL of the search the active summary came from (null when idle). */
+  originUrl: string | null;
   /** The drawer is visible when there's an active summary and it isn't minimized. */
   drawerOpen: boolean;
   generate: (input: AiSummaryInput) => void;
@@ -44,9 +48,9 @@ export interface UseAiSummaryResult {
 }
 
 /**
- * Owns AI-summary generation state for a page. Lives above the drawer so a
- * summary survives "Run in background" (the drawer closing) and can be reopened
- * from the background chip without losing the result.
+ * Owns AI-summary generation state. Mounted in AiSummaryProvider above the
+ * router, so a summary survives "Run in background" and navigation, and can be
+ * reopened from the background chip on any page without losing the result.
  */
 export function useAiSummary(): UseAiSummaryResult {
   const [status, setStatus] = useState<AiSummaryStatus>("idle");
@@ -54,6 +58,7 @@ export function useAiSummary(): UseAiSummaryResult {
   const [result, setResult] = useState<SummariseResponse | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [context, setContext] = useState<AiSummaryContext | null>(null);
+  const [originUrl, setOriginUrl] = useState<string | null>(null);
 
   const abortRef = useRef<AbortController | null>(null);
   // Guards against a stale request resolving after dismiss/regenerate.
@@ -68,6 +73,7 @@ export function useAiSummary(): UseAiSummaryResult {
     setResult(null);
     setErrorMessage(null);
     setContext(null);
+    setOriginUrl(null);
   }, []);
 
   const generate = useCallback((input: AiSummaryInput) => {
@@ -84,6 +90,7 @@ export function useAiSummary(): UseAiSummaryResult {
     // Freeze the context for this run so editing the search afterwards (while it
     // generates or runs in the background) can't change what the drawer shows.
     setContext(input.context);
+    setOriginUrl(input.originUrl);
 
     // Resolve every matching reference id, then summarise them. Both steps
     // honour the abort signal, so dismiss/regenerate cancels in-flight work.
@@ -128,6 +135,7 @@ export function useAiSummary(): UseAiSummaryResult {
     result,
     errorMessage,
     context,
+    originUrl,
     drawerOpen: status !== "idle" && !minimized,
     generate,
     open,

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -26,11 +26,9 @@ import { ResultRow } from "@/components/search/ResultRow";
 import { Pagination } from "@/components/common/Pagination";
 import { FilterDrawer, type AppliedFilters } from "@/components/filters/FilterDrawer";
 import { AiSummaryButton } from "@/components/ai-summary/AiSummaryButton";
-import { AiSummaryDrawer } from "@/components/ai-summary/AiSummaryDrawer";
-import { AiSummaryMiniChip } from "@/components/ai-summary/AiSummaryMiniChip";
-import { useAiSummary } from "@/hooks/useAiSummary";
+import { useAiSummaryContext } from "@/components/ai-summary/AiSummaryProvider";
+import { aiSummariesEnabled } from "@/components/ai-summary/aiSummariesEnabled";
 import { deriveSummaryTerms } from "@/components/ai-summary/summaryTerms";
-import { SUMMARISER_BASE, SUMMARISER_MOCK } from "@/config";
 import { formatTotal } from "@/utils/searchTotal";
 import { totalSelectedCount } from "@/components/filters/conceptSchemeFilterState";
 import { totalSelectedCount as totalSelectedCountryCount } from "@/components/filters/countryFilterState";
@@ -146,7 +144,7 @@ function SearchPageInner({ community }: { community: Community }) {
   const corpus = useCorpusTotal();
   const results = useSearch(params);
   const exportJob = useSearchExport();
-  const ai = useAiSummary();
+  const ai = useAiSummaryContext();
 
   // Kick off the vocabulary fetch on page mount (not on drawer open) via the
   // shared cache, so the Refine button is almost always ready by the time
@@ -282,29 +280,27 @@ function SearchPageInner({ community }: { community: Community }) {
   // (VITE_SUMMARISER_MOCK also enables it for local dev). The ai_summary.writer
   // role gates it per-user (#145).
   const { aiSummaryWriter } = useAuth();
-  const aiSummariesEnabled =
-    community.features.aiSummaries &&
-    (Boolean(SUMMARISER_BASE) || SUMMARISER_MOCK) &&
-    aiSummaryWriter;
+  const aiEnabled = aiSummariesEnabled(community, aiSummaryWriter);
 
   // Terms framing the summary: the free-text query plus any applied concept
   // filters (a map cell arrives here with those filters pre-applied).
   const aiTerms = deriveSummaryTerms(params, vocab.labels);
   const aiTotal = results.results?.total ?? { count: 0, is_lower_bound: false };
-  // The summariser accepts 1–50 references and at least one term; gate here so
-  // the user gets a clear reason rather than a server error.
+  // One summary at a time: while one is parked in the background (generating or
+  // unread) the button stays disabled and the indicator is the only way back.
+  // The rest mirror the summariser's limits — one term minimum, 1–50 references.
   const aiDisabledReason =
-    aiTerms.length === 0
-      ? "Search or filter by a term to summarise."
-      : aiTotal.count > MAX_SUMMARY_REFERENCES
-        ? `AI summaries cover up to ${MAX_SUMMARY_REFERENCES} references — refine your search.`
-        : undefined;
+    ai.status === "generating"
+      ? "A summary's still processing - open it to follow along or cancel."
+      : ai.minimized
+        ? "Your summary's ready - open it from the indicator to read it."
+        : aiTerms.length === 0
+          ? "Search or filter by a term to summarise."
+          : aiTotal.count > MAX_SUMMARY_REFERENCES
+            ? `AI summaries cover up to ${MAX_SUMMARY_REFERENCES} references - please refine your search.`
+            : undefined;
 
   function handleGenerateSummary() {
-    if (ai.minimized) {
-      ai.open();
-      return;
-    }
     const { query, filters } = toUnpaginatedSearchQuery(
       params,
       community.defaultAnnotations,
@@ -318,6 +314,7 @@ function SearchPageInner({ community }: { community: Community }) {
         count: aiTotal,
         countNoun: community.copy.countNoun,
       },
+      originUrl: buildSearchUrl(community.slug, params),
     });
   }
 
@@ -359,7 +356,7 @@ function SearchPageInner({ community }: { community: Community }) {
         />
       </section>
 
-      {aiSummariesEnabled && hasResults && (
+      {aiEnabled && hasResults && (
         <AiSummaryButton
           onClick={handleGenerateSummary}
           disabled={aiDisabledReason !== undefined}
@@ -481,13 +478,6 @@ function SearchPageInner({ community }: { community: Community }) {
           />
         )}
       </section>
-
-      {aiSummariesEnabled && (
-        <>
-          <AiSummaryDrawer ai={ai} />
-          <AiSummaryMiniChip ai={ai} />
-        </>
-      )}
 
       {filterableSchemes.length > 0 && (
         <FilterDrawer

--- a/tests/App.aiSummary.integration.test.tsx
+++ b/tests/App.aiSummary.integration.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/preact";
+import { vi, test, expect, beforeEach } from "vitest";
+import type { SearchResult } from "@/types/models";
+import { makeReference, makeVocabResult } from "./fixtures";
+
+// Feature gate forced on: these tests cover the summary's lifecycle across
+// navigation, not the enablement rules (summariser config + writer role).
+vi.mock("@/components/ai-summary/aiSummariesEnabled", () => ({
+  aiSummariesEnabled: () => true,
+}));
+
+// Mock at the service boundary so generation timing is ours to control — hold
+// it "generating", then resolve when the test wants the done state.
+vi.mock("@/services/apiClient", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/apiClient")>()),
+  searchReferences: vi.fn(),
+  searchReferenceIds: vi.fn(),
+}));
+
+vi.mock("@/services/summariserClient", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/summariserClient")>()),
+  requestSummary: vi.fn(),
+}));
+
+vi.mock("@/hooks/useVocabulary", () => ({ useVocabulary: vi.fn() }));
+
+// The same-community route hop lands on the record detail page; stub its data
+// so it renders a loading shell rather than firing a real fetch.
+vi.mock("@/hooks/useReference", () => ({
+  useReference: () => ({ reference: null, loading: true, error: null }),
+}));
+
+import { App } from "@/App";
+import { searchReferences, searchReferenceIds } from "@/services/apiClient";
+import { requestSummary } from "@/services/summariserClient";
+import { useVocabulary } from "@/hooks/useVocabulary";
+import { MOCK_SUMMARY } from "@/services/summariserMock";
+import { navigate } from "@/services/navigation";
+
+const mockSearch = vi.mocked(searchReferences);
+const mockSearchIds = vi.mocked(searchReferenceIds);
+const mockRequestSummary = vi.mocked(requestSummary);
+const mockVocab = vi.mocked(useVocabulary);
+
+function makeResult(count: number, ids: string[]): SearchResult {
+  return {
+    total: { count, is_lower_bound: false },
+    page: { count: ids.length, number: 1 },
+    references: ids.map((id) => makeReference({ id })),
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  mockVocab.mockReturnValue(makeVocabResult());
+  // ≤ 50 references (so the summariser cap doesn't gate the button) with at
+  // least one present (so the button renders).
+  mockSearch.mockResolvedValue(makeResult(3, ["r1", "r2", "r3"]));
+  mockSearchIds.mockResolvedValue({
+    total: { count: 3, is_lower_bound: false },
+    reference_ids: ["r1", "r2", "r3"],
+  });
+});
+
+// Generate a summary, then send the in-flight job to the background chip.
+async function generateAndBackground() {
+  fireEvent.click(
+    await screen.findByRole("button", { name: /generate ai summary/i }),
+  );
+  fireEvent.click(
+    await screen.findByRole("button", { name: /run in background/i }),
+  );
+  await screen.findByText(/summarising/i);
+}
+
+test("keeps a background summary across same-community routes and blocks a new run until viewed", async () => {
+  const job = deferred<typeof MOCK_SUMMARY>();
+  mockRequestSummary.mockReturnValue(job.promise);
+
+  history.pushState({}, "", "/esea?q=malaria");
+  render(<App />);
+
+  await generateAndBackground();
+
+  // Let it finish in the background → "Summary ready".
+  await act(async () => {
+    job.resolve(MOCK_SUMMARY);
+  });
+  await screen.findByText(/summary ready/i);
+
+  // Hop to another route in the same community and back — the chip survives.
+  await act(async () => {
+    navigate("/esea/references/r1");
+  });
+  expect(screen.getByText(/summary ready/i)).toBeInTheDocument();
+
+  await act(async () => {
+    navigate("/esea?q=malaria");
+  });
+  await screen.findByText(/summary ready/i);
+
+  // A finished-but-unread summary blocks a new run...
+  expect(
+    await screen.findByRole("button", { name: /generate ai summary/i }),
+  ).toBeDisabled();
+
+  // ...until it's viewed via the indicator, which reopens the drawer.
+  fireEvent.click(screen.getByRole("button", { name: /^view$/i }));
+  await screen.findByText(/ai-generated from the papers/i);
+  await waitFor(() =>
+    expect(
+      screen.getByRole("button", { name: /generate ai summary/i }),
+    ).toBeEnabled(),
+  );
+});
+
+test("drops the active summary when the user changes community", async () => {
+  // Never resolves: the summary is still generating when the community changes.
+  mockRequestSummary.mockReturnValue(deferred<typeof MOCK_SUMMARY>().promise);
+
+  history.pushState({}, "", "/esea?q=malaria");
+  render(<App />);
+
+  await generateAndBackground();
+
+  await act(async () => {
+    navigate("/hpv?q=malaria");
+  });
+
+  await waitFor(() =>
+    expect(screen.queryByText(/summarising/i)).not.toBeInTheDocument(),
+  );
+});

--- a/tests/components/ai-summary/AiSummaryDrawer.test.tsx
+++ b/tests/components/ai-summary/AiSummaryDrawer.test.tsx
@@ -22,6 +22,7 @@ function makeAi(overrides: Partial<UseAiSummaryResult> = {}): UseAiSummaryResult
     result: MOCK_SUMMARY,
     errorMessage: null,
     context,
+    originUrl: "/test-community?q=afghanistan",
     drawerOpen: true,
     generate: vi.fn(),
     open: vi.fn(),

--- a/tests/hooks/useAiSummary.test.tsx
+++ b/tests/hooks/useAiSummary.test.tsx
@@ -35,6 +35,7 @@ const input: AiSummaryInput = {
     count: { count: 3, is_lower_bound: false },
     countNoun: "references",
   },
+  originUrl: "/test-community?q=afghanistan",
 };
 
 function resolveIds(reference_ids: string[]) {

--- a/tests/pages/SearchPage.test.tsx
+++ b/tests/pages/SearchPage.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/preact";
 import { SearchPage } from "@/pages/SearchPage";
 import { CommunityProvider } from "@/community/CommunityContext";
 import { AuthProvider } from "@/auth/AuthContext";
+import { AiSummaryProvider } from "@/components/ai-summary/AiSummaryProvider";
 import type { SearchResult } from "@/types/models";
 import {
   OUTCOME_SCHEME_FIXTURE,
@@ -15,7 +16,9 @@ function renderSearchPage() {
   return render(
     <AuthProvider>
       <CommunityProvider>
-        <SearchPage />
+        <AiSummaryProvider>
+          <SearchPage />
+        </AiSummaryProvider>
       </CommunityProvider>
     </AuthProvider>,
   );


### PR DESCRIPTION
Simple implementation of behaviour discussed in https://covidence.slack.com/archives/C0810ARPCRG/p1781261286936989?thread_ts=1781238605.371139&cid=C0810ARPCRG

Lifts the AI summary drawer up into the main application so it can be invoked from other pages. The summary indicator persists across navigation. 

New summaries may not be requested until the existing one is either cancelled, or finished and viewed.

Weaknesses: does not persist across hard refreshes or new tabs. `Cancel` does not actually cancel the server-side request - the backend does not expose that functionality.