### PR TITLE
Update search placeholder to "Search titles and abstracts"

### DIFF
--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -13,7 +13,7 @@ export function SearchBar({
   draftQ,
   onDraftQChange,
   onSubmit,
-  placeholder = "Search the evidence",
+  placeholder = "Search titles and abstracts",
   disabled = false,
 }: SearchBarProps) {
   function handleSubmit(e?: Event) {

--- a/src/services/communities.ts
+++ b/src/services/communities.ts
@@ -43,7 +43,7 @@ function buildCopy(
   overrides: Partial<CommunityCopy>,
 ): CommunityCopy {
   return {
-    searchPlaceholder: "Search the evidence",
+    searchPlaceholder: "Search titles and abstracts",
     drawerTitle: "Refine the evidence",
     countNoun: "results",
     corpusDescriptor: `${name.toLowerCase()} research`,

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -67,7 +67,7 @@ export function makeCommunity(
       ...features,
     },
     copy: {
-      searchPlaceholder: "Search the evidence",
+      searchPlaceholder: "Search titles and abstracts",
       drawerTitle: "Refine the evidence",
       countNoun: "results",
       corpusDescriptor: "test research",

--- a/tests/services/communities.test.ts
+++ b/tests/services/communities.test.ts
@@ -39,13 +39,14 @@ describe("communities", () => {
     // copy: overridden noun, name-derived corpusDescriptor, shared defaults.
     expect(esea?.copy.countNoun).toBe("investigations");
     expect(esea?.copy.corpusDescriptor).toBe("education research");
-    expect(esea?.copy.searchPlaceholder).toBe("Search the evidence");
+    expect(esea?.copy.searchPlaceholder).toBe("Search titles and abstracts");
     expect(typeof esea?.features.evidenceMap).toBe("boolean");
 
     expect(hpv?.name).toBe("HPV Vaccine Delivery");
     expect(hpv?.vocabularyUrl).toBe("https://vocab.example/hpv-v1");
     expect(hpv?.copy.countNoun).toBe("references");
     expect(hpv?.copy.corpusDescriptor).toBe("HPV vaccine delivery research");
+    expect(hpv?.copy.searchPlaceholder).toBe("Search titles and abstracts");
     expect(typeof hpv?.features.evidenceMap).toBe("boolean");
     expect(hpv?.codingInstitution).toBeUndefined();
   });


### PR DESCRIPTION
Closes #153.

Changes the search field placeholder from "Search the evidence" to "Search titles and abstracts" so users can see which fields the query searches against.

The copy lives in the shared community-copy fallback (`buildCopy` in `src/services/communities.ts`), so both communities (Education and HPV) inherit the new text from a single source. The `SearchBar` default prop and the test fixture default were updated to match, keeping every placeholder source consistent. The "Search the evidence" `<h1>` hero heading is intentionally left unchanged; the issue scopes only the input field.

## Validation performed
- Typecheck clean (`tsc --noEmit`).
- Full test suite green (849/849); the communities suite asserts both communities resolve the new placeholder.
- Live-verified the rendered placeholder reads "Search titles and abstracts" for both the Education (ESEA) and HPV communities.
