### PR TITLE
Match AI-summary quote `page` type to corrected summariser contract

### DIFF
--- a/src/services/summariser.ts
+++ b/src/services/summariser.ts
@@ -16,7 +16,7 @@ export interface QuoteRef {
   quote: string;
   /** Identifies the source paper; joins to `PaperMeta.paper`. */
   paper: string;
-  page?: number | null;
+  page?: string | null;
   /** 1-based indices into the run's `terms` list. */
   terms: number[];
 }

--- a/src/services/summariserMock.ts
+++ b/src/services/summariserMock.ts
@@ -59,14 +59,14 @@ export const MOCK_SUMMARY: SummariseResponse = {
             quote:
               "Extending vaccination to multiple older cohorts remained cost-effective even under conservative coverage and cost assumptions.",
             paper: "abbas-2018",
-            page: 7,
+            page: "S17",
             terms: [2],
           },
           {
             quote:
               "Beyond the primary 9–14 cohort the incremental cost per DALY averted rose sharply, exceeding the threshold in lower-coverage scenarios.",
             paper: "brisson-2021",
-            page: 14,
+            page: "iv",
             terms: [2],
           },
         ],

--- a/tests/components/ai-summary/AiSummaryDrawer.test.tsx
+++ b/tests/components/ai-summary/AiSummaryDrawer.test.tsx
@@ -84,7 +84,7 @@ describe("AiSummaryDrawer", () => {
                 {
                   quote: "Catch-up vaccination remained cost-effective.",
                   paper: "anwari-2019",
-                  page: 12,
+                  page: "12",
                   terms: [2],
                 },
                 {

--- a/tests/components/ai-summary/AiSummaryDrawer.test.tsx
+++ b/tests/components/ai-summary/AiSummaryDrawer.test.tsx
@@ -114,6 +114,15 @@ describe("AiSummaryDrawer", () => {
     expect(pagelessCite?.querySelector(".ai-cite__page")).toBeNull();
   });
 
+  test("renders non-integer page labels verbatim, not coerced to numbers", () => {
+    // The summariser sends page as a printed label (string), e.g. "S17", "iv",
+    // "12-14"; the mock carries such labels. They must render as-is, so a numeric
+    // coercion in the render path (which would show "p. NaN") fails this.
+    render(<AiSummaryDrawer ai={makeAi()} />);
+    expect(screen.getByText("p. S17")).toBeDefined();
+    expect(screen.getByText("p. iv")).toBeDefined();
+  });
+
   test("clicking a footnote scrolls to and flashes its claim", () => {
     const { container } = render(
       <AiSummaryDrawer ai={makeAi()} />,


### PR DESCRIPTION
The evidence-summariser's OpenAPI now types a quote's `page` as `string | null` (futureevidence/ai-evidence-summariser#13, fixed in futureevidence/ai-evidence-summariser#14). This repo still declared `page?: number | null` in `src/services/summariser.ts`, with the mock and a test fixture supplying numeric pages.

`page` is render-only: `renderSummary.tsx` emits `p. {quote.page}` and guards with `quote.page != null`, and the summariser response is consumed via an unchecked `as SummariseResponse` cast, so a number-vs-string mismatch never affected runtime. This aligns the type and the mock/fixture with the corrected contract.

futureevidence/ai-evidence-summariser#14 or this PR can be deployed independently from each other, in either order. Because the value only flows to text, the old number-typed UI renders string pages fine and the new string-typed UI renders number payloads fine.

Changes:
- `src/services/summariser.ts`: `QuoteRef.page` from `number | null` to `string | null`
- `src/services/summariserMock.ts`: mock quote pages now carry real non-integer labels (`"S17"`, `"iv"`) so the mock represents the labels the corrected contract unblocks, not just integer-like strings
- `tests/components/ai-summary/AiSummaryDrawer.test.tsx`: fixture page `12` to `"12"`, and a new test rendering the mock's `"S17"`/`"iv"` labels and asserting they appear verbatim

## Validation performed
- `npm run typecheck` clean
- Full vitest suite green (882 tests across 80 files)
- Added a render test for non-integer page labels (`"S17"`, `"iv"`): it asserts the printed label shows as-is, so a numeric coercion in the render path would fail. The prior `p. 12` assertion was type-invariant and is not the guard.
- Live-validated in the running app (`/hpv`, dev `:3000` with mock summariser + staging search API, authed with the `ai_summary.writer` role): generated a summary over 24 references and confirmed the "Where papers disagree" quotes render `p. S17` and `p. iv` verbatim, no coercion or dropped label, console clean.
