### PR TITLE
Surface contradictions in AI summary UI

### DIFF
--- a/src/components/ai-summary/ai-summary.css
+++ b/src/components/ai-summary/ai-summary.css
@@ -115,12 +115,12 @@
   margin-bottom: var(--spacing-md);
   font-size: var(--font-size-small);
   line-height: 1.45;
-  color: #7a5a00;
+  color: var(--color-warning-text);
 }
 .ai-disclaimer svg {
   flex: 0 0 auto;
   margin-top: 1px;
-  color: #b8860b;
+  color: var(--color-warning-text);
 }
 
 /* ── Loading / error ──────────────────────────────────────── */
@@ -210,7 +210,8 @@
   border-radius: var(--radius-sm);
   transition: background 0.3s ease;
 }
-.ai-claim:last-child {
+.ai-claim:last-child,
+.ai-claim:has(+ .ai-contradictions-head) {
   border-bottom: none;
 }
 .ai-claim.is-flash {
@@ -260,6 +261,49 @@
 }
 .ai-cite__doi:hover {
   text-decoration: underline;
+}
+.ai-cite__page {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-mono-sm);
+}
+
+/* ── Contradictions ───────────────────────────────────────── */
+.ai-contradictions-head {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-mono-caps);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-warning-text);
+  padding-top: var(--spacing-md);
+  border-top: 1px solid var(--color-border);
+  margin: var(--spacing-md) 0 var(--spacing-sm);
+}
+.ai-contradiction {
+  display: grid;
+  grid-template-columns: 22px 1fr;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) 0;
+  border-bottom: 1px dashed var(--color-border);
+}
+.ai-contradiction:last-child {
+  border-bottom: none;
+}
+.ai-contradiction__marker {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--color-warning-light);
+  color: var(--color-warning-text);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.ai-contradiction__text {
+  font-family: var(--font-body);
+  font-size: var(--font-size-body);
+  line-height: 1.5;
+  color: var(--color-text-primary);
+  margin: 0 0 var(--spacing-sm);
 }
 
 /* ── Footer ───────────────────────────────────────────────── */

--- a/src/components/ai-summary/renderSummary.tsx
+++ b/src/components/ai-summary/renderSummary.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from "preact";
 import { useRef } from "preact/hooks";
-import { ExternalLinkIcon } from "@/components/common/icons";
-import type { PaperMeta, SummaryBlock } from "@/services/summariser";
+import { ExternalLinkIcon, WarningIcon } from "@/components/common/icons";
+import type { PaperMeta, QuoteRef, SummaryBlock } from "@/services/summariser";
 
 function citation(papers: PaperMeta[], paperId: string): string {
   const paper = papers.find((p) => p.paper === paperId);
@@ -12,6 +12,30 @@ function citation(papers: PaperMeta[], paperId: string): string {
   return `${lead}${etAl}${year}`;
 }
 
+// A verbatim quote with its provenance, shared by claims and contradictions.
+function QuoteSource({ quote, papers }: { quote: QuoteRef; papers: PaperMeta[] }) {
+  const paper = papers.find((p) => p.paper === quote.paper);
+  return (
+    <div class="ai-claim__source">
+      <p class="ai-quote">“{quote.quote}”</p>
+      <div class="ai-cite">
+        <span>{citation(papers, quote.paper)}</span>
+        {quote.page != null && <span class="ai-cite__page">p. {quote.page}</span>}
+        {paper?.doi && (
+          <a
+            class="ai-cite__doi"
+            href={`https://doi.org/${paper.doi}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            DOI <ExternalLinkIcon size={11} />
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}
+
 interface SummaryBodyProps {
   summary: SummaryBlock;
   papers: PaperMeta[];
@@ -20,9 +44,8 @@ interface SummaryBodyProps {
 /**
  * Renders the narrative prose with footnote markers linking to a numbered
  * "Claims & sources" list. Clicking a footnote scrolls to and flashes its claim.
- *
- * `summary.contradictions` is intentionally not rendered in this minimal
- * version; surfacing conflicting findings is a follow-up.
+ * Contradictions, when present, follow in a distinct "Where papers disagree"
+ * section with their own supporting quotes.
  */
 export function SummaryBody({ summary, papers }: SummaryBodyProps) {
   const rootRef = useRef<HTMLDivElement>(null);
@@ -72,31 +95,32 @@ export function SummaryBody({ summary, papers }: SummaryBodyProps) {
           <div key={n} id={`aiClaim-${n}`} class="ai-claim">
             <div class="ai-claim__num">{n}</div>
             <div class="ai-claim__body">
-              {claim.quotes.map((quote, qi) => {
-                const paper = papers.find((p) => p.paper === quote.paper);
-                return (
-                  <div key={qi} class="ai-claim__source">
-                    <p class="ai-quote">“{quote.quote}”</p>
-                    <div class="ai-cite">
-                      <span>{citation(papers, quote.paper)}</span>
-                      {paper?.doi && (
-                        <a
-                          class="ai-cite__doi"
-                          href={`https://doi.org/${paper.doi}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          DOI <ExternalLinkIcon size={11} />
-                        </a>
-                      )}
-                    </div>
-                  </div>
-                );
-              })}
+              {claim.quotes.map((quote, qi) => (
+                <QuoteSource key={qi} quote={quote} papers={papers} />
+              ))}
             </div>
           </div>
         );
       })}
