### PR TITLE
Implement popover tooltip

### DIFF
--- a/src/components/common/Tooltip.css
+++ b/src/components/common/Tooltip.css
@@ -1,17 +1,9 @@
 /**
- * CSS-only tooltip: the trigger renders the `text` prop in a pill above
- * itself on hover or keyboard focus, via a positioned pseudo-element.
- *
- * Known limitations:
- * - No viewport-edge clamping; tooltips near the right edge of narrow
- *   viewports may clip.
- * - No portaling; an ancestor with `overflow: hidden` will clip the
- *   bubble. Consumers near such an ancestor should reposition the bubble
- *   so it fits inside the available space (see ConceptSchemeFilter.css).
+ * Tooltip: the trigger shows the `text` prop in a bubble on hover or keyboard
+ * focus. The bubble is a top-layer popover positioned by JS (see Tooltip.tsx),
+ * escaping ancestor overflow/stacking and flipping/clamping to fit the viewport.
  */
 
-/* Bubble appearance, shared with bespoke tooltips that can't reuse the pseudo
-   (e.g. the evidence map's fixed-positioned header tooltip). */
 :root {
   --tooltip-bg: #161b22;
   --tooltip-color: #fff;
@@ -25,14 +17,19 @@
   display: inline-flex;
 }
 
