### PR TITLE
Sort by newest if sort field is relevance and there is no keyword search

### DIFF
--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "preact/hooks";
 import { searchReferences, type SearchFilters } from "@/services/apiClient";
-import { SORT_BACKEND } from "@/services/searchParams";
+import { effectiveSortBackend } from "@/services/searchParams";
 import { useCommunity } from "@/community/CommunityContext";
 import type { SearchResult } from "@/types/models";
 import type { SearchParams } from "@/services/searchParams";
@@ -65,7 +65,8 @@ export function useSearch(params: SearchParams): {
       conceptFilters: params.conceptFilters,
       countryCodes: params.countryCodes,
     };
-    if (params.sort !== undefined) filters.sort = [SORT_BACKEND[params.sort]];
+    const sort = effectiveSortBackend(params);
+    if (sort !== undefined) filters.sort = sort;
 
     searchReferences(params.q || undefined, filters)
       .then((r) => { if (!cancelled) setResults(r); })

--- a/src/services/searchParams.ts
+++ b/src/services/searchParams.ts
@@ -9,6 +9,18 @@ export const SORT_BACKEND: Record<SortOption, string> = {
   oldest: "publication_year",
 };
 
+// Resolves the `sort` array sent to the API. With no free-text query
+// Elasticsearch scores every doc 1, so a "relevance" (undefined) sort
+// produces arbitrary ordering. Fall back to `newest` in that case.
+// This is deliberately invisible to the URL and the sort dropdown.
+export function effectiveSortBackend(
+  params: Pick<SearchParams, "q" | "sort">,
+): string[] | undefined {
+  if (params.sort !== undefined) return [SORT_BACKEND[params.sort]];
+  if (params.q.trim() === "") return [SORT_BACKEND.newest];
+  return undefined;
+}
+
 export interface SearchParams {
   q: string;
   page: number;
@@ -43,7 +55,10 @@ export function parseSearchParams(search: string): SearchParams {
 
   const conceptFilters: string[][] = [];
   for (const raw of params.getAll("concept")) {
-    const uris = raw.split(",").map((s) => s.trim()).filter((s) => s !== "");
+    const uris = raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s !== "");
     if (uris.length > 0) conceptFilters.push(uris);
   }
 
@@ -81,14 +96,18 @@ export function toQueryString(params: SearchParams): string {
   if (params.countryCodes.length > 0) {
     out.append("country", params.countryCodes.join(","));
   }
-  if (params.startYear !== undefined) out.set("start_year", String(params.startYear));
+  if (params.startYear !== undefined)
+    out.set("start_year", String(params.startYear));
   if (params.endYear !== undefined) out.set("end_year", String(params.endYear));
   if (params.sort !== undefined) out.set("sort", params.sort);
   if (params.page !== 1) out.set("page", String(params.page));
   return out.toString();
 }
 
-export function buildSearchUrl(communitySlug: string, params: SearchParams): string {
+export function buildSearchUrl(
+  communitySlug: string,
+  params: SearchParams,
+): string {
   const qs = toQueryString(params);
   return qs ? `/${communitySlug}?${qs}` : `/${communitySlug}`;
 }
@@ -106,7 +125,8 @@ export function toUnpaginatedSearchQuery(
     endYear: params.endYear,
     annotation: annotations,
   };
-  if (params.sort !== undefined) filters.sort = [SORT_BACKEND[params.sort]];
+  const sort = effectiveSortBackend(params);
+  if (sort !== undefined) filters.sort = sort;
   if (params.conceptFilters.length > 0) {
     filters.conceptFilters = params.conceptFilters;
   }

--- a/tests/hooks/useSearch.test.tsx
+++ b/tests/hooks/useSearch.test.tsx
@@ -221,6 +221,20 @@ describe("useSearch", () => {
     expect(filters).not.toHaveProperty("sort");
   });
 
+  // Browse mode (empty q) has no relevance signal — ES scores all docs 1 — so
+  // the hook quietly sorts by newest while leaving the URL/dropdown on relevance.
+  test("empty q + undefined sort sends newest fallback to the API", async () => {
+    mockSearch.mockResolvedValue(makeResult(1));
+    renderHook(() => useSearch(makeSearchParams({ countryCodes: ["DE"] })), {
+      wrapper: withCommunityPath("/esea"),
+    });
+    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
+    expect(mockSearch).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ sort: ["-publication_year"] }),
+    );
+  });
+
   test("refetches when sort changes (cache key includes sort)", async () => {
     mockSearch.mockResolvedValue(makeResult(1));
     const { rerender } = renderHook(

--- a/tests/pages/SearchPage.test.tsx
+++ b/tests/pages/SearchPage.test.tsx
@@ -558,6 +558,8 @@ describe("SearchPage", () => {
         startYear: undefined,
         endYear: undefined,
         annotation: ["domain-inclusion/jacobs-education"],
+        // Browse mode has no relevance signal, so export mirrors the newest fallback.
+        sort: ["-publication_year"],
       });
     });
 
@@ -597,6 +599,7 @@ describe("SearchPage", () => {
         startYear: 2020,
         endYear: undefined,
         annotation: ["domain-inclusion/jacobs-education"],
+        sort: ["-publication_year"],
       });
     });
 

--- a/tests/services/searchParams.test.ts
+++ b/tests/services/searchParams.test.ts
@@ -315,6 +315,24 @@ describe("toUnpaginatedSearchQuery", () => {
     expect(out.filters.conceptFilters).toEqual([["https://x/A"]]);
   });
 
+  // ES scores every doc 1 with no free-text query, so relevance ordering is
+  // arbitrary; browse mode falls back to newest without touching the URL.
+  test("empty q + no explicit sort → newest fallback on filters", () => {
+    const out = toUnpaginatedSearchQuery(makeSearchParams(), ["dom-x"]);
+    expect(out.query).toBe("*");
+    expect(out.filters.sort).toEqual(["-publication_year"]);
+  });
+
+  test("non-empty q + no explicit sort → no fallback (relevance)", () => {
+    const out = toUnpaginatedSearchQuery(makeSearchParams({ q: "phonics" }), ["dom-x"]);
+    expect(out.filters).not.toHaveProperty("sort");
+  });
+
+  test("empty q + explicit oldest sort → oldest honoured (no override)", () => {
+    const out = toUnpaginatedSearchQuery(makeSearchParams({ sort: "oldest" }), ["dom-x"]);
+    expect(out.filters.sort).toEqual(["publication_year"]);
+  });
+
   test("filters carry years + annotations + sort alongside structured countries", () => {
     const p = makeSearchParams({
       q: "phonics",


### PR DESCRIPTION
Essentially sets `newest` as a secondary sort when relevance is unable to distinguish records.