### PR TITLE
Add HPV reference-level Excel export (#127)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,9 @@
 VITE_API_TARGET=http://localhost:8000
 VITE_VOCAB_PROXY_TARGET=https://vocab.staging.evidence-repository.org
+# Proxies signed search-export blob downloads in local dev: the deployed storage
+# account's CORS allows only the production UI origins, not localhost. Set to the
+# blob endpoint of the storage account the API hands back signed URLs for.
+VITE_BLOB_PROXY_TARGET=https://destinyrepositorystagsa.blob.core.windows.net
 VITE_KEYCLOAK_URL=https://auth.evidence-repository.org
 VITE_KEYCLOAK_REALM=destiny
 VITE_KEYCLOAK_CLIENT_ID=evidence-repo-ui-client-development

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,3 +41,20 @@ export function proxyVocabUrl(url: string): string {
   }
   return url;
 }
+
+const BLOB_PROXY_TARGET = import.meta.env.VITE_BLOB_PROXY_TARGET;
+
+/**
+ * Rewrite a signed blob-storage URL (e.g. a search-export download) through the
+ * local dev proxy when VITE_BLOB_PROXY_TARGET is set. The deployed storage
+ * account's CORS allows only the production UI origins, so local dev can't fetch
+ * the blob cross-origin; the proxy makes it same-origin. The SAS query string is
+ * preserved. In production, returns the URL unchanged.
+ */
+export function proxyBlobUrl(url: string): string {
+  if (!BLOB_PROXY_TARGET) return url;
+  if (url.startsWith(BLOB_PROXY_TARGET)) {
+    return "/blob-proxy" + url.slice(BLOB_PROXY_TARGET.length);
+  }
+  return url;
+}

--- a/src/hooks/useSearchExport.ts
+++ b/src/hooks/useSearchExport.ts
@@ -6,7 +6,11 @@ import {
   type SearchFilters,
 } from "@/services/apiClient";
 import { exportReferencesToExcel } from "@/services/export/export";
-import type { CodingInstitutionConfig, SearchExportRead } from "@/types/models";
+import type {
+  CodingInstitutionConfig,
+  ExportVariant,
+  SearchExportRead,
+} from "@/types/models";
 
 export type ExportStatus =
   | "idle"
@@ -22,6 +26,7 @@ export interface StartExportOptions {
   filename: string;
   vocabularyUrl: string;
   contextUrl: string;
+  variant: ExportVariant;
   codingInstitution?: CodingInstitutionConfig;
 }
 
@@ -76,6 +81,7 @@ export function useSearchExport(): UseSearchExportResult {
       filename,
       vocabularyUrl,
       contextUrl,
+      variant,
       codingInstitution,
     }: StartExportOptions) => {
       runIdRef.current += 1;
@@ -108,6 +114,7 @@ export function useSearchExport(): UseSearchExportResult {
             vocabularyUrl,
             contextUrl,
             filename,
+            variant,
             codingInstitution,
           );
         } catch (err) {

--- a/src/hooks/useSearchExport.ts
+++ b/src/hooks/useSearchExport.ts
@@ -9,6 +9,7 @@ import { exportReferencesToExcel } from "@/services/export/export";
 import type {
   CodingInstitutionConfig,
   ExportVariant,
+  PinnedFilter,
   SearchExportRead,
 } from "@/types/models";
 
@@ -28,6 +29,7 @@ export interface StartExportOptions {
   contextUrl: string;
   variant: ExportVariant;
   codingInstitution?: CodingInstitutionConfig;
+  pinnedFilters?: PinnedFilter[];
 }
 
 export interface UseSearchExportResult {
@@ -83,6 +85,7 @@ export function useSearchExport(): UseSearchExportResult {
       contextUrl,
       variant,
       codingInstitution,
+      pinnedFilters,
     }: StartExportOptions) => {
       runIdRef.current += 1;
       const runId = runIdRef.current;
@@ -116,6 +119,7 @@ export function useSearchExport(): UseSearchExportResult {
             filename,
             variant,
             codingInstitution,
+            pinnedFilters,
           );
         } catch (err) {
           fail(

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -271,6 +271,7 @@ function SearchPageInner({ community }: { community: Community }) {
       filename: formatExportFilename(community.slug),
       vocabularyUrl: community.vocabularyUrl,
       contextUrl: community.contextUrl,
+      variant: community.exportVariant,
       codingInstitution: community.codingInstitution,
     });
   }

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -273,6 +273,7 @@ function SearchPageInner({ community }: { community: Community }) {
       contextUrl: community.contextUrl,
       variant: community.exportVariant,
       codingInstitution: community.codingInstitution,
+      pinnedFilters: community.pinnedFilters,
     });
   }
 

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -126,9 +126,9 @@ export async function crossFacets(
   );
 }
 
-// Unlike searchReferences, no empty-q → "*" shim: the export endpoint is
-// gated at the search page (button disabled when q is empty), and an
-// explicit "*" from the user is forwarded as-is.
+// Unlike searchReferences, no empty-q → "*" shim here: the search page already
+// forwards "*" for a browse/empty search (exporting the whole corpus), and a
+// user's explicit "*" passes through as-is.
 export async function requestSearchExport(
   query: string,
   filters: Omit<SearchFilters, "page"> = {},

--- a/src/services/communities.ts
+++ b/src/services/communities.ts
@@ -81,6 +81,7 @@ const COMMUNITIES: Community[] = [
       },
     },
     copy: buildCopy("Education", { countNoun: "investigations" }),
