### PR TITLE
Updates to filters (#171)

### DIFF
--- a/src/components/filters/FilterCardList.tsx
+++ b/src/components/filters/FilterCardList.tsx
@@ -5,7 +5,11 @@ import { YearRangeFilter } from "./YearRangeFilter";
 import { summary } from "./conceptSchemeFilterState";
 import { summary as countrySummary } from "./countryFilterState";
 import { summary as yearSummary } from "./yearRangeFilterState";
-import { orderFilterItems, type FilterItem } from "./filterOrder";
+import {
+  DEFAULT_EXPANDED_FILTERS,
+  orderFilterItems,
+  type FilterItem,
+} from "./filterOrder";
 import {
   schemeDisplayLabel,
   type ConceptScheme,
@@ -21,6 +25,8 @@ interface FilterCardListProps {
   showCountryFacetFilter?: boolean;
   // Filter cards pinned to the top; absent ⇒ DEFAULT_PINNED_FILTERS.
   pinnedFilters?: readonly PinnedFilter[];
+  // Filter cards that start expanded; absent ⇒ DEFAULT_EXPANDED_FILTERS.
+  defaultExpandedFilters?: readonly PinnedFilter[];
 }
 
 /**
@@ -34,11 +40,13 @@ export function FilterCardList({
   countNoun = "results",
   showCountryFacetFilter = true,
   pinnedFilters,
+  defaultExpandedFilters = DEFAULT_EXPANDED_FILTERS,
 }: FilterCardListProps) {
   const items = orderFilterItems(draft.schemes, {
     pinned: pinnedFilters,
     showCountryFacetFilter,
   });
+  const expanded = new Set(defaultExpandedFilters);
 
   return (
     <>
@@ -47,12 +55,17 @@ export function FilterCardList({
           Filter counts unavailable.
         </div>
       )}
-      {items.map((item) => renderItem(item, draft, countNoun))}
+      {items.map((item) => renderItem(item, draft, countNoun, expanded))}
     </>
   );
 }
 
-function renderItem(item: FilterItem, draft: FilterDraft, countNoun: string) {
+function renderItem(
+  item: FilterItem,
+  draft: FilterDraft,
+  countNoun: string,
+  expanded: ReadonlySet<string>,
+) {
   switch (item.kind) {
     case "year":
       return (
@@ -60,7 +73,7 @@ function renderItem(item: FilterItem, draft: FilterDraft, countNoun: string) {
           key="year"
           title="Publication year"
           summary={yearSummary(draft.yearDraft)}
-          defaultExpanded
+          defaultExpanded={expanded.has("year")}
         >
           <YearRangeFilter
             state={draft.yearDraft}
@@ -74,7 +87,7 @@ function renderItem(item: FilterItem, draft: FilterDraft, countNoun: string) {
           key="country"
           title="Country"
           summary={countrySummary(draft.countryDraft)}
-          defaultExpanded
+          defaultExpanded={expanded.has("country")}
         >
           <CountryFilter
             state={draft.countryDraft}
@@ -92,6 +105,7 @@ function renderItem(item: FilterItem, draft: FilterDraft, countNoun: string) {
           scheme={item.scheme}
           draft={draft}
           countNoun={countNoun}
+          defaultExpanded={expanded.has(item.scheme.uri)}
         />
       );
   }
@@ -101,16 +115,19 @@ function SchemeCard({
   scheme,
   draft,
   countNoun,
+  defaultExpanded,
 }: {
   scheme: ConceptScheme;
   draft: FilterDraft;
   countNoun: string;
+  defaultExpanded: boolean;
 }) {
   const state = draft.conceptStateFor(scheme);
   return (
     <FilterCard
       title={schemeDisplayLabel(scheme.label)}
       summary={summary(state)}
+      defaultExpanded={defaultExpanded}
     >
       <ConceptSchemeFilter
         scheme={scheme}

--- a/src/components/filters/FilterDrawer.tsx
+++ b/src/components/filters/FilterDrawer.tsx
@@ -17,6 +17,8 @@ interface FilterDrawerProps {
   showCountryFacetFilter?: boolean;
   // Filter cards pinned to the top; absent ⇒ DEFAULT_PINNED_FILTERS.
   pinnedFilters?: readonly PinnedFilter[];
+  // Filter cards that start expanded; absent ⇒ DEFAULT_EXPANDED_FILTERS.
+  defaultExpandedFilters?: readonly PinnedFilter[];
   schemes: ConceptScheme[];
   appliedConceptFilters: readonly (readonly string[])[];
   appliedCountryCodes: readonly string[];
@@ -42,6 +44,7 @@ function FilterDrawerPanel({
   countNoun = "results",
   showCountryFacetFilter = true,
   pinnedFilters,
+  defaultExpandedFilters,
   schemes,
   appliedConceptFilters,
   appliedCountryCodes,
@@ -101,6 +104,7 @@ function FilterDrawerPanel({
         countNoun={countNoun}
         showCountryFacetFilter={showCountryFacetFilter}
         pinnedFilters={pinnedFilters}
+        defaultExpandedFilters={defaultExpandedFilters}
       />
     </Drawer>
   );

--- a/src/components/filters/filterOrder.ts
+++ b/src/components/filters/filterOrder.ts
@@ -14,6 +14,9 @@ export type FilterItem =
 // Year, then the country facet. Every scheme follows alphabetically.
 export const DEFAULT_PINNED_FILTERS: readonly PinnedFilter[] = ["year", "country"];
 
+// The two built-in cards open expanded; scheme cards start collapsed.
+export const DEFAULT_EXPANDED_FILTERS: readonly PinnedFilter[] = ["year", "country"];
+
 interface OrderFilterItemsOptions {
   pinned?: readonly PinnedFilter[];
   // When false the "country" slot renders nothing (facet unavailable).

--- a/src/components/visualise/MapConfigPanel.tsx
+++ b/src/components/visualise/MapConfigPanel.tsx
@@ -38,6 +38,8 @@ interface MapConfigPanelProps {
   showCountryFacetFilter?: boolean;
   // Filter cards pinned to the top; absent ⇒ DEFAULT_PINNED_FILTERS.
   pinnedFilters?: readonly PinnedFilter[];
+  // Filter cards that start expanded; absent ⇒ DEFAULT_EXPANDED_FILTERS.
+  defaultExpandedFilters?: readonly PinnedFilter[];
   onApply: (next: { axes: EvidenceMapAxes; filters: AppliedFilters }) => void;
 }
 
@@ -94,6 +96,7 @@ export function MapConfigPanel({
   countNoun = "results",
   showCountryFacetFilter = true,
   pinnedFilters,
+  defaultExpandedFilters,
   onApply,
 }: MapConfigPanelProps) {
   const [rowDraft, setRowDraft] = useState<EvidenceMapAxis>(appliedAxes.row);
@@ -163,6 +166,7 @@ export function MapConfigPanel({
             countNoun={countNoun}
             showCountryFacetFilter={showCountryFacetFilter}
             pinnedFilters={pinnedFilters}
+            defaultExpandedFilters={defaultExpandedFilters}
           />
         </section>
       </div>

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -488,6 +488,7 @@ function SearchPageInner({ community }: { community: Community }) {
           countNoun={community.copy.countNoun}
           showCountryFacetFilter={community.features.countryFacetFilter}
           pinnedFilters={community.pinnedFilters}
+          defaultExpandedFilters={community.defaultExpandedFilters}
           schemes={filterableSchemes}
           appliedConceptFilters={params.conceptFilters}
           appliedCountryCodes={params.countryCodes}

--- a/src/pages/VisualisePage.tsx
+++ b/src/pages/VisualisePage.tsx
@@ -367,6 +367,7 @@ function EvidenceMapView({
         schemes={filterableSchemes}
         showCountryFacetFilter={community.features.countryFacetFilter}
         pinnedFilters={community.pinnedFilters}
+        defaultExpandedFilters={community.defaultExpandedFilters}
         appliedAxes={axes}
         defaultAxes={defaults}
         appliedConceptFilters={params.conceptFilters}

--- a/src/services/communities.ts
+++ b/src/services/communities.ts
@@ -114,9 +114,12 @@ const COMMUNITIES: Community[] = [
     geographicSchemes: HPV_GEO_SCHEMES,
     pinnedFilters: [
       "https://vocab.aliveevidence.org/hpv/ConveningTheme",
+      "https://vocab.aliveevidence.org/hpv/ThematicFocusPrimary",
+      "https://vocab.aliveevidence.org/hpv/ThematicFocusSecondary",
       "year",
       ...HPV_GEO_SCHEMES,
     ],
+    defaultExpandedFilters: [],
     features: {
       ...DEFAULT_FEATURES,
       evidenceMap: true,

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -76,6 +76,9 @@ export interface Community {
   // Filter cards pinned to the top, in order; every remaining scheme follows
   // alphabetically. Absent ⇒ DEFAULT_PINNED_FILTERS (year, then country).
   pinnedFilters?: PinnedFilter[];
+  // Filter cards that start expanded, by slot ("year"/"country") or scheme URI;
+  // absent ⇒ DEFAULT_EXPANDED_FILTERS (year, country).
+  defaultExpandedFilters?: readonly PinnedFilter[];
   features: CommunityFeatures;
   // Default evidence-map axes; absent ⇒ the map shows a "not configured" notice
   // even where features.evidenceMap is on (e.g. before a vocabulary is published).

--- a/tests/components/filters/FilterDrawer.test.tsx
+++ b/tests/components/filters/FilterDrawer.test.tsx
@@ -382,18 +382,26 @@ describe("FilterDrawer", () => {
   });
 
   describe("default expansion", () => {
-    function yearButton() {
-      return screen.getByRole("button", { name: /Publication year/ });
+    function cardButton(name: RegExp) {
+      return screen.getByRole("button", { name });
     }
 
-    test("expands the Publication year card by default", () => {
+    test("expands the year and country cards by default", () => {
       renderDrawer();
-      expect(yearButton().getAttribute("aria-expanded")).toBe("true");
+      expect(
+        cardButton(/Publication year/).getAttribute("aria-expanded"),
+      ).toBe("true");
+      expect(cardButton(/Country/).getAttribute("aria-expanded")).toBe("true");
     });
 
     test("collapses cards omitted from defaultExpandedFilters", () => {
       renderDrawer({ defaultExpandedFilters: [] });
-      expect(yearButton().getAttribute("aria-expanded")).toBe("false");
+      expect(
+        cardButton(/Publication year/).getAttribute("aria-expanded"),
+      ).toBe("false");
+      expect(cardButton(/Country/).getAttribute("aria-expanded")).toBe(
+        "false",
+      );
     });
   });
 

--- a/tests/components/filters/FilterDrawer.test.tsx
+++ b/tests/components/filters/FilterDrawer.test.tsx
@@ -381,6 +381,22 @@ describe("FilterDrawer", () => {
     ).toBe(1);
   });
 
+  describe("default expansion", () => {
+    function yearButton() {
+      return screen.getByRole("button", { name: /Publication year/ });
+    }
+
+    test("expands the Publication year card by default", () => {
+      renderDrawer();
+      expect(yearButton().getAttribute("aria-expanded")).toBe("true");
+    });
+
+    test("collapses cards omitted from defaultExpandedFilters", () => {
+      renderDrawer({ defaultExpandedFilters: [] });
+      expect(yearButton().getAttribute("aria-expanded")).toBe("false");
+    });
+  });
+
   describe("country filter integration", () => {
     test("renders the Country card after Publication year but before any scheme card", () => {
       const { container } = renderDrawer();

--- a/tests/services/communities.test.ts
+++ b/tests/services/communities.test.ts
@@ -130,6 +130,22 @@ describe("communities", () => {
     );
   });
 
+  it("pins HPV's thematic-focus filters above publication year", async () => {
+    const { findCommunity } = await import("@/services/communities");
+    expect(findCommunity("hpv")?.pinnedFilters?.slice(0, 4)).toEqual([
+      "https://vocab.aliveevidence.org/hpv/ConveningTheme",
+      "https://vocab.aliveevidence.org/hpv/ThematicFocusPrimary",
+      "https://vocab.aliveevidence.org/hpv/ThematicFocusSecondary",
+      "year",
+    ]);
+  });
+
+  it("collapses HPV's filters by default, leaving ESEA on the default", async () => {
+    const { findCommunity } = await import("@/services/communities");
+    expect(findCommunity("hpv")?.defaultExpandedFilters).toEqual([]);
+    expect(findCommunity("esea")?.defaultExpandedFilters).toBeUndefined();
+  });
+
   it("excludes the HPV geographic schemes from result-card pills, none for ESEA", async () => {
     const { findCommunity } = await import("@/services/communities");
     expect(findCommunity("esea")?.pillExcludedSchemes).toEqual([]);


### PR DESCRIPTION
Closes #171.

- Collapse the **Publication year** filter by default for HPV.
- Move the **Thematic focus — Primary & Secondary** cards above Publication year (after Convening Theme).

Both are HPV-only. Implemented via a generic `defaultExpandedFilters` community config (parallel to `pinnedFilters`), which also folds the previously hard-coded year/country expansion into config. Absent ⇒ `["year", "country"]`, so Education is unchanged.

<img width="471" height="835" alt="Screenshot 2026-06-17 at 4 44 01 PM" src="https://github.com/user-attachments/assets/3279c36f-a901-45aa-b1b2-aef24b0a8402" />