### PR TITLE
Fix double-counting of extraction errors in footer

### DIFF
--- a/src/components/ai-summary/AiSummaryDrawer.tsx
+++ b/src/components/ai-summary/AiSummaryDrawer.tsx
@@ -4,7 +4,10 @@ import { Spinner } from "@/components/common/Spinner";
 import { WarningIcon } from "@/components/common/icons";
 import { AI_SUMMARY_FLAG_FORM_URL } from "@/config";
 import { URL_CHANGE_EVENT } from "@/services/navigation";
-import type { AiSummaryContext, UseAiSummaryResult } from "@/hooks/useAiSummary";
+import type {
+  AiSummaryContext,
+  UseAiSummaryResult,
+} from "@/hooks/useAiSummary";
 import type { SkipReason, SummariseResponse } from "@/services/summariser";
 import { formatTotal } from "@/utils/searchTotal";
 import { SummaryBody } from "./renderSummary";
@@ -31,7 +34,8 @@ export function AiSummaryDrawer({ ai }: AiSummaryDrawerProps) {
   // Closing should never abort an in-flight job — only the explicit "Cancel"
   // does. While generating, close drops it to the background chip; once there's
   // nothing running, close clears the finished summary.
-  const handleClose = ai.status === "generating" ? ai.runInBackground : ai.dismiss;
+  const handleClose =
+    ai.status === "generating" ? ai.runInBackground : ai.dismiss;
   const context = ai.context;
 
   return (
@@ -76,10 +80,7 @@ export function AiSummaryDrawer({ ai }: AiSummaryDrawerProps) {
       {ai.status === "done" && ai.result && (
         <>
           <Disclaimer />
-          <SummaryBody
-            summary={ai.result.summary}
-            papers={ai.result.papers}
-          />
+          <SummaryBody summary={ai.result.summary} papers={ai.result.papers} />
           <CoverageNote result={ai.result} />
         </>
       )}
@@ -89,7 +90,9 @@ export function AiSummaryDrawer({ ai }: AiSummaryDrawerProps) {
 
 // How many references the summary actually drew on, and which were left out.
 function CoverageNote({ result }: { result: SummariseResponse }) {
-  const used = result.papers.length;
+  // Avoid double-counting papers with extraction
+  const erroredIds = new Set(result.extraction_errors.map((err) => err.paper));
+  const used = result.papers.filter((p) => !erroredIds.has(p.paper)).length;
 
   const reasonCounts = new Map<SkipReason, number>();
   for (const ref of result.skipped_references) {
@@ -102,7 +105,8 @@ function CoverageNote({ result }: { result: SummariseResponse }) {
     clauses.push(`${result.extraction_errors.length} couldn't be read`);
   }
 
-  const leftOut = result.skipped_references.length + result.extraction_errors.length;
+  const leftOut =
+    result.skipped_references.length + result.extraction_errors.length;
   const total = used + leftOut;
 
   return (

--- a/tests/components/ai-summary/AiSummaryDrawer.test.tsx
+++ b/tests/components/ai-summary/AiSummaryDrawer.test.tsx
@@ -155,6 +155,24 @@ describe("AiSummaryDrawer", () => {
     expect(note.textContent).toMatch(/1 couldn't be read/i);
   });
 
+  test("coverage note counts a paper listed in both papers and extraction_errors only once", () => {
+    // The service returns an unreadable paper (e.g. 413 too-large) in `papers`
+    // with empty metadata *and* in `extraction_errors`. Naively adding the two
+    // list lengths double-counts it ("5 of 6"); it must read "4 of 5".
+    const duplicated = MOCK_SUMMARY.papers[0].paper;
+    const ai = makeAi({
+      result: {
+        ...MOCK_SUMMARY,
+        papers: MOCK_SUMMARY.papers, // 5, one of which also errored
+        skipped_references: [],
+        extraction_errors: [{ paper: duplicated, error: "request_too_large" }],
+      },
+    });
+    render(<AiSummaryDrawer ai={ai} />);
+    const note = screen.getByText(/Based on 4 of 5 references/i);
+    expect(note.textContent).toMatch(/1 couldn't be read/i);
+  });
+
   test("coverage note reads cleanly at full coverage", () => {
     const ai = makeAi({
       result: { ...MOCK_SUMMARY, skipped_references: [], extraction_errors: [] },

--- a/tests/components/ai-summary/AiSummaryDrawer.test.tsx
+++ b/tests/components/ai-summary/AiSummaryDrawer.test.tsx
@@ -15,7 +15,9 @@ const context = {
   countNoun: "references",
 };
 
-function makeAi(overrides: Partial<UseAiSummaryResult> = {}): UseAiSummaryResult {
+function makeAi(
+  overrides: Partial<UseAiSummaryResult> = {},
+): UseAiSummaryResult {
   return {
     status: "done",
     minimized: false,
@@ -49,7 +51,9 @@ describe("AiSummaryDrawer", () => {
   test("renders the result: prose, context chips, and claims", () => {
     render(<AiSummaryDrawer ai={makeAi()} />);
 
-    expect(screen.getByText(/highly cost-effective at national coverage/i)).toBeDefined();
+    expect(
+      screen.getByText(/highly cost-effective at national coverage/i),
+    ).toBeDefined();
     expect(screen.getByText("Afghanistan")).toBeDefined();
     expect(screen.getByText("15 references")).toBeDefined();
     // One numbered claim per claim in the summary.
@@ -124,9 +128,7 @@ describe("AiSummaryDrawer", () => {
   });
 
   test("clicking a footnote scrolls to and flashes its claim", () => {
-    const { container } = render(
-      <AiSummaryDrawer ai={makeAi()} />,
-    );
+    const { container } = render(<AiSummaryDrawer ai={makeAi()} />);
     const firstFootnote = container.querySelector(".ai-fn") as HTMLElement;
     fireEvent.click(firstFootnote);
 
@@ -156,9 +158,6 @@ describe("AiSummaryDrawer", () => {
   });
 
   test("coverage note counts a paper listed in both papers and extraction_errors only once", () => {
-    // The service returns an unreadable paper (e.g. 413 too-large) in `papers`
-    // with empty metadata *and* in `extraction_errors`. Naively adding the two
-    // list lengths double-counts it ("5 of 6"); it must read "4 of 5".
     const duplicated = MOCK_SUMMARY.papers[0].paper;
     const ai = makeAi({
       result: {
@@ -175,7 +174,11 @@ describe("AiSummaryDrawer", () => {
 
   test("coverage note reads cleanly at full coverage", () => {
     const ai = makeAi({
-      result: { ...MOCK_SUMMARY, skipped_references: [], extraction_errors: [] },
+      result: {
+        ...MOCK_SUMMARY,
+        skipped_references: [],
+        extraction_errors: [],
+      },
     });
     render(<AiSummaryDrawer ai={ai} />);
     expect(screen.getByText(/Based on 5 references\./i)).toBeDefined();
@@ -192,11 +195,12 @@ describe("AiSummaryDrawer", () => {
     render(
       <AiSummaryDrawer
         ai={makeAi({ status: "error", result: null, errorMessage: "boom" })}
-       
       />,
     );
     expect(screen.getByRole("alert")).toHaveTextContent("boom");
-    expect(screen.queryByRole("link", { name: /flag this summary/i })).toBeNull();
+    expect(
+      screen.queryByRole("link", { name: /flag this summary/i }),
+    ).toBeNull();
   });
 
   test("shows a loading state with Cancel and Run in background while generating", () => {
@@ -205,7 +209,9 @@ describe("AiSummaryDrawer", () => {
     );
     expect(screen.getByText(/summarising 15 references/i)).toBeDefined();
     expect(screen.getByRole("button", { name: "Cancel" })).toBeDefined();
-    expect(screen.getByRole("button", { name: "Run in background" })).toBeDefined();
+    expect(
+      screen.getByRole("button", { name: "Run in background" }),
+    ).toBeDefined();
   });
 
   test("Run in background invokes the hook action", () => {


### PR DESCRIPTION
Spotted in investigation of https://github.com/futureevidence/ai-evidence-summariser/issues/15.

For example, if an AI summary request had 41 references, and one had an extraction error, the footer would print "41/42" as it double-counts the errored paper.