### PR TITLE
Resolve community slugs case-insensitively

### DIFF
--- a/src/services/communities.ts
+++ b/src/services/communities.ts
@@ -176,6 +176,18 @@ const COMMUNITIES: Community[] = [
   },
 ];
 
+// findCommunity normalises lookups to lowercase, so an uppercase registered slug would be unreachable.
+export function assertLowercaseSlugs(communities: readonly Community[]): void {
+  for (const { slug } of communities) {
+    if (slug !== slug.toLowerCase()) {
+      throw new Error(
+        `Community slug "${slug}" must be lowercase (findCommunity normalises lookups to lowercase).`,
+      );
+    }
+  }
+}
+assertLowercaseSlugs(COMMUNITIES);
+
 export function findCommunity(slug: string): Community | undefined {
   // Slugs are acronyms (ESEA, HPV) registered lowercase; normalise input so a user typing /ESEA resolves.
   return COMMUNITIES.find((c) => c.slug === slug.toLowerCase());

--- a/src/services/communities.ts
+++ b/src/services/communities.ts
@@ -177,7 +177,8 @@ const COMMUNITIES: Community[] = [
 ];
 
 export function findCommunity(slug: string): Community | undefined {
-  return COMMUNITIES.find((c) => c.slug === slug);
+  // Slugs are acronyms (ESEA, HPV) registered lowercase; normalise input so a user typing /ESEA resolves.
+  return COMMUNITIES.find((c) => c.slug === slug.toLowerCase());
 }
 
 // Brand link / not-found fallback target while there's no true "/" landing

--- a/tests/services/communities.test.ts
+++ b/tests/services/communities.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Community } from "@/types/models";
 
 function stubValidEnv() {
   vi.stubEnv("VITE_ESEA_VOCABULARY_URL", "https://vocab.example/v1");
@@ -55,6 +56,13 @@ describe("communities", () => {
     const { findCommunity } = await import("@/services/communities");
     expect(findCommunity("ESEA")?.slug).toBe("esea");
     expect(findCommunity("Hpv")?.slug).toBe("hpv");
+  });
+
+  it("rejects a registered community slug that is not lowercase", async () => {
+    const { assertLowercaseSlugs } = await import("@/services/communities");
+    expect(() => assertLowercaseSlugs([{ slug: "ESEA" } as Community])).toThrow(
+      /lowercase/,
+    );
   });
 
   it("defaults to the HPV community", async () => {

--- a/tests/services/communities.test.ts
+++ b/tests/services/communities.test.ts
@@ -51,6 +51,12 @@ describe("communities", () => {
     expect(hpv?.codingInstitution).toBeUndefined();
   });
 
+  it("resolves community slugs case-insensitively, so uppercase acronym URLs still work", async () => {
+    const { findCommunity } = await import("@/services/communities");
+    expect(findCommunity("ESEA")?.slug).toBe("esea");
+    expect(findCommunity("Hpv")?.slug).toBe("hpv");
+  });
+
   it("defaults to the HPV community", async () => {
     const { DEFAULT_COMMUNITY, DEFAULT_COMMUNITY_SLUG } = await import(
       "@/services/communities"


### PR DESCRIPTION
## Summary

Community slugs are acronyms (`ESEA`, `HPV`) that are conventionally written uppercase, so a user typing their organisation's URL the way they know it, `/ESEA`, got "Page not found" instead of the search page.

The route `/:community` is a wildcard, so `/ESEA` matches and captures `community = "ESEA"`. The rejection happened one layer down: `findCommunity` compared case-sensitively against the registered lowercase slugs (`esea`, `hpv`), returned `undefined`, `CommunityContext` set the community to `null`, and `SearchPage` rendered `NotFoundPage`. It is a data-lookup mismatch, not a routing limitation.

The fix normalises the incoming slug to lowercase before lookup. `findCommunity` is the single chokepoint for all three slug-resolution paths: route resolution (`CommunityContext`), the self-signup gate (`keycloak.ts`), and the default-community init, so one change covers them.

Scope note: the inbound URL is matched, not canonicalised. Internal links are all built from the canonical lowercase `community.slug`, so the first internal navigation (a result, a nav item) rewrites `/ESEA` to `/esea`; it self-heals. One known cosmetic residual: on the initial uppercase landing the top-nav active highlight is absent (`AppShell` compares `pathname` against the lowercase slug exactly), correcting on that first navigation. A `/ESEA` to `/esea` replace-redirect would canonicalise immediately and remove the residual, but it is a larger navigation-layer change and is not needed to kill the 404.

## Validation performed

- Added a focused test asserting `findCommunity("ESEA")` / `findCommunity("Hpv")` resolve to the canonical lowercase communities; watched it fail behaviourally (`expected undefined to be 'esea'`) before the fix.
- Full suite green (882 tests); `tsc --noEmit` clean.
- Live-verified against local DR (dev server on :3000, host-native API on :8000):
  - `/ESEA` renders the Education search page (8,500 investigations, real result cards); previously 404.
  - `/HPV` renders the HPV Vaccine Delivery search page.
  - `/esea` still renders (no regression on the canonical lowercase form).
  - `/NONSENSE` still shows "Page not found" (negative control: confirms the change normalises case rather than accepting any slug).
  - No console errors.