-.tooltip:hover::after,
-.tooltip:focus-within::after,
-.tooltip:focus-visible::after {
-  content: attr(data-tooltip);
-  position: absolute;
-  bottom: calc(100% + 8px);
-  left: 50%;
+.tooltip__bubble {
+  position: fixed;
+  /* Override the UA `[popover]` defaults so our JS top/left win over centring. */
+  inset: auto;
+  margin: 0;
+  border: 0;
+  overflow: visible; /* let the tail pseudo-element show outside the box */
+  /* Off-screen until the layout effect positions it, to avoid a corner flash. */
+  top: -9999px;
+  left: 0;
   transform: translateX(-50%);
+  z-index: 2000; /* matters only where the top layer is unavailable */
+  pointer-events: none;
   background: var(--tooltip-bg);
   color: var(--tooltip-color);
   padding: var(--tooltip-padding);
@@ -42,11 +39,27 @@
   line-height: var(--tooltip-line-height);
   width: max-content;
   max-width: var(--tooltip-max-width);
-  /* pre-line honours explicit "\n" in `text` (multi-line tooltips) while still
-     wrapping/collapsing other whitespace; single-line tooltips are unaffected. */
+  /* pre-line honours explicit "\n" in `text` while still wrapping long lines. */
   white-space: pre-line;
   text-align: left;
-  z-index: 10;
-  pointer-events: none;
   box-shadow: var(--shadow-md);
+}
+
+.tooltip__bubble::after {
+  content: "";
+  position: absolute;
+  left: calc(50% + var(--tail-x, 0px));
+  transform: translateX(-50%);
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+}
+
+.tooltip__bubble[data-placement="above"]::after {
+  top: 100%;
+  border-top: 8px solid var(--tooltip-bg);
+}
+
+.tooltip__bubble[data-placement="below"]::after {
+  bottom: 100%;
+  border-bottom: 8px solid var(--tooltip-bg);
 }

--- a/src/components/common/Tooltip.tsx
+++ b/src/components/common/Tooltip.tsx
@@ -41,7 +41,12 @@ function TooltipTrigger({
     const trigger = triggerRef.current;
     if (!shown || !bubble || !trigger) return;
 
-    bubble.showPopover?.(); // absent in jsdom and pre-2024 engines
+    // Re-runs when `text` changes mid-hover; showPopover() throws if already open.
+    try {
+      bubble.showPopover?.(); // absent in jsdom and pre-2024 engines
+    } catch {
+      // already open
+    }
 
     const r = trigger.getBoundingClientRect();
     const { offsetWidth: w, offsetHeight: h } = bubble;

--- a/src/components/common/Tooltip.tsx
+++ b/src/components/common/Tooltip.tsx
@@ -1,4 +1,5 @@
 import type { ComponentChildren } from "preact";
+import { useLayoutEffect, useRef, useState } from "preact/hooks";
 import "./Tooltip.css";
 
 interface TooltipProps {
@@ -14,9 +15,73 @@ interface TooltipProps {
  */
 export function Tooltip({ text, children }: TooltipProps) {
   if (!text) return <>{children}</>;
+  return <TooltipTrigger text={text}>{children}</TooltipTrigger>;
+}
+
+const GAP = 8; // px between the trigger and the bubble
+const MARGIN = 8; // px the bubble keeps from the viewport edges
+
+function TooltipTrigger({
+  text,
+  children,
+}: {
+  text: string;
+  children: ComponentChildren;
+}) {
+  const triggerRef = useRef<HTMLSpanElement>(null);
+  const bubbleRef = useRef<HTMLDivElement>(null);
+  const [shown, setShown] = useState(false);
+
+  // showPopover() lifts the bubble into the top layer, where it escapes every
+  // ancestor's overflow and stacking context (drawer/map scroll boxes) without
+  // a portal. We position it by hand for universal support; unmounting on hide
+  // clears the top layer, so no hidePopover() is needed.
+  useLayoutEffect(() => {
+    const bubble = bubbleRef.current;
+    const trigger = triggerRef.current;
+    if (!shown || !bubble || !trigger) return;
+
+    bubble.showPopover?.(); // absent in jsdom and pre-2024 engines
+
+    const r = trigger.getBoundingClientRect();
+    const { offsetWidth: w, offsetHeight: h } = bubble;
+    const centerX = r.left + r.width / 2;
+    const half = w / 2;
+    const left = Math.max(
+      MARGIN + half,
+      Math.min(centerX, window.innerWidth - MARGIN - half),
+    );
+    // Prefer above; flip below when it won't clear the viewport top.
+    const above = r.top - GAP - h >= MARGIN;
+    const top = above ? r.top - GAP - h : r.bottom + GAP;
+    bubble.style.left = `${left}px`;
+    bubble.style.top = `${top}px`;
+    bubble.dataset.placement = above ? "above" : "below";
+    // Keep the tail over the trigger when the bubble is clamped to the edge.
+    bubble.style.setProperty("--tail-x", `${centerX - left}px`);
+  }, [shown, text]);
+
   return (
-    <span class="tooltip" data-tooltip={text}>
+    <span
+      ref={triggerRef}
+      class="tooltip"
+      data-tooltip={text}
+      onMouseEnter={() => setShown(true)}
+      onMouseLeave={() => setShown(false)}
+      onFocusCapture={() => setShown(true)}
+      onBlurCapture={() => setShown(false)}
+    >
       {children}
+      {shown && (
+        <div
+          ref={bubbleRef}
+          class="tooltip__bubble"
+          popover="manual"
+          aria-hidden="true"
+        >
+          {text}
+        </div>
+      )}
     </span>
   );
 }

--- a/src/components/filters/ConceptSchemeFilter.css
+++ b/src/components/filters/ConceptSchemeFilter.css
@@ -12,10 +12,6 @@
 }
 
 .concept-scheme-filter__row {
-  /* Positioning context for the tooltip bubble below — anchors the bubble
-     to the row's left edge (the checkbox) instead of the label, while the
-     hover/focus trigger stays on the label only. */
-  position: relative;
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
@@ -63,25 +59,6 @@
 
 .concept-scheme-filter__count.is-updating {
   opacity: 0.5;
-}
-
-/* Make the row (not the .tooltip span) the positioned ancestor for the
-   bubble: with position: static here the bubble falls through to the row.
-   Hover/focus still triggers on the .tooltip span (around the label only),
-   but the bubble is anchored at the row's left edge so it lines up with
-   the checkbox and extends rightward into the panel, avoiding the
-   horizontal clipping the drawer body would otherwise impose. Applies to
-   both label tooltips (concept definitions) and count tooltips (parent
-   semantics). */
-.concept-scheme-filter__row > .tooltip {
-  position: static;
-}
-
-.concept-scheme-filter__row > .tooltip:hover::after,
-.concept-scheme-filter__row > .tooltip:focus-within::after,
-.concept-scheme-filter__row > .tooltip:focus-visible::after {
-  left: 0;
-  transform: none;
 }
 
 .concept-scheme-filter__children {

--- a/src/components/search/ResultRow.css
+++ b/src/components/search/ResultRow.css
@@ -175,7 +175,8 @@
   display: contents;
 }
 
-.row-pills .tag-group__tag {
+.row-pills .tag-group__tag,
+.row-pills .tooltip {
   pointer-events: auto;
 }
 

--- a/src/components/visualise/EvidenceMapGrid.css
+++ b/src/components/visualise/EvidenceMapGrid.css
@@ -134,39 +134,6 @@
   outline-offset: 2px;
 }
 
-/* The header tooltip: a fixed-positioned bubble (JS sets left/top from the
-   hovered header) so it escapes the scroll box and the map column's overflow,
-   which clip any in-cell pseudo-element. It sits above the text; --tail-x keeps
-   the tail over the text when the bubble is clamped to the viewport edge. */
-.evidence-map__head-tip {
-  position: fixed;
-  transform: translate(-50%, calc(-100% - 8px));
-  z-index: 1000;
-  pointer-events: none;
-  background: var(--tooltip-bg);
-  color: var(--tooltip-color);
-  padding: var(--tooltip-padding);
-  border-radius: var(--radius-lg);
-  font-size: var(--font-size-xs);
-  line-height: var(--tooltip-line-height);
-  width: max-content;
-  max-width: var(--tooltip-max-width);
-  white-space: pre-line;
-  text-align: left;
-  box-shadow: var(--shadow-md);
-}
-
-.evidence-map__head-tip::after {
-  content: "";
-  position: absolute;
-  top: 100%;
-  left: calc(50% + var(--tail-x, 0px));
-  transform: translateX(-50%);
-  border-left: 6px solid transparent;
-  border-right: 6px solid transparent;
-  border-top: 8px solid var(--tooltip-bg);
-}
-
 /* ── Corner: total + axis key ── */
 .evidence-map__corner {
   top: 0;
@@ -252,42 +219,6 @@
   display: flex;
   width: 100%;
   height: 100%;
-}
-
-/* Anchor the bubble just above the dot (centred in the cell, radius in
-   --evidence-map-dot) rather than the cell edge, and shrink the text. */
-.evidence-map__cell .tooltip:hover::after,
-.evidence-map__cell .tooltip:focus-within::after,
-.evidence-map__cell .tooltip:focus-visible::after {
-  white-space: pre-line;
-  font-size: var(--font-size-xs);
-  bottom: calc(
-    50% + var(--evidence-map-dot, 0px) + var(--evidence-map-tip-lift, 0px) + 8px
-  );
-}
-
-/* Speech-bubble tail: a downward triangle whose apex meets the dot's top edge,
-   base meeting the bubble bottom 8px above. */
-.evidence-map__cell .tooltip:hover::before,
-.evidence-map__cell .tooltip:focus-within::before,
-.evidence-map__cell .tooltip:focus-visible::before {
-  content: "";
-  position: absolute;
-  bottom: calc(
-    50% + var(--evidence-map-dot, 0px) + var(--evidence-map-tip-lift, 0px)
-  );
-  left: 50%;
-  transform: translateX(-50%);
-  border-left: 6px solid transparent;
-  border-right: 6px solid transparent;
-  border-top: 8px solid var(--tooltip-bg);
-  z-index: 10;
-}
-
-/* Table cells have no bubble (--evidence-map-dot is 0), so the tail would land
-   on the centre of the number. Lift it clear of the digits. */
-.evidence-map__table--table .evidence-map__cell {
-  --evidence-map-tip-lift: 14px;
 }
 
 .evidence-map__cell-inner,

--- a/src/components/visualise/EvidenceMapGrid.tsx
+++ b/src/components/visualise/EvidenceMapGrid.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from "preact/hooks";
+import { useState } from "preact/hooks";
 import {
   bubbleRadius,
   formatCompact,
@@ -94,35 +94,6 @@ export function EvidenceMapGrid({
     null,
   );
 
-  // Header tooltips can't be CSS pseudo-elements: the headers live inside the
-  // scroll box (overflow) and the map column (overflow: hidden), both of which
-  // clip a bubble that escapes the cell. Instead a single fixed-positioned
-  // bubble is measured against the hovered/focused header so it can sit above
-  // the text, clear of every clip. tailX tracks the text when the bubble is
-  // clamped to the viewport edge.
-  const [tip, setTip] = useState<{ text: string; x: number; y: number } | null>(
-    null,
-  );
-  const tipRef = useRef<HTMLDivElement>(null);
-  const showTip = (text: string, el: HTMLElement) => {
-    const r = el.getBoundingClientRect();
-    setTip({ text, x: r.left + r.width / 2, y: r.top });
-  };
-  const hideTip = () => setTip(null);
-
-  useLayoutEffect(() => {
-    const el = tipRef.current;
-    if (!tip || !el) return;
-    const half = el.offsetWidth / 2;
-    const margin = 8;
-    const x = Math.max(
-      margin + half,
-      Math.min(tip.x, window.innerWidth - margin - half),
-    );
-    el.style.left = `${x}px`;
-    el.style.setProperty("--tail-x", `${tip.x - x}px`);
-  }, [tip]);
-
   return (
     <div
       class={`evidence-map${updating ? " is-updating" : ""}${
@@ -182,8 +153,6 @@ export function EvidenceMapGrid({
                     onClick={
                       onColumnClick ? () => onColumnClick(column) : undefined
                     }
-                    onTipShow={showTip}
-                    onTipHide={hideTip}
                   />
                 </th>
               ))}
@@ -204,8 +173,6 @@ export function EvidenceMapGrid({
                     tooltip={headerTooltip}
                     ariaLabel={headerAriaLabel(row.label, countNoun)}
                     onClick={onRowClick ? () => onRowClick(row) : undefined}
-                    onTipShow={showTip}
-                    onTipHide={hideTip}
                   />
                 </th>
                 {columns.map((column) => {
@@ -249,56 +216,38 @@ export function EvidenceMapGrid({
       {view === "bubble" && (
         <MapLegend maxCount={maxCount} countNoun={countNoun} />
       )}
-      {tip && (
-        <div
-          ref={tipRef}
-          class="evidence-map__head-tip"
-          style={{ left: `${tip.x}px`, top: `${tip.y}px` }}
-          aria-hidden="true"
-        >
-          {tip.text}
-        </div>
-      )}
     </div>
   );
 }
 
-// A row/column header label. When clickable it's a button wrapping just the
-// label text (the click target is the label, while the whole cell shades on
-// hover — see CSS). Hover/focus reports the button's box up to the grid, which
-// positions the shared fixed tooltip above the text.
+// A row/column header label. When clickable it's a button (the click target is
+// the label; the whole cell shades on hover — see CSS) with a Tooltip.
 function HeaderLabel({
   label,
   labelClass,
   tooltip,
   ariaLabel,
   onClick,
-  onTipShow,
-  onTipHide,
 }: {
   label: string;
   labelClass?: string;
   tooltip: string;
   ariaLabel: string;
   onClick?: () => void;
-  onTipShow: (text: string, el: HTMLElement) => void;
-  onTipHide: () => void;
 }) {
   const labelSpan = <span class={labelClass}>{label}</span>;
   if (!onClick) return labelSpan;
   return (
-    <button
-      type="button"
-      class="evidence-map__head-link"
-      aria-label={ariaLabel}
-      onClick={onClick}
-      onMouseEnter={(e) => onTipShow(tooltip, e.currentTarget)}
-      onMouseLeave={onTipHide}
-      onFocus={(e) => onTipShow(tooltip, e.currentTarget)}
-      onBlur={onTipHide}
-    >
-      {labelSpan}
-    </button>
+    <Tooltip text={tooltip}>
+      <button
+        type="button"
+        class="evidence-map__head-link"
+        aria-label={ariaLabel}
+        onClick={onClick}
+      >
+        {labelSpan}
+      </button>
+    </Tooltip>
   );
 }
 
@@ -327,8 +276,6 @@ function Cell({
   onHover,
   onClick,
 }: CellProps) {
-  // Bubble radius drives the tooltip/tail anchor (--evidence-map-dot): the dot
-  // is centred in the cell, so the tail points at it rather than the cell edge.
   const radius =
     view === "bubble" && !empty
       ? bubbleRadius(count, maxCount, BUBBLE_MIN_RADIUS, BUBBLE_MAX_RADIUS)
@@ -365,7 +312,6 @@ function Cell({
   return (
     <td
       class={`evidence-map__cell${empty ? " is-empty" : ""}${activeClass}`}
-      style={{ "--evidence-map-dot": `${radius}px` }}
       onMouseEnter={onHover}
     >
       <Tooltip text={tooltip}>{content}</Tooltip>

--- a/tests/components/common/Tooltip.test.tsx
+++ b/tests/components/common/Tooltip.test.tsx
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { render } from "@testing-library/preact";
+import { render, fireEvent, screen } from "@testing-library/preact";
 import { Tooltip } from "@/components/common/Tooltip";
 
 describe("Tooltip", () => {
@@ -32,5 +32,35 @@ describe("Tooltip", () => {
       </Tooltip>,
     );
     expect(container.querySelector(".tooltip")).toBeNull();
+  });
+
+  test("shows the bubble on hover and removes it on leave", () => {
+    const { container } = render(
+      <Tooltip text="bubble text">
+        <button type="button">click</button>
+      </Tooltip>,
+    );
+    const wrap = container.querySelector(".tooltip")!;
+
+    fireEvent.mouseEnter(wrap);
+    expect(screen.getByText("bubble text")).toBeInTheDocument();
+
+    fireEvent.mouseLeave(wrap);
+    expect(screen.queryByText("bubble text")).not.toBeInTheDocument();
+  });
+
+  test("shows the bubble when the trigger is focused and hides it on blur", () => {
+    render(
+      <Tooltip text="focus text">
+        <button type="button">click</button>
+      </Tooltip>,
+    );
+    const button = screen.getByRole("button");
+
+    fireEvent.focus(button);
+    expect(screen.getByText("focus text")).toBeInTheDocument();
+
+    fireEvent.blur(button);
+    expect(screen.queryByText("focus text")).not.toBeInTheDocument();
   });
 });

--- a/tests/components/visualise/EvidenceMapGrid.test.tsx
+++ b/tests/components/visualise/EvidenceMapGrid.test.tsx
@@ -184,11 +184,13 @@ describe("EvidenceMapGrid", () => {
     });
 
     // Hovering shows the action tooltip for sighted users; leaving hides it.
-    fireEvent.mouseEnter(columnButton);
+    // The tooltip's hover handlers live on the .tooltip wrapper around the button.
+    const columnTip = columnButton.closest(".tooltip")!;
+    fireEvent.mouseEnter(columnTip);
     expect(
       screen.getByText("Click to view matching investigations"),
     ).toBeInTheDocument();
-    fireEvent.mouseLeave(columnButton);
+    fireEvent.mouseLeave(columnTip);
     expect(
       screen.queryByText("Click to view matching investigations"),
     ).not.toBeInTheDocument();


### PR DESCRIPTION
Fixes #170 

Refactor tooltips to use [popover](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) in order to properly escape above their own context.

Also, if a tooltip is too close to the top of the page, it will flip to be below the hovered element.