+
+      {summary.contradictions.length > 0 && (
+        <>
+          <p class="ai-contradictions-head">Where papers disagree</p>
+          {summary.contradictions.map((c, idx) => (
+            <div key={idx} class="ai-contradiction">
+              <div class="ai-contradiction__marker" aria-hidden="true">
+                <WarningIcon size={12} />
+              </div>
+              <div class="ai-claim__body">
+                <p class="ai-contradiction__text">{c.contradiction}</p>
+                {c.quotes.map((quote, qi) => (
+                  <QuoteSource key={qi} quote={quote} papers={papers} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </>
+      )}
     </div>
   );
 }

--- a/src/services/summariserMock.ts
+++ b/src/services/summariserMock.ts
@@ -50,7 +50,28 @@ export const MOCK_SUMMARY: SummariseResponse = {
     },
   ],
   summary: {
-    contradictions: [],
+    contradictions: [
+      {
+        contradiction:
+          "Studies disagree on whether multi-cohort catch-up vaccination stays cost-effective once delivery costs scale.",
+        quotes: [
+          {
+            quote:
+              "Extending vaccination to multiple older cohorts remained cost-effective even under conservative coverage and cost assumptions.",
+            paper: "abbas-2018",
+            page: 7,
+            terms: [2],
+          },
+          {
+            quote:
+              "Beyond the primary 9–14 cohort the incremental cost per DALY averted rose sharply, exceeding the threshold in lower-coverage scenarios.",
+            paper: "brisson-2021",
+            page: 14,
+            terms: [2],
+          },
+        ],
+      },
+    ],
     claims: [
       {
         claim:

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -67,6 +67,7 @@
   --color-success: #198754;
   --color-warning: #ffc107;
   --color-warning-light: #fef3c7;
+  --color-warning-text: #7a5a00;
   --color-estimate-neg: #6b2020;
 
   /* ── Colors: retracted state ── (unchanged — landed in PR #18) */

--- a/tests/components/ai-summary/AiSummaryDrawer.test.tsx
+++ b/tests/components/ai-summary/AiSummaryDrawer.test.tsx
@@ -106,9 +106,12 @@ describe("AiSummaryDrawer", () => {
       screen.getByText(/disagree on whether catch-up campaigns/i),
     ).toBeDefined();
     expect(screen.getByText(/remained cost-effective/i)).toBeDefined();
-    expect(screen.getByText(/poor value for money/i)).toBeDefined();
     // The page number surfaces only for the quote that carries one.
     expect(screen.getByText("p. 12")).toBeDefined();
+    const pagelessCite = screen
+      .getByText(/poor value for money/i)
+      .closest(".ai-claim__source");
+    expect(pagelessCite?.querySelector(".ai-cite__page")).toBeNull();
   });
 
   test("clicking a footnote scrolls to and flashes its claim", () => {

--- a/tests/components/ai-summary/AiSummaryDrawer.test.tsx
+++ b/tests/components/ai-summary/AiSummaryDrawer.test.tsx
@@ -58,6 +58,53 @@ describe("AiSummaryDrawer", () => {
     );
   });
 
+  test("omits the contradictions section when there are none", () => {
+    render(<AiSummaryDrawer ai={makeAi()} />);
+    expect(screen.queryByText(/where papers disagree/i)).toBeNull();
+    expect(document.querySelector(".ai-contradiction")).toBeNull();
+  });
+
+  test("renders contradictions with their description and backing quotes", () => {
+    const ai = makeAi({
+      result: {
+        ...MOCK_SUMMARY,
+        summary: {
+          ...MOCK_SUMMARY.summary,
+          contradictions: [
+            {
+              contradiction:
+                "Papers disagree on whether catch-up campaigns are cost-effective.",
+              quotes: [
+                {
+                  quote: "Catch-up vaccination remained cost-effective.",
+                  paper: "anwari-2019",
+                  page: 12,
+                  terms: [2],
+                },
+                {
+                  quote: "Catch-up offered poor value for money.",
+                  paper: "canfell-2020",
+                  terms: [2],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    render(<AiSummaryDrawer ai={ai} />);
+
+    expect(screen.getByText(/where papers disagree/i)).toBeDefined();
+    expect(document.querySelectorAll(".ai-contradiction").length).toBe(1);
+    expect(
+      screen.getByText(/disagree on whether catch-up campaigns/i),
+    ).toBeDefined();
+    expect(screen.getByText(/remained cost-effective/i)).toBeDefined();
+    expect(screen.getByText(/poor value for money/i)).toBeDefined();
+    // The page number surfaces only for the quote that carries one.
+    expect(screen.getByText("p. 12")).toBeDefined();
+  });
+
   test("clicking a footnote scrolls to and flashes its claim", () => {
     const { container } = render(
       <AiSummaryDrawer ai={makeAi()} />,

--- a/tests/components/ai-summary/AiSummaryDrawer.test.tsx
+++ b/tests/components/ai-summary/AiSummaryDrawer.test.tsx
@@ -59,7 +59,13 @@ describe("AiSummaryDrawer", () => {
   });
 
   test("omits the contradictions section when there are none", () => {
-    render(<AiSummaryDrawer ai={makeAi()} />);
+    const ai = makeAi({
+      result: {
+        ...MOCK_SUMMARY,
+        summary: { ...MOCK_SUMMARY.summary, contradictions: [] },
+      },
+    });
+    render(<AiSummaryDrawer ai={ai} />);
     expect(screen.queryByText(/where papers disagree/i)).toBeNull();
     expect(document.querySelector(".ai-contradiction")).toBeNull();
   });


### PR DESCRIPTION
Renders the summariser's `contradictions` in the AI summary drawer, in a distinct "Where papers disagree" section beneath the claims, each with its description and backing quotes (paper, page, DOI). Closes #172.

- Extracted a shared `QuoteSource` component (claims + contradictions) and surfaced the quote `page` (`p. N`) when present.
- Added a `--color-warning-text` foreground token so warning text/icons meet WCAG AA; migrated the disclaimer's inline hex onto it.
- Tests for the section rendering (present / absent / page number).

<img width="535" height="1076" alt="Screenshot 2026-06-17 at 4 37 58 PM" src="https://github.com/user-attachments/assets/fefedc0c-e1c4-41e3-a154-c5d658dab0ae" />

### To do
- [ ] Confirm design with @acdonald 
