### PR TITLE
Replace "Signing you in..." text with loading spinner

### DIFF
--- a/src/auth/AuthGate.tsx
+++ b/src/auth/AuthGate.tsx
@@ -26,7 +26,7 @@ export function Landing() {
 export function Loading() {
   return (
     <div class="auth-gate">
-      <Spinner />
+      <Spinner size={36} />
     </div>
   );
 }

--- a/src/auth/AuthGate.tsx
+++ b/src/auth/AuthGate.tsx
@@ -1,3 +1,4 @@
+import { Spinner } from "@/components/common/Spinner";
 import { login, register } from "./keycloak";
 
 export function Landing() {
@@ -25,7 +26,7 @@ export function Landing() {
 export function Loading() {
   return (
     <div class="auth-gate">
-      <p>Signing you in…</p>
+      <Spinner />
     </div>
   );
 }

--- a/src/components/ai-summary/AiSummaryDrawer.tsx
+++ b/src/components/ai-summary/AiSummaryDrawer.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "preact/hooks";
 import { Drawer } from "@/components/common/Drawer";
+import { Spinner } from "@/components/common/Spinner";
 import { WarningIcon } from "@/components/common/icons";
 import { AI_SUMMARY_FLAG_FORM_URL } from "@/config";
 import { URL_CHANGE_EVENT } from "@/services/navigation";
@@ -57,7 +58,7 @@ export function AiSummaryDrawer({ ai }: AiSummaryDrawerProps) {
     >
       {ai.status === "generating" && context && (
         <div class="ai-loading">
-          <span class="ai-spinner" />
+          <Spinner size={14} class="ai-loading__spinner" />
           <span>
             Summarising {formatTotal(context.count)} {context.countNoun}… this
             can take several minutes. You can keep working — use “Run in

--- a/src/components/ai-summary/AiSummaryMiniChip.tsx
+++ b/src/components/ai-summary/AiSummaryMiniChip.tsx
@@ -1,3 +1,4 @@
+import { Spinner } from "@/components/common/Spinner";
 import type { UseAiSummaryResult } from "@/hooks/useAiSummary";
 import "./ai-summary.css";
 
@@ -28,7 +29,7 @@ export function AiSummaryMiniChip({ ai }: AiSummaryMiniChipProps) {
             ✓
           </span>
         ) : (
-          <span class="ai-spinner" aria-hidden="true" />
+          <Spinner size={14} />
         )}
         <span>{done ? "Summary ready" : "Summarising…"}</span>
       </button>

--- a/src/components/ai-summary/ai-summary.css
+++ b/src/components/ai-summary/ai-summary.css
@@ -143,20 +143,9 @@
   font-size: var(--font-size-small);
   color: var(--color-text-tertiary);
 }
-.ai-spinner {
-  flex: 0 0 auto;
-  width: 14px;
-  height: 14px;
-  border: 1.5px solid var(--color-accent-light);
-  border-top-color: var(--color-accent);
-  border-radius: 50%;
+/* Nudge the spinner down to align with the first line of loading text. */
+.ai-loading__spinner {
   margin-top: 3px;
-  animation: ai-spin 0.7s linear infinite;
-}
-@keyframes ai-spin {
-  to {
-    transform: rotate(360deg);
-  }
 }
 
 /* ── Narrative prose + footnotes ──────────────────────────── */
@@ -398,8 +387,5 @@
 @media (prefers-reduced-motion: reduce) {
   .ai-mini {
     animation: none;
-  }
-  .ai-spinner {
-    animation-duration: 1.4s;
   }
 }

--- a/src/components/common/Spinner.css
+++ b/src/components/common/Spinner.css
@@ -1,0 +1,25 @@
+.spinner {
+  display: inline-block;
+  flex: 0 0 auto;
+  box-sizing: border-box;
+  width: var(--spinner-size, 24px);
+  height: var(--spinner-size, 24px);
+  border: 2px solid var(--color-accent-light);
+  border-top-color: var(--color-accent);
+  border-radius: 50%;
+  animation: spinner-spin 0.7s linear infinite;
+}
+
+@keyframes spinner-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Keep a slow spin rather than freezing: a frozen indicator during a long
+   wait reads as broken. */
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation-duration: 1.4s;
+  }
+}

--- a/src/components/common/Spinner.tsx
+++ b/src/components/common/Spinner.tsx
@@ -1,0 +1,22 @@
+import "./Spinner.css";
+
+interface SpinnerProps {
+  /** Diameter in px. Defaults to 24. */
+  size?: number;
+  /** Extra class for layout (e.g. margins) in the host context. */
+  class?: string;
+}
+
+/**
+ * Animated rotating ring used to indicate an in-progress wait. Sizes via the
+ * --spinner-size CSS var; respects prefers-reduced-motion.
+ */
+export function Spinner({ size, class: className }: SpinnerProps) {
+  return (
+    <span
+      class={`spinner${className ? ` ${className}` : ""}`}
+      aria-hidden="true"
+      style={size ? { "--spinner-size": `${size}px` } : undefined}
+    />
+  );
+}

--- a/tests/auth/AuthGate.test.tsx
+++ b/tests/auth/AuthGate.test.tsx
@@ -4,9 +4,9 @@ import { AuthError, Landing, Loading } from "@/auth/AuthGate";
 import { login, register } from "@/auth/keycloak";
 
 describe("AuthGate", () => {
-  test("Loading shows the signing-in message", () => {
-    render(<Loading />);
-    expect(screen.getByText("Signing you in…")).toBeInTheDocument();
+  test("Loading shows an animated spinner", () => {
+    const { container } = render(<Loading />);
+    expect(container.querySelector(".spinner")).toBeInTheDocument();
   });
 
   describe("Landing", () => {


### PR DESCRIPTION
Closes #157 

Extracted spinner to a shared component and reuse it for both the auth loading page and the AI spinner. 

If you want to visually test, check out the branch, start it up, and you should see it on the loading page. Hard to take a screenshot of because it's so quick! 