+    exportVariant: "esea",
     codingInstitution: rawSourcePatterns([
       [/(^|[^a-z])eef([^a-z]|$)/, "EEF"],
       [/(^|[^a-z])iiie([^a-z]|$)/, "IIIE"],
@@ -123,6 +124,7 @@ const COMMUNITIES: Community[] = [
       selfSignup: true,
       findingsAndEstimates: false,
       countryFacetFilter: false,
+      exportExcel: true,
     },
     defaultEvidenceMapAxes: {
       row: {
@@ -138,6 +140,7 @@ const COMMUNITIES: Community[] = [
       countNoun: "references",
       corpusDescriptor: "HPV vaccine delivery research",
     }),
+    exportVariant: "hpv",
     externalResources: [
       {
         title: "Report v2.0 May 2026",

--- a/src/services/export/buildHpvRows.ts
+++ b/src/services/export/buildHpvRows.ts
@@ -1,0 +1,128 @@
+/**
+ * Row-building logic for the HPV reference-level workbook: one row per
+ * reference, a fixed bibliographic block followed by one column per SKOS
+ * scheme. Each scheme cell holds the `; `-joined prefLabels of that
+ * reference's applied concepts that fall in the scheme. References with no
+ * applied concepts still produce a row (with blank scheme cells).
+ */
+
+import {
+  extractAbstract,
+  extractBibliographic,
+  extractDoi,
+  extractLinkedDataEnhancement,
+} from "@/services/referenceUtils";
+import { parseInvestigation } from "@/services/investigationParser";
+import {
+  schemeDisplayLabel,
+  type ConceptScheme,
+} from "@/services/vocabulary/vocabularyService";
+import type { Reference } from "@/types/models";
+
+import type { CellValue, ConceptResolver } from "./types.ts";
+
+export const HPV_SHEET_NAME = "References";
+
+type SheetRow = Record<string, CellValue>;
+
+type ReferenceSource = Iterable<Reference> | AsyncIterable<Reference>;
+
+const BIBLIOGRAPHIC_HEADERS = [
+  "reference_id",
+  "title",
+  "authors",
+  "publication_year",
+  "journal",
+  "doi",
+  "abstract",
+] as const;
+
+interface SchemeColumn {
+  uri: string;
+  header: string;
+}
+
+/**
+ * Derive one column per scheme, headed by the scheme's display label. Guards
+ * against a label colliding with the bibliographic block or another scheme by
+ * falling back to the (unique) scheme URI suffix.
+ */
+function buildSchemeColumns(schemes: ConceptScheme[]): SchemeColumn[] {
+  const used = new Set<string>(BIBLIOGRAPHIC_HEADERS);
+  return schemes.map((scheme) => {
+    let header = schemeDisplayLabel(scheme.label);
+    if (used.has(header)) header = `${header} (${scheme.uri})`;
+    used.add(header);
+    return { uri: scheme.uri, header };
+  });
+}
+
+function buildReferenceRow(
+  reference: Reference,
+  vocab: ConceptResolver,
+  inScheme: Map<string, string>,
+  schemeHeaderByUri: Map<string, string>,
+): SheetRow {
+  const bib = extractBibliographic(reference);
+  const authors = bib?.authorship
+    ? bib.authorship.map((a) => a.display_name).join("; ")
+    : null;
+  const row: SheetRow = {
+    reference_id: String(reference.id),
+    title: bib?.title ?? null,
+    authors: authors || null,
+    publication_year: bib?.publication_year ?? null,
+    journal: bib?.publication_venue?.display_name ?? null,
+    doi: extractDoi(reference.identifiers),
+    abstract: extractAbstract(reference)?.abstract ?? null,
+  };
+
+  const linked = extractLinkedDataEnhancement(reference);
+  if (linked) {
+    const { appliedConcepts } = parseInvestigation(
+      linked.content.data,
+      vocab.prefixes,
+      vocab.labels,
+    );
+    const buckets = new Map<string, string[]>();
+    for (const concept of appliedConcepts) {
+      const header = schemeHeaderByUri.get(inScheme.get(concept.uri) ?? "");
+      if (!header) continue;
+      const value = concept.label ?? concept.uri;
+      const bucket = buckets.get(header);
+      if (bucket) bucket.push(value);
+      else buckets.set(header, [value]);
+    }
+    for (const [header, values] of buckets) {
+      row[header] = values.join("; ");
+    }
+  }
+
+  return row;
+}
+
+/**
+ * Stream references and produce the header list (bibliographic block plus one
+ * column per scheme) and one row per reference. Accepts a sync or async
+ * iterable; `for await...of` handles both.
+ */
+export async function buildReferenceRows(
+  references: ReferenceSource,
+  vocab: ConceptResolver,
+): Promise<{ headers: string[]; rows: SheetRow[] }> {
+  const schemeColumns = buildSchemeColumns(vocab.schemes ?? []);
+  const schemeHeaderByUri = new Map(
+    schemeColumns.map((c) => [c.uri, c.header]),
+  );
+  const inScheme = vocab.inScheme ?? new Map<string, string>();
+  const headers = [
+    ...BIBLIOGRAPHIC_HEADERS,
+    ...schemeColumns.map((c) => c.header),
+  ];
+
+  const rows: SheetRow[] = [];
+  for await (const reference of references) {
+    rows.push(buildReferenceRow(reference, vocab, inScheme, schemeHeaderByUri));
+  }
+  return { headers, rows };
+}

--- a/src/services/export/buildHpvRows.ts
+++ b/src/services/export/buildHpvRows.ts
@@ -1,42 +1,49 @@
 /**
  * Row-building logic for the HPV reference-level workbook: one row per
  * reference, a fixed bibliographic block followed by one column per SKOS
- * scheme. Each scheme cell holds the `; `-joined prefLabels of that
- * reference's applied concepts that fall in the scheme. References with no
- * applied concepts still produce a row (with blank scheme cells).
+ * scheme and an "Other codes" catch-all. Each scheme cell holds the
+ * `; `-joined prefLabels of that reference's applied concepts that fall in the
+ * scheme; concepts in no listed scheme land in "Other codes". References with
+ * no applied concepts still produce a row (with blank concept cells).
  */
 
+import { orderFilterItems } from "@/components/filters/filterOrder";
 import {
   extractAbstract,
   extractBibliographic,
   extractDoi,
   extractLinkedDataEnhancement,
+  extractOpenAlexId,
   getInvestigation,
 } from "@/services/referenceUtils";
 import { parseAppliedConcepts } from "@/services/investigationParser";
 import {
-  compareLabels,
   schemeDisplayLabel,
   type ConceptScheme,
 } from "@/services/vocabulary/vocabularyService";
-import type { Reference } from "@/types/models";
+import type { PinnedFilter, Reference } from "@/types/models";
 
 import type { CellValue, ConceptResolver } from "./types.ts";
 
 export const HPV_SHEET_NAME = "References";
 
+const OTHER_CODES_HEADER = "Other codes";
+
 type SheetRow = Record<string, CellValue>;
 
 type ReferenceSource = Iterable<Reference> | AsyncIterable<Reference>;
 
+// Human-readable to sit alongside the vocabulary-derived scheme columns; the
+// esea workbook instead uses technical keys.
 const BIBLIOGRAPHIC_HEADERS = [
-  "reference_id",
-  "title",
-  "authors",
-  "publication_year",
-  "journal",
-  "doi",
-  "abstract",
+  "Reference ID",
+  "Title",
+  "Authors",
+  "Publication year",
+  "Journal",
+  "DOI",
+  "OpenAlex ID",
+  "Abstract",
 ] as const;
 
 interface SchemeColumn {
@@ -44,12 +51,17 @@ interface SchemeColumn {
   header: string;
 }
 
-// Ordered by label to match the filter drawer / evidence map, not raw @graph
-// order. A label clashing with the bibliographic block or another scheme falls
-// back to a URI-suffixed form.
-function buildSchemeColumns(schemes: ConceptScheme[]): SchemeColumn[] {
-  const used = new Set<string>(BIBLIOGRAPHIC_HEADERS);
-  return [...schemes].sort(compareLabels).map((scheme) => {
+// Ordered like the filter drawer (orderFilterItems) so columns match the UI
+// facets; a label clashing with another column falls back to a URI suffix.
+function buildSchemeColumns(
+  schemes: ConceptScheme[],
+  pinnedFilters: PinnedFilter[] | undefined,
+): SchemeColumn[] {
+  const ordered = orderFilterItems(schemes, { pinned: pinnedFilters }).flatMap(
+    (item) => (item.kind === "scheme" ? [item.scheme] : []),
+  );
+  const used = new Set<string>([...BIBLIOGRAPHIC_HEADERS, OTHER_CODES_HEADER]);
+  return ordered.map((scheme) => {
     let header = schemeDisplayLabel(scheme.label);
     if (used.has(header)) header = `${header} (${scheme.uri})`;
     used.add(header);
@@ -62,20 +74,20 @@ function buildReferenceRow(
   vocab: ConceptResolver,
   inScheme: Map<string, string>,
   schemeHeaderByUri: Map<string, string>,
-  dropped: Set<string>,
 ): SheetRow {
   const bib = extractBibliographic(reference);
   const authors = bib?.authorship
     ? bib.authorship.map((a) => a.display_name).join("; ")
     : null;
   const row: SheetRow = {
-    reference_id: String(reference.id),
-    title: bib?.title ?? null,
-    authors: authors || null,
-    publication_year: bib?.publication_year ?? null,
-    journal: bib?.publication_venue?.display_name ?? null,
-    doi: extractDoi(reference.identifiers),
-    abstract: extractAbstract(reference)?.abstract ?? null,
+    "Reference ID": String(reference.id),
+    Title: bib?.title ?? null,
+    Authors: authors || null,
+    "Publication year": bib?.publication_year ?? null,
+    Journal: bib?.publication_venue?.display_name ?? null,
+    DOI: extractDoi(reference.identifiers),
+    "OpenAlex ID": extractOpenAlexId(reference.identifiers),
+    Abstract: extractAbstract(reference)?.abstract ?? null,
   };
 
   const linked = extractLinkedDataEnhancement(reference);
@@ -87,13 +99,9 @@ function buildReferenceRow(
     );
     const buckets = new Map<string, string[]>();
     for (const concept of appliedConcepts) {
-      const header = schemeHeaderByUri.get(inScheme.get(concept.uri) ?? "");
-      // No column for this concept's scheme; record it so callers can warn
-      // rather than drop it silently.
-      if (!header) {
-        dropped.add(concept.uri);
-        continue;
-      }
+      const header =
+        schemeHeaderByUri.get(inScheme.get(concept.uri) ?? "") ??
+        OTHER_CODES_HEADER;
       const value = concept.label ?? concept.uri;
       const bucket = buckets.get(header);
       if (bucket) bucket.push(value);
@@ -108,36 +116,32 @@ function buildReferenceRow(
 }
 
 /**
- * Stream references and produce the header list (bibliographic block plus one
- * column per scheme) and one row per reference. Accepts a sync or async
- * iterable; `for await...of` handles both.
+ * Stream references into a header list and one row per reference. `pinnedFilters`
+ * orders the scheme columns to match the community's filter drawer.
  */
 export async function buildReferenceRows(
   references: ReferenceSource,
   vocab: ConceptResolver,
+  pinnedFilters?: PinnedFilter[],
 ): Promise<{ headers: string[]; rows: SheetRow[] }> {
-  const schemeColumns = buildSchemeColumns(vocab.schemes ?? []);
+  const schemeColumns = buildSchemeColumns(vocab.schemes ?? [], pinnedFilters);
   const schemeHeaderByUri = new Map(
     schemeColumns.map((c) => [c.uri, c.header]),
   );
   const inScheme = vocab.inScheme ?? new Map<string, string>();
+
+  const rows: SheetRow[] = [];
+  for await (const reference of references) {
+    rows.push(buildReferenceRow(reference, vocab, inScheme, schemeHeaderByUri));
+  }
+
   const headers = [
     ...BIBLIOGRAPHIC_HEADERS,
     ...schemeColumns.map((c) => c.header),
   ];
-
-  const rows: SheetRow[] = [];
-  const dropped = new Set<string>();
-  for await (const reference of references) {
-    rows.push(
-      buildReferenceRow(reference, vocab, inScheme, schemeHeaderByUri, dropped),
-    );
-  }
-  if (dropped.size > 0) {
-    console.warn(
-      `HPV export: omitted ${dropped.size} applied concept(s) with no matching ` +
-        `scheme column: ${[...dropped].join(", ")}`,
-    );
+  // Omit the catch-all unless something landed there — usually nothing does.
+  if (rows.some((row) => row[OTHER_CODES_HEADER] !== undefined)) {
+    headers.push(OTHER_CODES_HEADER);
   }
   return { headers, rows };
 }

--- a/src/services/export/buildHpvRows.ts
+++ b/src/services/export/buildHpvRows.ts
@@ -11,9 +11,11 @@ import {
   extractBibliographic,
   extractDoi,
   extractLinkedDataEnhancement,
+  getInvestigation,
 } from "@/services/referenceUtils";
-import { parseInvestigation } from "@/services/investigationParser";
+import { parseAppliedConcepts } from "@/services/investigationParser";
 import {
+  compareLabels,
   schemeDisplayLabel,
   type ConceptScheme,
 } from "@/services/vocabulary/vocabularyService";
@@ -42,14 +44,12 @@ interface SchemeColumn {
   header: string;
 }
 
-/**
- * Derive one column per scheme, headed by the scheme's display label. Guards
- * against a label colliding with the bibliographic block or another scheme by
- * falling back to the (unique) scheme URI suffix.
- */
+// Ordered by label to match the filter drawer / evidence map, not raw @graph
+// order. A label clashing with the bibliographic block or another scheme falls
+// back to a URI-suffixed form.
 function buildSchemeColumns(schemes: ConceptScheme[]): SchemeColumn[] {
   const used = new Set<string>(BIBLIOGRAPHIC_HEADERS);
-  return schemes.map((scheme) => {
+  return [...schemes].sort(compareLabels).map((scheme) => {
     let header = schemeDisplayLabel(scheme.label);
     if (used.has(header)) header = `${header} (${scheme.uri})`;
     used.add(header);
@@ -62,6 +62,7 @@ function buildReferenceRow(
   vocab: ConceptResolver,
   inScheme: Map<string, string>,
   schemeHeaderByUri: Map<string, string>,
+  dropped: Set<string>,
 ): SheetRow {
   const bib = extractBibliographic(reference);
   const authors = bib?.authorship
@@ -79,15 +80,20 @@ function buildReferenceRow(
 
   const linked = extractLinkedDataEnhancement(reference);
   if (linked) {
-    const { appliedConcepts } = parseInvestigation(
-      linked.content.data,
+    const appliedConcepts = parseAppliedConcepts(
+      getInvestigation(linked.content.data),
       vocab.prefixes,
       vocab.labels,
     );
     const buckets = new Map<string, string[]>();
     for (const concept of appliedConcepts) {
       const header = schemeHeaderByUri.get(inScheme.get(concept.uri) ?? "");
-      if (!header) continue;
+      // No column for this concept's scheme; record it so callers can warn
+      // rather than drop it silently.
+      if (!header) {
+        dropped.add(concept.uri);
+        continue;
+      }
       const value = concept.label ?? concept.uri;
       const bucket = buckets.get(header);
       if (bucket) bucket.push(value);
@@ -121,8 +127,17 @@ export async function buildReferenceRows(
   ];
 
   const rows: SheetRow[] = [];
+  const dropped = new Set<string>();
   for await (const reference of references) {
-    rows.push(buildReferenceRow(reference, vocab, inScheme, schemeHeaderByUri));
+    rows.push(
+      buildReferenceRow(reference, vocab, inScheme, schemeHeaderByUri, dropped),
+    );
+  }
+  if (dropped.size > 0) {
+    console.warn(
+      `HPV export: omitted ${dropped.size} applied concept(s) with no matching ` +
+        `scheme column: ${[...dropped].join(", ")}`,
+    );
   }
   return { headers, rows };
 }

--- a/src/services/export/buildHpvRows.ts
+++ b/src/services/export/buildHpvRows.ts
@@ -13,7 +13,7 @@ import {
   extractBibliographic,
   extractDoi,
   extractLinkedDataEnhancement,
-  extractOpenAlexId,
+  extractOtherIdentifier,
   getInvestigation,
 } from "@/services/referenceUtils";
 import { parseAppliedConcepts } from "@/services/investigationParser";
@@ -42,7 +42,7 @@ const BIBLIOGRAPHIC_HEADERS = [
   "Publication year",
   "Journal",
   "DOI",
-  "OpenAlex ID",
+  "EPPI ItemId",
   "Abstract",
 ] as const;
 
@@ -86,7 +86,7 @@ function buildReferenceRow(
     "Publication year": bib?.publication_year ?? null,
     Journal: bib?.publication_venue?.display_name ?? null,
     DOI: extractDoi(reference.identifiers),
-    "OpenAlex ID": extractOpenAlexId(reference.identifiers),
+    "EPPI ItemId": extractOtherIdentifier(reference.identifiers, "EPPI ItemId"),
     Abstract: extractAbstract(reference)?.abstract ?? null,
   };
 

--- a/src/services/export/export.ts
+++ b/src/services/export/export.ts
@@ -7,11 +7,15 @@
  * triggers a browser download of the resulting `.xlsx`.
  */
 
+import { proxyBlobUrl } from "@/config";
 import {
   getCachedContext,
   getCachedVocabulary,
 } from "@/services/vocabulary";
-import type { CodingInstitutionConfig } from "@/types/models";
+import type {
+  CodingInstitutionConfig,
+  ExportVariant,
+} from "@/types/models";
 
 import { generateWorkbook, workbookToArrayBuffer } from "./generate.ts";
 import { streamJsonlFromUrl } from "./jsonlStream.ts";
@@ -39,17 +43,18 @@ function triggerDownload(data: ArrayBuffer, filename: string): void {
 /**
  * Stream the JSONL at `jsonlUrl`, resolve concepts against the JSON-LD
  * vocabulary at `vocabularyUrl` (URI-keyed prefLabels) and the JSON-LD
- * @context at `contextUrl` (prefix → namespace map), build the
- * three-tab workbook, and prompt the user to download it as `filename`.
+ * @context at `contextUrl` (prefix → namespace map), build the workbook for
+ * the community's `variant`, and prompt the user to download it as `filename`.
  */
 export async function exportReferencesToExcel(
   jsonlUrl: string,
   vocabularyUrl: string,
   contextUrl: string,
   filename: string,
+  variant: ExportVariant,
   codingInstitution?: CodingInstitutionConfig,
 ): Promise<void> {
-  const references = streamJsonlFromUrl(jsonlUrl);
+  const references = streamJsonlFromUrl(proxyBlobUrl(jsonlUrl));
   const [vocab, context] = await Promise.all([
     getCachedVocabulary(vocabularyUrl),
     getCachedContext(contextUrl),
@@ -59,8 +64,10 @@ export async function exportReferencesToExcel(
     {
       prefixes: context.prefixes,
       labels: vocab.labels,
+      inScheme: vocab.inScheme,
+      schemes: vocab.schemes,
     },
-    codingInstitution,
+    { variant, codingInstitution },
   );
   triggerDownload(workbookToArrayBuffer(wb), filename);
 }

--- a/src/services/export/export.ts
+++ b/src/services/export/export.ts
@@ -15,6 +15,7 @@ import {
 import type {
   CodingInstitutionConfig,
   ExportVariant,
+  PinnedFilter,
 } from "@/types/models";
 
 import { generateWorkbook, workbookToArrayBuffer } from "./generate.ts";
@@ -53,6 +54,7 @@ export async function exportReferencesToExcel(
   filename: string,
   variant: ExportVariant,
   codingInstitution?: CodingInstitutionConfig,
+  pinnedFilters?: PinnedFilter[],
 ): Promise<void> {
   const references = streamJsonlFromUrl(proxyBlobUrl(jsonlUrl));
   const [vocab, context] = await Promise.all([
@@ -67,7 +69,7 @@ export async function exportReferencesToExcel(
       inScheme: vocab.inScheme,
       schemes: vocab.schemes,
     },
-    { variant, codingInstitution },
+    { variant, codingInstitution, pinnedFilters },
   );
   triggerDownload(workbookToArrayBuffer(wb), filename);
 }

--- a/src/services/export/generate.ts
+++ b/src/services/export/generate.ts
@@ -14,12 +14,17 @@ import {
   buildInvestigationRow,
   buildOutcomeRows,
 } from "./buildRows.ts";
+import { buildReferenceRows, HPV_SHEET_NAME } from "./buildHpvRows.ts";
 import {
   extractBibliographic,
   extractLinkedDataEnhancement,
   isDict,
 } from "@/services/referenceUtils";
-import type { CodingInstitutionConfig, Reference } from "@/types/models";
+import type {
+  CodingInstitutionConfig,
+  ExportVariant,
+  Reference,
+} from "@/types/models";
 
 import type {
   ArmRow,
@@ -37,8 +42,6 @@ const SHEET_NAMES = {
   outcomes: "Outcomes",
 } as const;
 
-type AnyRow = InvestigationRow | ArmRow | OutcomeRow;
-
 type ReferenceSource =
   | Iterable<Reference>
   | AsyncIterable<Reference>;
@@ -47,11 +50,13 @@ type ReferenceSource =
  * Convert a list of header-keyed row objects into the array-of-arrays
  * shape SheetJS expects: the first inner array is the header row, and
  * each subsequent row contains the values in the same column order, with
- * missing keys filled in as null.
+ * missing keys filled in as null. Generic over the row type so it serves
+ * both the fixed-interface (esea) rows and the dynamic, scheme-keyed (HPV)
+ * rows.
  */
-function rowsToAoa<R extends AnyRow>(
+function rowsToAoa<R extends object>(
   headers: ReadonlyArray<keyof R & string>,
-  rows: R[],
+  rows: ReadonlyArray<R>,
 ): unknown[][] {
   const aoa: unknown[][] = [headers as unknown as string[]];
   for (const row of rows) {
@@ -71,9 +76,9 @@ function rowsToAoa<R extends AnyRow>(
  * Multi-line cell contents are measured per line so
  * wrapped cells don't blow the column out.
  */
-function colWidths<R extends AnyRow>(
+function colWidths<R extends object>(
   headers: ReadonlyArray<keyof R & string>,
-  rows: R[],
+  rows: ReadonlyArray<R>,
 ): Array<{ wch: number }> {
   return headers.map((header) => {
     let maxLen = String(header).length;
@@ -92,11 +97,11 @@ function colWidths<R extends AnyRow>(
  * Materialise one tab on the workbook: convert rows to AoA, set column
  * widths, and append the sheet under the given name.
  */
-function appendSheet<R extends AnyRow>(
+function appendSheet<R extends object>(
   wb: XLSX.WorkBook,
   name: string,
   headers: ReadonlyArray<keyof R & string>,
-  rows: R[],
+  rows: ReadonlyArray<R>,
 ): void {
   const ws = XLSX.utils.aoa_to_sheet(rowsToAoa(headers, rows));
   ws["!cols"] = colWidths(headers, rows);
@@ -144,18 +149,10 @@ export async function buildAllRows(
 }
 
 /**
- * Top-level export: build rows for every reference and assemble the
- * three-tab workbook (Investigation Details, Investigation Arms,
- * Outcomes). Pure with respect to its inputs — no disk or network
- * access — so it runs in the browser as well as Node.
- *
- * The references argument can be a sync iterable (array) or async
- * iterable (JSONL stream), letting callers either load the whole file or
- * stream it from a signed URL. The `vocab` argument bundles the
- * JSON-LD @context prefix map and the URI-keyed prefLabel map fetched
- * via `vocabularyService` / `contextService`.
+ * Build the Education (esea) three-tab workbook (Investigation Details,
+ * Investigation Arms, Outcomes) from the structured investigation hierarchy.
  */
-export async function generateWorkbook(
+async function buildEducationWorkbook(
   references: ReferenceSource,
   vocab: ConceptResolver,
   codingInstitution?: CodingInstitutionConfig,
@@ -166,6 +163,49 @@ export async function generateWorkbook(
   appendSheet(wb, SHEET_NAMES.arms, SHEET_HEADERS.arms, rows.arms);
   appendSheet(wb, SHEET_NAMES.outcomes, SHEET_HEADERS.outcomes, rows.outcomes);
   return wb;
+}
+
+/**
+ * Build the HPV reference-level workbook: a single sheet with one row per
+ * reference, bibliographic columns followed by one column per SKOS scheme
+ * holding that reference's applied concepts in that scheme.
+ */
+async function buildHpvWorkbook(
+  references: ReferenceSource,
+  vocab: ConceptResolver,
+): Promise<XLSX.WorkBook> {
+  const { headers, rows } = await buildReferenceRows(references, vocab);
+  const wb = XLSX.utils.book_new();
+  appendSheet(wb, HPV_SHEET_NAME, headers, rows);
+  return wb;
+}
+
+export interface WorkbookOptions {
+  variant?: ExportVariant;
+  codingInstitution?: CodingInstitutionConfig;
+}
+
+/**
+ * Top-level export: assemble the workbook for the community's `variant`.
+ * Pure with respect to its inputs — no disk or network access — so it runs
+ * in the browser as well as Node.
+ *
+ * The references argument can be a sync iterable (array) or async
+ * iterable (JSONL stream), letting callers either load the whole file or
+ * stream it from a signed URL. The `vocab` argument bundles the
+ * JSON-LD @context prefix map and the URI-keyed prefLabel map fetched
+ * via `vocabularyService` / `contextService`; the reference-level (HPV)
+ * variant additionally reads its `inScheme` map and `schemes` list.
+ */
+export async function generateWorkbook(
+  references: ReferenceSource,
+  vocab: ConceptResolver,
+  options: WorkbookOptions = {},
+): Promise<XLSX.WorkBook> {
+  if (options.variant === "hpv") {
+    return buildHpvWorkbook(references, vocab);
+  }
+  return buildEducationWorkbook(references, vocab, options.codingInstitution);
 }
 
 /**

--- a/src/services/export/generate.ts
+++ b/src/services/export/generate.ts
@@ -18,7 +18,7 @@ import { buildReferenceRows, HPV_SHEET_NAME } from "./buildHpvRows.ts";
 import {
   extractBibliographic,
   extractLinkedDataEnhancement,
-  isDict,
+  getInvestigation,
 } from "@/services/referenceUtils";
 import type {
   CodingInstitutionConfig,
@@ -128,8 +128,7 @@ export async function buildAllRows(
     if (!linked) continue;
     const bibliographic = extractBibliographic(reference);
     const referenceId = String(reference.id);
-    const rawInvestigation = linked.content.data["hasInvestigation"];
-    const inv: Investigation = isDict(rawInvestigation) ? rawInvestigation : {};
+    const inv: Investigation = getInvestigation(linked.content.data);
     const findings = (Array.isArray(inv["hasFinding"]) ? inv["hasFinding"] : []) as Finding[];
     const armIds = assignArmIds(findings);
     investigation.push(

--- a/src/services/export/generate.ts
+++ b/src/services/export/generate.ts
@@ -23,6 +23,7 @@ import {
 import type {
   CodingInstitutionConfig,
   ExportVariant,
+  PinnedFilter,
   Reference,
 } from "@/types/models";
 
@@ -167,21 +168,28 @@ async function buildEducationWorkbook(
 /**
  * Build the HPV reference-level workbook: a single sheet with one row per
  * reference, bibliographic columns followed by one column per SKOS scheme
- * holding that reference's applied concepts in that scheme.
+ * holding that reference's applied concepts in that scheme. `pinnedFilters`
+ * orders the scheme columns to match the community's filter drawer.
  */
 async function buildHpvWorkbook(
   references: ReferenceSource,
   vocab: ConceptResolver,
+  pinnedFilters?: PinnedFilter[],
 ): Promise<XLSX.WorkBook> {
-  const { headers, rows } = await buildReferenceRows(references, vocab);
+  const { headers, rows } = await buildReferenceRows(
+    references,
+    vocab,
+    pinnedFilters,
+  );
   const wb = XLSX.utils.book_new();
   appendSheet(wb, HPV_SHEET_NAME, headers, rows);
   return wb;
 }
 
 export interface WorkbookOptions {
-  variant?: ExportVariant;
+  variant: ExportVariant;
   codingInstitution?: CodingInstitutionConfig;
+  pinnedFilters?: PinnedFilter[];
 }
 
 /**
@@ -199,12 +207,14 @@ export interface WorkbookOptions {
 export async function generateWorkbook(
   references: ReferenceSource,
   vocab: ConceptResolver,
-  options: WorkbookOptions = {},
+  options: WorkbookOptions,
 ): Promise<XLSX.WorkBook> {
-  if (options.variant === "hpv") {
-    return buildHpvWorkbook(references, vocab);
+  switch (options.variant) {
+    case "esea":
+      return buildEducationWorkbook(references, vocab, options.codingInstitution);
+    case "hpv":
+      return buildHpvWorkbook(references, vocab, options.pinnedFilters);
   }
-  return buildEducationWorkbook(references, vocab, options.codingInstitution);
 }
 
 /**

--- a/src/services/export/types.ts
+++ b/src/services/export/types.ts
@@ -1,3 +1,5 @@
+import type { ConceptScheme } from "@/services/vocabulary/vocabularyService";
+
 // JSON-LD structures inside LinkedDataEnhancement.data are kept loose: any
 // node can be either an inline object or a blank-node ref string, and
 // most fields are optional. We treat them as Record<string, unknown>
@@ -24,6 +26,11 @@ export interface CodedAnnotation {
 export interface ConceptResolver {
   prefixes: Map<string, string>;
   labels: Map<string, string>;
+  // URI → scheme URI and the scheme list, used by the reference-level (HPV)
+  // workbook to group applied concepts into per-scheme columns. The
+  // investigation-hierarchy (esea) workbook doesn't need them.
+  inScheme?: Map<string, string>;
+  schemes?: ConceptScheme[];
 }
 
 // Row types — the column set each sheet writes. Values are the raw

--- a/src/services/investigationParser.ts
+++ b/src/services/investigationParser.ts
@@ -1,5 +1,5 @@
 import { expandCompactUri } from "./vocabulary/contextService";
-import { isDict } from "./referenceUtils";
+import { getInvestigation, isDict } from "./referenceUtils";
 import type {
   InvestigationData,
   CodedAnnotation,
@@ -262,7 +262,7 @@ function resolveConceptRef(
   return { uri, label: labels.get(uri) };
 }
 
-function parseAppliedConcepts(
+export function parseAppliedConcepts(
   investigation: Dict,
   prefixes: Map<string, string>,
   labels: Map<string, string>,
@@ -431,10 +431,7 @@ function parseFindings(
  * is always available even when vocab/context fetches fail.
  */
 export function extractIsRetracted(data: Record<string, unknown>): boolean {
-  const investigation = isDict(data["hasInvestigation"])
-    ? (data["hasInvestigation"] as Dict)
-    : data;
-  return investigation["isRetracted"] === true;
+  return getInvestigation(data)["isRetracted"] === true;
 }
 
 /**
@@ -449,9 +446,7 @@ export function parseInvestigation(
   prefixes: Map<string, string>,
   labels: Map<string, string>,
 ): InvestigationData {
-  const investigation = isDict(data["hasInvestigation"])
-    ? (data["hasInvestigation"] as Dict)
-    : data;
+  const investigation = getInvestigation(data);
 
   return {
     documentType: parseOptional(investigation, "documentType", (n) =>

--- a/src/services/referenceUtils.ts
+++ b/src/services/referenceUtils.ts
@@ -166,6 +166,21 @@ export function extractOpenAlexId(
   return typeof openAlex?.identifier === "string" ? openAlex.identifier : null;
 }
 
+// `other`-typed identifiers are distinguished by `other_identifier_name`
+// (e.g. "EPPI ItemId"); return the first match's value.
+export function extractOtherIdentifier(
+  identifiers: ExternalIdentifier[] | null,
+  otherIdentifierName: string,
+): string | number | null {
+  if (!identifiers) return null;
+  const match = identifiers.find(
+    (i) =>
+      i.identifier_type === "other" &&
+      i.other_identifier_name === otherIdentifierName,
+  );
+  return match?.identifier ?? null;
+}
+
 // Editorial citation format: `volume(issue), first_page–last_page`.
 // Uses en dash (U+2013) for page ranges per typographic convention.
 // Returns "" when nothing meaningful to render.

--- a/src/services/referenceUtils.ts
+++ b/src/services/referenceUtils.ts
@@ -17,6 +17,14 @@ export function isDict(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
+// The investigation node of a linked-data `data` dict: `hasInvestigation` when
+// present, else the dict itself (vocabularies that omit the wrapper).
+export function getInvestigation(
+  data: Record<string, unknown>,
+): Record<string, unknown> {
+  return isDict(data["hasInvestigation"]) ? data["hasInvestigation"] : data;
+}
+
 /**
  * Return the highest-priority enhancement of the given type on a
  * reference, or null.
@@ -125,13 +133,10 @@ export function extractFindingsAndEstimatesCount(
 ): { findings: number; estimates: number } | null {
   const ld = extractLinkedData(reference);
   if (!ld) return null;
-  const root = isDict(ld.data) ? ld.data : null;
-  const investigation =
-    root && isDict(root["hasInvestigation"]) ? root["hasInvestigation"] : root;
-  const rawFindings =
-    investigation && Array.isArray(investigation["hasFinding"])
-      ? investigation["hasFinding"]
-      : [];
+  const investigation = getInvestigation(ld.data);
+  const rawFindings = Array.isArray(investigation["hasFinding"])
+    ? investigation["hasFinding"]
+    : [];
   let estimates = 0;
   for (const f of rawFindings) {
     if (isDict(f) && Array.isArray(f["hasEffectEstimate"])) {

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -53,6 +53,11 @@ export interface ExternalResource {
   href: string;
 }
 
+// Selects which client-side Excel workbook a community's export builds.
+// Matches the community slug: "esea" is the investigation-hierarchy workbook,
+// "hpv" the reference-level one.
+export type ExportVariant = "esea" | "hpv";
+
 export interface Community {
   slug: string;
   name: string;
@@ -78,6 +83,8 @@ export interface Community {
   copy: CommunityCopy;
   // Absent ⇒ no coder concept; the "Coded by" pill and export source are hidden.
   codingInstitution?: CodingInstitutionConfig;
+  // Which Excel workbook the export builds when features.exportExcel is on.
+  exportVariant: ExportVariant;
   externalResources?: ExternalResource[];
 }
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+const TARGET = "https://acct.blob.core.windows.net";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+// config.ts reads import.meta.env at module-eval, so reload it under a stubbed
+// VITE_BLOB_PROXY_TARGET to exercise each branch.
+async function loadConfig(blobTarget: string) {
+  vi.resetModules();
+  vi.stubEnv("VITE_BLOB_PROXY_TARGET", blobTarget);
+  return import("@/config");
+}
+
+describe("proxyBlobUrl", () => {
+  test("returns the URL unchanged when no proxy target is set", async () => {
+    const { proxyBlobUrl } = await loadConfig("");
+    const url = `${TARGET}/container/file.jsonl?sig=abc`;
+    expect(proxyBlobUrl(url)).toBe(url);
+  });
+
+  test("rewrites a matching URL through the dev proxy, preserving path + query", async () => {
+    const { proxyBlobUrl } = await loadConfig(TARGET);
+    expect(proxyBlobUrl(`${TARGET}/container/file.jsonl?sig=abc`)).toBe(
+      "/blob-proxy/container/file.jsonl?sig=abc",
+    );
+  });
+
+  test("leaves a non-matching URL unchanged", async () => {
+    const { proxyBlobUrl } = await loadConfig(TARGET);
+    const other = "https://other.example/container/file.jsonl?sig=abc";
+    expect(proxyBlobUrl(other)).toBe(other);
+  });
+});

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -57,6 +57,7 @@ export function makeCommunity(
     filterExcludedSchemes: [],
     pillExcludedSchemes: [],
     geographicSchemes: [],
+    exportVariant: "esea",
     features: {
       evidenceMap: false,
       aiSummaries: false,

--- a/tests/hooks/useSearchExport.test.tsx
+++ b/tests/hooks/useSearchExport.test.tsx
@@ -32,6 +32,7 @@ function startArgs(
     filename: string;
     vocabularyUrl: string;
     contextUrl: string;
+    variant: "esea" | "hpv";
   }> = {},
 ) {
   return {
@@ -40,6 +41,7 @@ function startArgs(
     filename: "f.xlsx",
     vocabularyUrl: VOCAB_URL,
     contextUrl: CONTEXT_URL,
+    variant: "esea" as const,
     ...overrides,
   };
 }
@@ -106,6 +108,7 @@ describe("useSearchExport", () => {
       VOCAB_URL,
       CONTEXT_URL,
       "file.xlsx",
+      "esea",
       undefined,
     );
     expect(mockRequest).toHaveBeenCalledWith("phonics", { annotation: ["x"] });

--- a/tests/hooks/useSearchExport.test.tsx
+++ b/tests/hooks/useSearchExport.test.tsx
@@ -110,6 +110,7 @@ describe("useSearchExport", () => {
       "file.xlsx",
       "esea",
       undefined,
+      undefined,
     );
     expect(mockRequest).toHaveBeenCalledWith("phonics", { annotation: ["x"] });
   });

--- a/tests/pages/SearchPage.test.tsx
+++ b/tests/pages/SearchPage.test.tsx
@@ -561,7 +561,7 @@ describe("SearchPage", () => {
       });
     });
 
-    test("export button hidden on /hpv until HPV Excel export (#127) lands", async () => {
+    test("export button shown on /hpv", async () => {
       history.replaceState(null, "", "/hpv");
       mockBoth({ results: makeResult(6, ["r1"]) });
       renderSearchPage();
@@ -570,7 +570,7 @@ describe("SearchPage", () => {
       );
       expect(
         screen.queryByRole("button", { name: /export to excel/i }),
-      ).toBeNull();
+      ).not.toBeNull();
     });
 
     test("enabled in year-only URL; click POSTs with q=* and the year filter", async () => {

--- a/tests/services/communities.test.ts
+++ b/tests/services/communities.test.ts
@@ -74,10 +74,16 @@ describe("communities", () => {
     expect(findCommunity("hpv")?.features.findingsAndEstimates).toBe(false);
   });
 
-  it("gates Excel export per community (ESEA on, HPV off until #127)", async () => {
+  it("enables Excel export for both communities", async () => {
     const { findCommunity } = await import("@/services/communities");
     expect(findCommunity("esea")?.features.exportExcel).toBe(true);
-    expect(findCommunity("hpv")?.features.exportExcel).toBe(false);
+    expect(findCommunity("hpv")?.features.exportExcel).toBe(true);
+  });
+
+  it("selects the per-community export workbook variant", async () => {
+    const { findCommunity } = await import("@/services/communities");
+    expect(findCommunity("esea")?.exportVariant).toBe("esea");
+    expect(findCommunity("hpv")?.exportVariant).toBe("hpv");
   });
 
   it("gates the facet-backed country filter per community (ESEA on, HPV off)", async () => {

--- a/tests/services/export/buildHpvRows.test.ts
+++ b/tests/services/export/buildHpvRows.test.ts
@@ -92,7 +92,10 @@ const VOCAB: ConceptResolver = {
 function hpvRef(id: string, conceptCuries: string[]): Reference {
   return makeRef({
     id,
-    identifiers: [{ identifier: `10.1/${id}`, identifier_type: "doi" }],
+    identifiers: [
+      { identifier: `10.1/${id}`, identifier_type: "doi" },
+      { identifier: `W-${id}`, identifier_type: "open_alex" },
+    ],
     enhancements: [
       makeEnh(makeBibContent(), { id: `bib-${id}`, reference_id: id }),
       makeEnh(
@@ -116,23 +119,38 @@ function hpvRef(id: string, conceptCuries: string[]): Reference {
 }
 
 const BIB_HEADERS = [
-  "reference_id",
-  "title",
-  "authors",
-  "publication_year",
-  "journal",
-  "doi",
-  "abstract",
+  "Reference ID",
+  "Title",
+  "Authors",
+  "Publication year",
+  "Journal",
+  "DOI",
+  "OpenAlex ID",
+  "Abstract",
 ];
 
 describe("buildReferenceRows", () => {
-  test("derives one scheme column per scheme, ordered by label", async () => {
+  test("derives one scheme column per scheme, alphabetical, no Other codes when empty", async () => {
     const { headers } = await buildReferenceRows([], VOCAB);
     expect(headers).toEqual([
       ...BIB_HEADERS,
       "Country",
       "Delivery Actor",
       "Target Population",
+    ]);
+    expect(headers).not.toContain("Other codes");
+  });
+
+  test("orders scheme columns by pinnedFilters, then alphabetically", async () => {
+    const { headers } = await buildReferenceRows([], VOCAB, [
+      `${NS}TargetPopulation`,
+      "year",
+    ]);
+    expect(headers).toEqual([
+      ...BIB_HEADERS,
+      "Target Population",
+      "Country",
+      "Delivery Actor",
     ]);
   });
 
@@ -148,13 +166,14 @@ describe("buildReferenceRows", () => {
     );
     expect(rows).toHaveLength(1);
     const row = rows[0]!;
-    expect(row.reference_id).toBe("ref-1");
-    expect(row.title).toBe("HPV vaccine uptake in adolescents");
-    expect(row.authors).toBe("Smith J; Jones K");
-    expect(row.publication_year).toBe(2021);
-    expect(row.journal).toBe("Vaccine Journal");
-    expect(row.doi).toBe("10.1/ref-1");
-    expect(row.abstract).toBe("Study summary ref-1");
+    expect(row["Reference ID"]).toBe("ref-1");
+    expect(row["Title"]).toBe("HPV vaccine uptake in adolescents");
+    expect(row["Authors"]).toBe("Smith J; Jones K");
+    expect(row["Publication year"]).toBe(2021);
+    expect(row["Journal"]).toBe("Vaccine Journal");
+    expect(row["DOI"]).toBe("10.1/ref-1");
+    expect(row["OpenAlex ID"]).toBe("W-ref-1");
+    expect(row["Abstract"]).toBe("Study summary ref-1");
   });
 
   test("groups applied concepts into their scheme columns, joined with '; '", async () => {
@@ -187,8 +206,8 @@ describe("buildReferenceRows", () => {
     });
     const { rows } = await buildReferenceRows([bibOnly], VOCAB);
     expect(rows).toHaveLength(1);
-    expect(rows[0]!.reference_id).toBe("ref-bib-only");
-    expect(rows[0]!.title).toBe("Bib only");
+    expect(rows[0]!["Reference ID"]).toBe("ref-bib-only");
+    expect(rows[0]!["Title"]).toBe("Bib only");
     expect(rows[0]!["Delivery Actor"]).toBeUndefined();
   });
 
@@ -198,8 +217,40 @@ describe("buildReferenceRows", () => {
       yield hpvRef("ref-2", ["hpv:c3"]);
     }
     const { rows } = await buildReferenceRows(gen(), VOCAB);
-    expect(rows.map((r) => r.reference_id)).toEqual(["ref-1", "ref-2"]);
+    expect(rows.map((r) => r["Reference ID"])).toEqual(["ref-1", "ref-2"]);
     expect(rows[0]!["Delivery Actor"]).toBe("Nurse");
     expect(rows[1]!["Target Population"]).toBe("Adolescent girls");
+  });
+
+  test("routes concepts with no scheme column into Other codes", async () => {
+    // hpv:c9 has a label but no inScheme entry; hpv:c8 is unlabelled too.
+    const vocab: ConceptResolver = {
+      ...VOCAB,
+      labels: new Map([...LABELS, [`${NS}c9`, "Uncoded concept"]]),
+    };
+    const { headers, rows } = await buildReferenceRows(
+      [hpvRef("ref-1", ["hpv:c1", "hpv:c9", "hpv:c8"])],
+      vocab,
+    );
+    expect(headers).toContain("Other codes");
+    const row = rows[0]!;
+    expect(row["Delivery Actor"]).toBe("Nurse");
+    expect(row["Other codes"]).toBe(`Uncoded concept; ${NS}c8`);
+  });
+
+  test("URI-suffixes a scheme header that collides with another scheme", async () => {
+    const collidingSchemes = [
+      { uri: `${NS}DeliveryActorA`, label: "Delivery Actor Scheme", topConcepts: [] },
+      { uri: `${NS}DeliveryActorB`, label: "Delivery Actor Scheme", topConcepts: [] },
+    ];
+    const { headers } = await buildReferenceRows([], {
+      ...VOCAB,
+      schemes: collidingSchemes,
+    });
+    expect(headers).toEqual([
+      ...BIB_HEADERS,
+      "Delivery Actor",
+      `Delivery Actor (${NS}DeliveryActorB)`,
+    ]);
   });
 });

--- a/tests/services/export/buildHpvRows.test.ts
+++ b/tests/services/export/buildHpvRows.test.ts
@@ -126,13 +126,13 @@ const BIB_HEADERS = [
 ];
 
 describe("buildReferenceRows", () => {
-  test("derives one scheme column per scheme, headed by the display label", async () => {
+  test("derives one scheme column per scheme, ordered by label", async () => {
     const { headers } = await buildReferenceRows([], VOCAB);
     expect(headers).toEqual([
       ...BIB_HEADERS,
+      "Country",
       "Delivery Actor",
       "Target Population",
-      "Country",
     ]);
   });
 

--- a/tests/services/export/buildHpvRows.test.ts
+++ b/tests/services/export/buildHpvRows.test.ts
@@ -1,0 +1,205 @@
+import { describe, test, expect } from "vitest";
+
+import { buildReferenceRows } from "@/services/export/buildHpvRows.ts";
+import type { ConceptResolver } from "@/services/export/types.ts";
+import type {
+  BibliographicMetadataEnhancement,
+  Enhancement,
+  EnhancementContent,
+  Reference,
+} from "@/types/models";
+
+function makeRef(overrides: Partial<Reference>): Reference {
+  return {
+    id: "ref-1",
+    visibility: "public",
+    identifiers: null,
+    enhancements: null,
+    ...overrides,
+  };
+}
+
+function makeEnh(
+  content: EnhancementContent,
+  overrides: Partial<Enhancement> = {},
+): Enhancement {
+  return {
+    id: "enh-1",
+    reference_id: "ref-1",
+    source: "test",
+    visibility: "public",
+    robot_version: null,
+    derived_from: null,
+    created_at: "2024-01-01T00:00:00Z",
+    content,
+    ...overrides,
+  };
+}
+
+function makeBibContent(
+  overrides: Partial<BibliographicMetadataEnhancement> = {},
+): BibliographicMetadataEnhancement {
+  return {
+    enhancement_type: "bibliographic",
+    title: "HPV vaccine uptake in adolescents",
+    authorship: [
+      { display_name: "Smith J", orcid: null, position: "first" },
+      { display_name: "Jones K", orcid: null, position: "middle" },
+    ],
+    publication_year: 2021,
+    cited_by_count: null,
+    created_date: null,
+    updated_date: null,
+    publication_date: null,
+    publisher: null,
+    pagination: null,
+    publication_venue: { display_name: "Vaccine Journal", venue_type: "journal" },
+    ...overrides,
+  };
+}
+
+const NS = "https://vocab.aliveevidence.org/hpv/";
+const PREFIXES = new Map([["hpv", NS]]);
+
+const LABELS = new Map([
+  [`${NS}c1`, "Nurse"],
+  [`${NS}c2`, "Pharmacist"],
+  [`${NS}c3`, "Adolescent girls"],
+  [`${NS}c4`, "Kenya"],
+]);
+
+const IN_SCHEME = new Map([
+  [`${NS}c1`, `${NS}DeliveryActor`],
+  [`${NS}c2`, `${NS}DeliveryActor`],
+  [`${NS}c3`, `${NS}TargetPopulation`],
+  [`${NS}c4`, `${NS}Country`],
+]);
+
+const SCHEMES = [
+  { uri: `${NS}DeliveryActor`, label: "Delivery Actor Scheme", topConcepts: [] },
+  { uri: `${NS}TargetPopulation`, label: "Target Population Scheme", topConcepts: [] },
+  { uri: `${NS}Country`, label: "Country Scheme", topConcepts: [] },
+];
+
+const VOCAB: ConceptResolver = {
+  prefixes: PREFIXES,
+  labels: LABELS,
+  inScheme: IN_SCHEME,
+  schemes: SCHEMES,
+};
+
+/** A reference with bibliographic, abstract, and linked-data (applied concepts). */
+function hpvRef(id: string, conceptCuries: string[]): Reference {
+  return makeRef({
+    id,
+    identifiers: [{ identifier: `10.1/${id}`, identifier_type: "doi" }],
+    enhancements: [
+      makeEnh(makeBibContent(), { id: `bib-${id}`, reference_id: id }),
+      makeEnh(
+        { enhancement_type: "abstract", process: "test", abstract: `Study summary ${id}` },
+        { id: `abs-${id}`, reference_id: id },
+      ),
+      makeEnh(
+        {
+          enhancement_type: "linked_data",
+          vocabulary_uri: `${NS}v1`,
+          data: {
+            hasInvestigation: {
+              hasAppliedConcept: conceptCuries.map((c) => ({ "@id": c })),
+            },
+          },
+        },
+        { id: `ld-${id}`, reference_id: id },
+      ),
+    ],
+  });
+}
+
+const BIB_HEADERS = [
+  "reference_id",
+  "title",
+  "authors",
+  "publication_year",
+  "journal",
+  "doi",
+  "abstract",
+];
+
+describe("buildReferenceRows", () => {
+  test("derives one scheme column per scheme, headed by the display label", async () => {
+    const { headers } = await buildReferenceRows([], VOCAB);
+    expect(headers).toEqual([
+      ...BIB_HEADERS,
+      "Delivery Actor",
+      "Target Population",
+      "Country",
+    ]);
+  });
+
+  test("includes geo schemes as columns", async () => {
+    const { headers } = await buildReferenceRows([], VOCAB);
+    expect(headers).toContain("Country");
+  });
+
+  test("emits one row per reference with bibliographic columns populated", async () => {
+    const { rows } = await buildReferenceRows(
+      [hpvRef("ref-1", [])],
+      VOCAB,
+    );
+    expect(rows).toHaveLength(1);
+    const row = rows[0]!;
+    expect(row.reference_id).toBe("ref-1");
+    expect(row.title).toBe("HPV vaccine uptake in adolescents");
+    expect(row.authors).toBe("Smith J; Jones K");
+    expect(row.publication_year).toBe(2021);
+    expect(row.journal).toBe("Vaccine Journal");
+    expect(row.doi).toBe("10.1/ref-1");
+    expect(row.abstract).toBe("Study summary ref-1");
+  });
+
+  test("groups applied concepts into their scheme columns, joined with '; '", async () => {
+    const { rows } = await buildReferenceRows(
+      [hpvRef("ref-1", ["hpv:c1", "hpv:c2", "hpv:c3", "hpv:c4"])],
+      VOCAB,
+    );
+    const row = rows[0]!;
+    expect(row["Delivery Actor"]).toBe("Nurse; Pharmacist");
+    expect(row["Target Population"]).toBe("Adolescent girls");
+    expect(row["Country"]).toBe("Kenya");
+  });
+
+  test("leaves scheme cells blank for a reference with no applied concepts", async () => {
+    const { rows } = await buildReferenceRows([hpvRef("ref-1", [])], VOCAB);
+    const row = rows[0]!;
+    expect(row["Delivery Actor"]).toBeUndefined();
+    expect(row["Target Population"]).toBeUndefined();
+  });
+
+  test("emits a row even for a reference with no linked-data enhancement", async () => {
+    const bibOnly = makeRef({
+      id: "ref-bib-only",
+      enhancements: [
+        makeEnh(makeBibContent({ title: "Bib only" }), {
+          id: "bib-x",
+          reference_id: "ref-bib-only",
+        }),
+      ],
+    });
+    const { rows } = await buildReferenceRows([bibOnly], VOCAB);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.reference_id).toBe("ref-bib-only");
+    expect(rows[0]!.title).toBe("Bib only");
+    expect(rows[0]!["Delivery Actor"]).toBeUndefined();
+  });
+
+  test("accepts an async iterable of references", async () => {
+    async function* gen(): AsyncGenerator<Reference> {
+      yield hpvRef("ref-1", ["hpv:c1"]);
+      yield hpvRef("ref-2", ["hpv:c3"]);
+    }
+    const { rows } = await buildReferenceRows(gen(), VOCAB);
+    expect(rows.map((r) => r.reference_id)).toEqual(["ref-1", "ref-2"]);
+    expect(rows[0]!["Delivery Actor"]).toBe("Nurse");
+    expect(rows[1]!["Target Population"]).toBe("Adolescent girls");
+  });
+});

--- a/tests/services/export/buildHpvRows.test.ts
+++ b/tests/services/export/buildHpvRows.test.ts
@@ -94,7 +94,11 @@ function hpvRef(id: string, conceptCuries: string[]): Reference {
     id,
     identifiers: [
       { identifier: `10.1/${id}`, identifier_type: "doi" },
-      { identifier: `W-${id}`, identifier_type: "open_alex" },
+      {
+        identifier: `EPPI-${id}`,
+        identifier_type: "other",
+        other_identifier_name: "EPPI ItemId",
+      },
     ],
     enhancements: [
       makeEnh(makeBibContent(), { id: `bib-${id}`, reference_id: id }),
@@ -125,7 +129,7 @@ const BIB_HEADERS = [
   "Publication year",
   "Journal",
   "DOI",
-  "OpenAlex ID",
+  "EPPI ItemId",
   "Abstract",
 ];
 
@@ -172,7 +176,7 @@ describe("buildReferenceRows", () => {
     expect(row["Publication year"]).toBe(2021);
     expect(row["Journal"]).toBe("Vaccine Journal");
     expect(row["DOI"]).toBe("10.1/ref-1");
-    expect(row["OpenAlex ID"]).toBe("W-ref-1");
+    expect(row["EPPI ItemId"]).toBe("EPPI-ref-1");
     expect(row["Abstract"]).toBe("Study summary ref-1");
   });
 

--- a/tests/services/export/export.test.ts
+++ b/tests/services/export/export.test.ts
@@ -193,7 +193,7 @@ describe("exportReferencesToExcel", () => {
 
   test("triggers a download with the given filename and xlsx MIME type", async () => {
     const { captured } = installSpies();
-    await exportReferencesToExcel(JSONL_URL, VOCAB_URL, CONTEXT_URL, "out.xlsx");
+    await exportReferencesToExcel(JSONL_URL, VOCAB_URL, CONTEXT_URL, "out.xlsx", "esea");
 
     expect(captured.filename).toBe("out.xlsx");
     expect(captured.blob).not.toBeNull();
@@ -215,7 +215,7 @@ describe("exportReferencesToExcel", () => {
       "https://vocab.example.org/v1/",
     ]) {
       const { fetchSpy } = installSpies();
-      await exportReferencesToExcel(JSONL_URL, input, CONTEXT_URL, "out.xlsx");
+      await exportReferencesToExcel(JSONL_URL, input, CONTEXT_URL, "out.xlsx", "esea");
       const vocabCalls = fetchSpy.mock.calls
         .map((c) => (typeof c[0] === "string" ? c[0] : c[0]!.toString()))
         .filter((u) => u.includes("vocab") && !u.includes("context"));
@@ -227,7 +227,7 @@ describe("exportReferencesToExcel", () => {
 
   test("fetches the vocabulary, context, and JSONL", async () => {
     const { fetchSpy } = installSpies();
-    await exportReferencesToExcel(JSONL_URL, VOCAB_URL, CONTEXT_URL, "out.xlsx");
+    await exportReferencesToExcel(JSONL_URL, VOCAB_URL, CONTEXT_URL, "out.xlsx", "esea");
     const urls = fetchSpy.mock.calls.map((c) =>
       typeof c[0] === "string" ? c[0] : c[0]!.toString(),
     );
@@ -241,7 +241,7 @@ describe("exportReferencesToExcel", () => {
       vocabBody: { status: 404, statusText: "Not Found", body: "nope" },
     });
     await expect(
-      exportReferencesToExcel(JSONL_URL, VOCAB_URL, CONTEXT_URL, "out.xlsx"),
+      exportReferencesToExcel(JSONL_URL, VOCAB_URL, CONTEXT_URL, "out.xlsx", "esea"),
     ).rejects.toThrow(/Failed to fetch vocabulary: 404/);
   });
 
@@ -250,7 +250,7 @@ describe("exportReferencesToExcel", () => {
       contextBody: { status: 404, statusText: "Not Found", body: "nope" },
     });
     await expect(
-      exportReferencesToExcel(JSONL_URL, VOCAB_URL, CONTEXT_URL, "out.xlsx"),
+      exportReferencesToExcel(JSONL_URL, VOCAB_URL, CONTEXT_URL, "out.xlsx", "esea"),
     ).rejects.toThrow(/Failed to fetch context: 404/);
   });
 
@@ -259,7 +259,7 @@ describe("exportReferencesToExcel", () => {
       jsonlBody: { status: 500, statusText: "Server Error", body: "" },
     });
     await expect(
-      exportReferencesToExcel(JSONL_URL, VOCAB_URL, CONTEXT_URL, "out.xlsx"),
+      exportReferencesToExcel(JSONL_URL, VOCAB_URL, CONTEXT_URL, "out.xlsx", "esea"),
     ).rejects.toThrow(/HTTP 500/);
   });
 
@@ -270,6 +270,7 @@ describe("exportReferencesToExcel", () => {
       VOCAB_URL,
       CONTEXT_URL,
       "chunked.xlsx",
+      "esea",
     );
     expect(captured.filename).toBe("chunked.xlsx");
     expect(captured.blob!.size).toBeGreaterThan(0);
@@ -349,6 +350,7 @@ describe.each([
       VOCAB_URL,
       CONTEXT_URL,
       `${stem}.xlsx`,
+      "esea",
       CODING,
     );
 

--- a/tests/services/export/generate.test.ts
+++ b/tests/services/export/generate.test.ts
@@ -107,6 +107,7 @@ describe("generateWorkbook", () => {
     const wb = await generateWorkbook(
       [syntheticReference("ref-1")],
       MINIMAL_VOCAB,
+      { variant: "esea" },
     );
     expect(wb.SheetNames).toEqual([
       "Investigation Details",
@@ -128,6 +129,7 @@ describe("generateWorkbook", () => {
     const wb = await generateWorkbook(
       [noLinked, syntheticReference("ref-keep")],
       MINIMAL_VOCAB,
+      { variant: "esea" },
     );
     const inv = wb.Sheets["Investigation Details"]!;
     const rows = XLSX.utils.sheet_to_json<Record<string, unknown>>(inv);
@@ -141,7 +143,7 @@ describe("generateWorkbook", () => {
       yield syntheticReference("ref-1");
       yield syntheticReference("ref-2");
     }
-    const wb = await generateWorkbook(gen(), MINIMAL_VOCAB);
+    const wb = await generateWorkbook(gen(), MINIMAL_VOCAB, { variant: "esea" });
     const inv = wb.Sheets["Investigation Details"]!;
     const rows = XLSX.utils.sheet_to_json<Record<string, unknown>>(inv);
     expect(rows.map((r) => r.reference_id)).toEqual(["ref-1", "ref-2"]);
@@ -157,7 +159,7 @@ describe("generateWorkbook", () => {
     const sheet = wb.Sheets["References"]!;
     const rows = XLSX.utils.sheet_to_json<Record<string, unknown>>(sheet);
     expect(rows).toHaveLength(1);
-    expect(rows[0]!.reference_id).toBe("ref-1");
+    expect(rows[0]!["Reference ID"]).toBe("ref-1");
   });
 });
 
@@ -166,6 +168,7 @@ describe("workbookToArrayBuffer", () => {
     const wb = await generateWorkbook(
       [syntheticReference("ref-1")],
       MINIMAL_VOCAB,
+      { variant: "esea" },
     );
     const buf = workbookToArrayBuffer(wb);
     expect(buf).toBeInstanceOf(ArrayBuffer);

--- a/tests/services/export/generate.test.ts
+++ b/tests/services/export/generate.test.ts
@@ -146,6 +146,19 @@ describe("generateWorkbook", () => {
     const rows = XLSX.utils.sheet_to_json<Record<string, unknown>>(inv);
     expect(rows.map((r) => r.reference_id)).toEqual(["ref-1", "ref-2"]);
   });
+
+  test("the hpv variant produces a single reference-level sheet", async () => {
+    const wb = await generateWorkbook(
+      [syntheticReference("ref-1")],
+      MINIMAL_VOCAB,
+      { variant: "hpv" },
+    );
+    expect(wb.SheetNames).toEqual(["References"]);
+    const sheet = wb.Sheets["References"]!;
+    const rows = XLSX.utils.sheet_to_json<Record<string, unknown>>(sheet);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.reference_id).toBe("ref-1");
+  });
 });
 
 describe("workbookToArrayBuffer", () => {

--- a/tests/services/referenceUtils.test.ts
+++ b/tests/services/referenceUtils.test.ts
@@ -7,6 +7,7 @@ import {
   extractLinkedDataEnhancement,
   extractDoi,
   extractOpenAlexId,
+  extractOtherIdentifier,
   formatPagination,
 } from "@/services/referenceUtils";
 import type {
@@ -198,6 +199,51 @@ describe("extractOpenAlexId", () => {
     expect(
       extractOpenAlexId([{ identifier: 12345, identifier_type: "open_alex" }]),
     ).toBeNull();
+  });
+});
+
+describe("extractOtherIdentifier", () => {
+  test("returns null when identifiers is null", () => {
+    expect(extractOtherIdentifier(null, "EPPI ItemId")).toBeNull();
+  });
+
+  test("returns null when no matching other identifier exists", () => {
+    expect(
+      extractOtherIdentifier(
+        [{ identifier: "10.1/x", identifier_type: "doi" }],
+        "EPPI ItemId",
+      ),
+    ).toBeNull();
+  });
+
+  test("returns null when the other_identifier_name differs", () => {
+    expect(
+      extractOtherIdentifier(
+        [
+          {
+            identifier: "abc",
+            identifier_type: "other",
+            other_identifier_name: "arxiv",
+          },
+        ],
+        "EPPI ItemId",
+      ),
+    ).toBeNull();
+  });
+
+  test("returns the value of the matching other identifier", () => {
+    expect(
+      extractOtherIdentifier(
+        [
+          {
+            identifier: 482931,
+            identifier_type: "other",
+            other_identifier_name: "EPPI ItemId",
+          },
+        ],
+        "EPPI ItemId",
+      ),
+    ).toBe(482931);
   });
 });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,6 +29,14 @@ export default defineConfig(({ mode }) => {
             followRedirects: true,
           },
         }),
+        ...(env.VITE_BLOB_PROXY_TARGET && {
+          "/blob-proxy": {
+            target: env.VITE_BLOB_PROXY_TARGET,
+            changeOrigin: true,
+            rewrite: (path: string) => path.replace(/^\/blob-proxy/, ""),
+            followRedirects: true,
+          },
+        }),
       },
     },
   };


### PR DESCRIPTION
Closes #127.

Adds a per-community workbook dispatch so `/hpv` "Export to Excel" produces a single-sheet, one-row-per-reference workbook (bibliographic columns + one column per SKOS scheme), while `/esea` keeps its three-sheet investigation workbook unchanged.

- `Community.exportVariant` (`esea` | `hpv`) selects the builder; HPV's `exportExcel` feature is now on.
- New `buildHpvRows.ts` groups each reference's applied concepts by scheme (all schemes included, including geo; one row per reference even when concept-less).
- Dev-only blob proxy (`/blob-proxy`, mirroring `/vocab-proxy`) so local dev can fetch signed export blobs — the storage CORS only allows deployed UI origins. Inert in production.

### To do:
- [x] Confirm export format