### PR TITLE
export: tolerate dict-or-array JSON-LD shapes in the investigation-hierarchy export

### DIFF
--- a/src/services/export/buildRows.ts
+++ b/src/services/export/buildRows.ts
@@ -206,6 +206,18 @@ function joinCodedValues(annotations: unknown): string {
 }
 
 /**
+ * Scalar `@value` cell: a lone value kept typed (numeric stays numeric),
+ * two or more `; `-joined so an extra coded value is never dropped.
+ */
+function collapseCodedValues(annotations: unknown): CellValue {
+  const values = ensureArray(annotations)
+    .map((a) => codedValue(a))
+    .filter((v): v is string | number | boolean => v != null);
+  if (values.length <= 1) return values[0] ?? null;
+  return values.map((v) => String(v)).join("; ");
+}
+
+/**
  * Concatenate the `supportingText` field of each annotation with ` | `
  * between entries.
  */
@@ -375,14 +387,15 @@ export function buildFindingRows(
   vocab: ConceptResolver,
 ): ArmRow[] {
   const resolve = makeResolver(buildBlankNodeLookup(findings));
+  const resolveMany = (value: unknown): PlainRecord[] => ensureArray(value).map(resolve);
   const rows: ArmRow[] = [];
   for (let i = 0; i < findings.length; i++) {
     const finding = findings[i]!;
     const armId = armIds[i]!;
     const ctx = resolve(finding["hasContext"]);
-    const sampleSize = resolve(finding["sampleSize"]);
-    const attrition = resolve(finding["attrition"]);
-    const cost = resolve(finding["cost"]);
+    const sampleSizes = resolveMany(finding["sampleSize"]);
+    const attritions = resolveMany(finding["attrition"]);
+    const costs = resolveMany(finding["cost"]);
     const intervention = resolve(finding["evaluates"]);
     const control = resolve(finding["comparedTo"]);
     rows.push({
@@ -391,19 +404,19 @@ export function buildFindingRows(
       intervention_name: typeof intervention["name"] === "string" ? (intervention["name"] as string) : null,
       intervention_description: flattenDescription(intervention["description"]),
       control_description: flattenDescription(control["description"]),
-      intervention_duration_value: codedValue(first(intervention["duration"])),
-      intervention_duration_supportingText: supportingText(first(intervention["duration"])),
+      intervention_duration_value: collapseCodedValues(intervention["duration"]),
+      intervention_duration_supportingText: joinSupportingTexts(intervention["duration"]),
       intervention_educationTheme: joinCodedIds(intervention["educationTheme"], vocab),
       intervention_educationTheme_supportingText: joinSupportingTexts(intervention["educationTheme"]),
       intervention_implementationFidelity: joinCodedIds(ensureArray(intervention["implementationFidelity"]), vocab),
       intervention_implementationFidelity_supportingText: joinSupportingTexts(ensureArray(intervention["implementationFidelity"])),
       intervention_implementerType: joinCodedIds(ensureArray(intervention["implementerType"]), vocab),
       intervention_implementerType_supportingText: joinSupportingTexts(ensureArray(intervention["implementerType"])),
-      sampleSize_value: codedValue(sampleSize),
-      sampleSize_supportingText: supportingText(sampleSize),
-      attrition_value: codedValue(attrition),
-      attrition_supportingText: supportingText(attrition),
-      cost_value: codedValue(cost),
+      sampleSize_value: collapseCodedValues(sampleSizes),
+      sampleSize_supportingText: joinSupportingTexts(sampleSizes),
+      attrition_value: collapseCodedValues(attritions),
+      attrition_supportingText: joinSupportingTexts(attritions),
+      cost_value: collapseCodedValues(costs),
       context_country: joinCodedValues(ctx["country"]),
       context_countryLevel1: joinCodedValues(ctx["countryLevel1"]),
       context_educationLevel: joinCodedIds(ctx["educationLevel"], vocab),

--- a/src/services/export/buildRows.ts
+++ b/src/services/export/buildRows.ts
@@ -106,6 +106,17 @@ const ARM_KEY_FIELDS = [
 
 type PlainRecord = Record<string, unknown>;
 
+/** Normalise a JSON-LD value to a list: absent → [], array → itself, single → [value]. */
+export function ensureArray(v: unknown): unknown[] {
+  if (v === undefined || v === null) return [];
+  return Array.isArray(v) ? v : [v];
+}
+
+/** Take the first element of an array (any type), else the value itself. */
+function first(v: unknown): unknown {
+  return Array.isArray(v) ? v[0] : v;
+}
+
 /**
  * Round numeric cells to 5 decimal places.
  * Pass-through for non-finite numbers and non-numeric values.
@@ -176,8 +187,7 @@ function supportingText(annotation: unknown): string | null {
  * delimiter-separated string.
  */
 function joinCodedIds(annotations: unknown, vocab: ConceptResolver): string {
-  const list = Array.isArray(annotations) ? annotations : [];
-  return list
+  return ensureArray(annotations)
     .map((a) => codedId(a, vocab))
     .filter((v): v is string | number | boolean => v != null && v !== "")
     .join("; ");
@@ -188,8 +198,7 @@ function joinCodedIds(annotations: unknown, vocab: ConceptResolver): string {
  * stringifying numerics. Nullish entries are dropped.
  */
 function joinCodedValues(annotations: unknown): string {
-  const list = Array.isArray(annotations) ? annotations : [];
-  return list
+  return ensureArray(annotations)
     .map((a) => codedValue(a))
     .filter((v): v is string | number | boolean => v != null)
     .map((v) => String(v))
@@ -201,8 +210,7 @@ function joinCodedValues(annotations: unknown): string {
  * between entries.
  */
 function joinSupportingTexts(annotations: unknown): string {
-  const list = Array.isArray(annotations) ? annotations : [];
-  return list
+  return ensureArray(annotations)
     .map((a) => supportingText(a))
     .filter((v): v is string => v != null && v !== "")
     .join(" | ");
@@ -213,11 +221,12 @@ function joinSupportingTexts(annotations: unknown): string {
  * dict (`{"@id": "_:foo", ...}`) or a bare string ref (`"_:foo"`).
  */
 function refId(value: unknown): string | null {
-  if (isDict(value)) {
-    const id = value["@id"];
+  const v = first(value);
+  if (isDict(v)) {
+    const id = v["@id"];
     return typeof id === "string" ? id : null;
   }
-  if (typeof value === "string") return value;
+  if (typeof v === "string") return v;
   return null;
 }
 
@@ -231,10 +240,11 @@ function buildBlankNodeLookup(findings: Finding[]): Map<string, PlainRecord> {
   const lookup = new Map<string, PlainRecord>();
   for (const finding of findings) {
     for (const key of ["comparedTo", "evaluates", "hasContext", "sampleSize", "attrition", "cost"] as const) {
-      const value = finding[key];
-      if (isDict(value)) {
-        const id = value["@id"];
-        if (typeof id === "string") lookup.set(id, value);
+      for (const value of ensureArray(finding[key])) {
+        if (isDict(value)) {
+          const id = value["@id"];
+          if (typeof id === "string") lookup.set(id, value as PlainRecord);
+        }
       }
     }
   }
@@ -251,8 +261,9 @@ type Resolver = (value: unknown) => PlainRecord;
  */
 function makeResolver(lookup: Map<string, PlainRecord>): Resolver {
   return (value) => {
-    if (typeof value === "string") return lookup.get(value) ?? {};
-    if (isDict(value)) return value;
+    const v = first(value);
+    if (typeof v === "string") return lookup.get(v) ?? {};
+    if (isDict(v)) return v;
     return {};
   };
 }
@@ -332,7 +343,6 @@ export function buildInvestigationRow(
   vocab: ConceptResolver,
   codingInstitution?: CodingInstitutionConfig,
 ): InvestigationRow {
-  const docType = investigation.documentType ?? {};
   const authors = bibliographic?.authorship
     ? bibliographic.authorship.map((a) => a.display_name).join("; ")
     : null;
@@ -344,8 +354,8 @@ export function buildInvestigationRow(
     publication_year: bibliographic?.publication_year ?? null,
     doi: extractDoi(reference.identifiers ?? null),
     openalex_id: extractOpenAlexId(reference.identifiers ?? null),
-    documentType: codedId(docType, vocab),
-    studyDesign: codedId(investigation.studyDesign ?? {}, vocab),
+    documentType: joinCodedIds(ensureArray(investigation.documentType), vocab),
+    studyDesign: joinCodedIds(ensureArray(investigation.studyDesign), vocab),
     vocabulary: linked.content.vocabulary_uri,
   };
 }
@@ -381,14 +391,14 @@ export function buildFindingRows(
       intervention_name: typeof intervention["name"] === "string" ? (intervention["name"] as string) : null,
       intervention_description: flattenDescription(intervention["description"]),
       control_description: flattenDescription(control["description"]),
-      intervention_duration_value: codedValue(intervention["duration"]),
-      intervention_duration_supportingText: supportingText(intervention["duration"]),
+      intervention_duration_value: codedValue(first(intervention["duration"])),
+      intervention_duration_supportingText: supportingText(first(intervention["duration"])),
       intervention_educationTheme: joinCodedIds(intervention["educationTheme"], vocab),
       intervention_educationTheme_supportingText: joinSupportingTexts(intervention["educationTheme"]),
-      intervention_implementationFidelity: codedId(intervention["implementationFidelity"], vocab),
-      intervention_implementationFidelity_supportingText: supportingText(intervention["implementationFidelity"]),
-      intervention_implementerType: codedId(intervention["implementerType"], vocab),
-      intervention_implementerType_supportingText: supportingText(intervention["implementerType"]),
+      intervention_implementationFidelity: joinCodedIds(ensureArray(intervention["implementationFidelity"]), vocab),
+      intervention_implementationFidelity_supportingText: joinSupportingTexts(ensureArray(intervention["implementationFidelity"])),
+      intervention_implementerType: joinCodedIds(ensureArray(intervention["implementerType"]), vocab),
+      intervention_implementerType_supportingText: joinSupportingTexts(ensureArray(intervention["implementerType"])),
       sampleSize_value: codedValue(sampleSize),
       sampleSize_supportingText: supportingText(sampleSize),
       attrition_value: codedValue(attrition),
@@ -425,11 +435,12 @@ export function buildOutcomeRows(
   for (let i = 0; i < findings.length; i++) {
     const finding = findings[i]!;
     const armId = armIds[i]!;
-    const outcomeBlock = isDict(finding["hasOutcome"]) ? (finding["hasOutcome"] as PlainRecord) : {};
+    const outcomeRaw = first(finding["hasOutcome"]);
+    const outcomeBlock = isDict(outcomeRaw) ? (outcomeRaw as PlainRecord) : {};
     const outcomeConcepts = joinCodedIds(outcomeBlock["outcome"], vocab);
     const outcomeConceptsSupporting = joinSupportingTexts(outcomeBlock["outcome"]);
 
-    const armData = Array.isArray(finding["hasArmData"]) ? (finding["hasArmData"] as PlainRecord[]) : [];
+    const armData = ensureArray(finding["hasArmData"]).filter(isDict) as PlainRecord[];
     const armLookup = new Map<string, PlainRecord>();
     for (const arm of armData) {
       const id = refId(arm["forCondition"]);
@@ -438,9 +449,9 @@ export function buildOutcomeRows(
     const interventionArm = armLookup.get(refId(finding["evaluates"]) ?? "") ?? {};
     const controlArm = armLookup.get(refId(finding["comparedTo"]) ?? "") ?? {};
 
-    const effectEstimates = Array.isArray(finding["hasEffectEstimate"])
-      ? (finding["hasEffectEstimate"] as PlainRecord[])
-      : [{}];
+    const estimates = ensureArray(finding["hasEffectEstimate"]).filter(isDict) as PlainRecord[];
+    // findings with no effect estimate still emit one row (outcome/arm data preserved)
+    const effectEstimates = estimates.length ? estimates : [{}];
     for (const effect of effectEstimates) {
       const baselineAdjusted = effect["baselineAdjusted"];
       rows.push({
@@ -450,7 +461,7 @@ export function buildOutcomeRows(
         outcome_description: typeof outcomeBlock["description"] === "string" ? (outcomeBlock["description"] as string) : null,
         outcome_concepts: outcomeConcepts,
         outcome_concepts_supportingText: outcomeConceptsSupporting,
-        effect_metric: label(effect["effectSizeMetric"], vocab) as CellValue,
+        effect_metric: label(first(effect["effectSizeMetric"]), vocab) as CellValue,
         point_estimate: round5Cell((effect["pointEstimate"] ?? null) as CellValue),
         ci_lower: round5Cell((effect["confidenceIntervalLower"] ?? null) as CellValue),
         ci_upper: round5Cell((effect["confidenceIntervalUpper"] ?? null) as CellValue),

--- a/src/services/export/generate.ts
+++ b/src/services/export/generate.ts
@@ -13,12 +13,14 @@ import {
   buildFindingRows,
   buildInvestigationRow,
   buildOutcomeRows,
+  ensureArray,
 } from "./buildRows.ts";
 import { buildReferenceRows, HPV_SHEET_NAME } from "./buildHpvRows.ts";
 import {
   extractBibliographic,
   extractLinkedDataEnhancement,
   getInvestigation,
+  isDict,
 } from "@/services/referenceUtils";
 import type {
   CodingInstitutionConfig,
@@ -130,7 +132,7 @@ export async function buildAllRows(
     const bibliographic = extractBibliographic(reference);
     const referenceId = String(reference.id);
     const inv: Investigation = getInvestigation(linked.content.data);
-    const findings = (Array.isArray(inv["hasFinding"]) ? inv["hasFinding"] : []) as Finding[];
+    const findings = ensureArray(inv["hasFinding"]).filter(isDict) as Finding[];
     const armIds = assignArmIds(findings);
     investigation.push(
       buildInvestigationRow(

--- a/src/services/export/types.ts
+++ b/src/services/export/types.ts
@@ -47,8 +47,8 @@ export interface InvestigationRow {
   publication_year: number | null;
   doi: string | null;
   openalex_id: string | null;
-  documentType: CellValue;
-  studyDesign: CellValue;
+  documentType: string;
+  studyDesign: string;
   vocabulary: string;
 }
 
@@ -62,10 +62,10 @@ export interface ArmRow {
   intervention_duration_supportingText: string | null;
   intervention_educationTheme: string;
   intervention_educationTheme_supportingText: string;
-  intervention_implementationFidelity: CellValue;
-  intervention_implementationFidelity_supportingText: string | null;
-  intervention_implementerType: CellValue;
-  intervention_implementerType_supportingText: string | null;
+  intervention_implementationFidelity: string;
+  intervention_implementationFidelity_supportingText: string;
+  intervention_implementerType: string;
+  intervention_implementerType_supportingText: string;
   sampleSize_value: CellValue;
   sampleSize_supportingText: string | null;
   attrition_value: CellValue;

--- a/tests/services/export/buildRows.test.ts
+++ b/tests/services/export/buildRows.test.ts
@@ -396,6 +396,39 @@ describe("buildFindingRows", () => {
     expect(outRows[0]!.intervention_n).toBe(100);
     expect(outRows[0]!.control_n).toBe(95);
   });
+
+  test("joins multiple sampleSize/attrition/cost values instead of dropping extras", () => {
+    const findings: Finding[] = [
+      {
+        sampleSize: [
+          { codedValue: { "@value": 100 }, supportingText: "arm A" },
+          { codedValue: { "@value": 120 }, supportingText: "arm B" },
+        ],
+        attrition: [{ codedValue: { "@value": 5 } }, { codedValue: { "@value": 8 } }],
+        cost: [{ codedValue: { "@value": 1000 } }, { codedValue: { "@value": 2000 } }],
+      },
+    ];
+    const rows = buildFindingRows("ref-1", findings, [1], VOCAB);
+    expect(rows[0]!.sampleSize_value).toBe("100; 120");
+    expect(rows[0]!.sampleSize_supportingText).toBe("arm A | arm B");
+    expect(rows[0]!.attrition_value).toBe("5; 8");
+    expect(rows[0]!.cost_value).toBe("1000; 2000");
+  });
+
+  test("resolves and joins sampleSize given as multiple blank-node refs", () => {
+    const findings: Finding[] = [
+      {
+        sampleSize: [
+          { "@id": "_:ss1", codedValue: { "@value": 100 } },
+          { "@id": "_:ss2", codedValue: { "@value": 120 } },
+        ],
+      },
+      // later finding reaches the same nodes by bare ref (the common real-data shape)
+      { sampleSize: ["_:ss1", "_:ss2"] },
+    ];
+    const rows = buildFindingRows("ref-1", findings, [1, 2], VOCAB);
+    expect(rows[1]!.sampleSize_value).toBe("100; 120");
+  });
 });
 
 describe("buildOutcomeRows", () => {
@@ -500,6 +533,23 @@ describe("buildOutcomeRows", () => {
     expect(armRows[0]!.intervention_duration_value).toBe(40);
     const outRows = buildOutcomeRows("ref-1", findings, [1], VOCAB);
     expect(outRows[0]!.effect_metric).toBe("Standardised Mean Difference");
+  });
+
+  test("joins multiple durations rather than dropping all but the first", () => {
+    const findings: Finding[] = [
+      {
+        evaluates: {
+          "@id": "_:i1",
+          duration: [
+            { codedValue: { "@value": 5 }, supportingText: "5 weeks" },
+            { codedValue: { "@value": 10 }, supportingText: "10 weeks" },
+          ],
+        },
+      },
+    ];
+    const rows = buildFindingRows("ref-1", findings, [1], VOCAB);
+    expect(rows[0]!.intervention_duration_value).toBe("5; 10");
+    expect(rows[0]!.intervention_duration_supportingText).toBe("5 weeks | 10 weeks");
   });
 
   test("tolerates single-dict hasArmData/hasEffectEstimate and array-wrapped hasOutcome (@set shape)", () => {

--- a/tests/services/export/buildRows.test.ts
+++ b/tests/services/export/buildRows.test.ts
@@ -93,6 +93,10 @@ const LABELS = new Map([
   ["https://vocab.esea.education/ImplementerScheme/Teacher", "Teacher"],
   ["https://vocab.esea.education/FidelityScheme/High", "High"],
   ["https://vocab.esea.education/EffectMetricScheme/SMD", "Standardised Mean Difference"],
+  ["https://vocab.esea.education/StudyDesignScheme/QED", "Quasi-Experimental Design"],
+  ["https://vocab.esea.education/ImplementerScheme/NGO", "NGO"],
+  ["https://vocab.esea.education/ImplementationFidelityScheme/High", "High Fidelity"],
+  ["https://vocab.esea.education/ImplementationFidelityScheme/Partial", "Partial Fidelity"],
 ]);
 
 const VOCAB: ConceptResolver = { prefixes: PREFIXES, labels: LABELS };
@@ -219,6 +223,29 @@ describe("buildInvestigationRow", () => {
     expect(buildInvestigationRow(ref, null, linked, {}, VOCAB, coding).source).toBe("EEF");
     expect(buildInvestigationRow(ref, null, linked, {}, VOCAB).source).toBeNull();
   });
+
+  test("joins multiple study designs; single document type unchanged", () => {
+    const linked = linkedEnh({});
+    const bib = bibEnh();
+    const ref = makeRef({ enhancements: [bib, linked] });
+    const row = buildInvestigationRow(
+      ref,
+      bib.content,
+      linked,
+      {
+        documentType: { codedValue: { "@id": "esea:DocumentTypeScheme/C00008" } },
+        studyDesign: [
+          { codedValue: { "@id": "esea:StudyDesignScheme/RCT" } },
+          { codedValue: { "@id": "esea:StudyDesignScheme/QED" } },
+        ],
+      },
+      VOCAB,
+    );
+    expect(row.documentType).toBe("Journal Article");
+    expect(row.studyDesign).toBe(
+      "Randomised Controlled Trial; Quasi-Experimental Design",
+    );
+  });
 });
 
 describe("buildFindingRows", () => {
@@ -291,6 +318,83 @@ describe("buildFindingRows", () => {
     expect(rows[0]!.intervention_educationTheme).toBe(
       "Literacy; esea:UnknownScheme/X",
     );
+  });
+
+  test("joins multiple implementer types and fidelity, with their supporting text", () => {
+    const findings: Finding[] = [
+      {
+        evaluates: {
+          "@id": "_:i1",
+          implementerType: [
+            { codedValue: { "@id": "esea:ImplementerScheme/Teacher" }, supportingText: "p. 1" },
+            { codedValue: { "@id": "esea:ImplementerScheme/NGO" }, supportingText: "p. 2" },
+          ],
+          implementationFidelity: [
+            { codedValue: { "@id": "esea:ImplementationFidelityScheme/High" }, supportingText: "p. 4" },
+            { codedValue: { "@id": "esea:ImplementationFidelityScheme/Partial" }, supportingText: "p. 5" },
+          ],
+        },
+      },
+    ];
+    const rows = buildFindingRows("ref-1", findings, [1], VOCAB);
+    expect(rows[0]!.intervention_implementerType).toBe("Teacher; NGO");
+    expect(rows[0]!.intervention_implementerType_supportingText).toBe("p. 1 | p. 2");
+    // implementationFidelity is a separate read/type, so pin it too.
+    expect(rows[0]!.intervention_implementationFidelity).toBe("High Fidelity; Partial Fidelity");
+    expect(rows[0]!.intervention_implementationFidelity_supportingText).toBe("p. 4 | p. 5");
+  });
+
+  test("tolerates a single dict (not array) for multi-valued concept and value columns", () => {
+    const findings: Finding[] = [
+      {
+        evaluates: {
+          "@id": "_:i1",
+          // no @set upstream → a single value compacts to a bare dict, not [dict]
+          educationTheme: { codedValue: { "@id": "esea:EducationThemeScheme/Literacy" } },
+        },
+        hasContext: {
+          "@id": "_:ctx",
+          country: { codedValue: { "@value": "USA" } },
+          educationLevel: {
+            codedValue: { "@id": "esea:EducationLevelScheme/Primary" },
+            supportingText: "p. 3",
+          },
+        },
+      },
+    ];
+    const rows = buildFindingRows("ref-1", findings, [1], VOCAB);
+    expect(rows[0]!.intervention_educationTheme).toBe("Literacy");
+    expect(rows[0]!.context_country).toBe("USA");
+    expect(rows[0]!.context_educationLevel).toBe("Primary");
+    expect(rows[0]!.context_educationLevel_supportingText).toBe("p. 3");
+  });
+
+  test("resolves structural refs wrapped in single-element arrays (@set shape)", () => {
+    const findings: Finding[] = [
+      {
+        evaluates: [{ "@id": "_:i1", name: "Wrapped intervention" }],
+        comparedTo: [{ "@id": "_:c1", name: "Control" }],
+        hasArmData: [
+          { forCondition: ["_:i1"], n: 100 },
+          { forCondition: ["_:c1"], n: 95 },
+        ],
+        hasEffectEstimate: [{ pointEstimate: 0.5 }],
+      },
+      // later finding reuses the array-defined intervention/control by bare ref
+      { evaluates: "_:i1", comparedTo: "_:c1" },
+    ];
+    // Drive arm IDs through the real assignArmIds path (not a hardcoded [1, 2]),
+    // which production calls before row-building and which depends on the same
+    // makeResolver/buildBlankNodeLookup/refId helpers this task changes. Both
+    // findings share one arm tuple, so the real flow dedupes to a single row.
+    const armIds = assignArmIds(findings);
+    expect(armIds).toEqual([1, 1]);
+    const armRows = buildFindingRows("ref-1", findings, armIds, VOCAB);
+    expect(armRows).toHaveLength(1);
+    expect(armRows[0]!.intervention_name).toBe("Wrapped intervention");
+    const outRows = buildOutcomeRows("ref-1", findings, armIds, VOCAB);
+    expect(outRows[0]!.intervention_n).toBe(100);
+    expect(outRows[0]!.control_n).toBe(95);
   });
 });
 
@@ -381,5 +485,37 @@ describe("buildOutcomeRows", () => {
     const rows = buildOutcomeRows("ref-1", findings, [1], VOCAB);
     expect(rows[0]!.intervention_n).toBe(50);
     expect(rows[0]!.control_n).toBe(48);
+  });
+
+  test("resolves effect metric and duration wrapped in an array (@set shape)", () => {
+    const findings: Finding[] = [
+      {
+        evaluates: { "@id": "_:i1", duration: [{ codedValue: { "@value": 40 } }] },
+        hasEffectEstimate: [
+          { effectSizeMetric: ["esea:EffectMetricScheme/SMD"], pointEstimate: 0.2 },
+        ],
+      },
+    ];
+    const armRows = buildFindingRows("ref-1", findings, [1], VOCAB);
+    expect(armRows[0]!.intervention_duration_value).toBe(40);
+    const outRows = buildOutcomeRows("ref-1", findings, [1], VOCAB);
+    expect(outRows[0]!.effect_metric).toBe("Standardised Mean Difference");
+  });
+
+  test("tolerates single-dict hasArmData/hasEffectEstimate and array-wrapped hasOutcome (@set shape)", () => {
+    const findings: Finding[] = [
+      {
+        evaluates: { "@id": "_:i1" },
+        comparedTo: { "@id": "_:c1" },
+        hasOutcome: [{ name: "Reading" }],            // array wrap of a singular block → first
+        hasArmData: { forCondition: "_:i1", n: 100 }, // single dict of a repeatable container → all
+        hasEffectEstimate: { pointEstimate: 0.5 },    // single dict of a repeatable container → all
+      },
+    ];
+    const rows = buildOutcomeRows("ref-1", findings, [1], VOCAB);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.outcome_name).toBe("Reading");
+    expect(rows[0]!.point_estimate).toBe(0.5);
+    expect(rows[0]!.intervention_n).toBe(100);
   });
 });

--- a/tests/services/export/generate.test.ts
+++ b/tests/services/export/generate.test.ts
@@ -161,6 +161,25 @@ describe("generateWorkbook", () => {
     expect(rows).toHaveLength(1);
     expect(rows[0]!["Reference ID"]).toBe("ref-1");
   });
+
+  test("tolerates a single-dict hasFinding (no @set) and still emits arm/outcome rows", async () => {
+    const ref = syntheticReference("ref-1");
+    // A 1-finding investigation compacts hasFinding to a bare dict (no @set).
+    const ld = ref.enhancements!.find(
+      (e) => e.content.enhancement_type === "linked_data",
+    )!;
+    const inv = (ld.content as unknown as {
+      data: { hasInvestigation: { hasFinding: unknown } };
+    }).data.hasInvestigation;
+    inv.hasFinding = (inv.hasFinding as unknown[])[0];
+
+    const wb = await generateWorkbook([ref], MINIMAL_VOCAB, { variant: "esea" });
+    const outcomes = XLSX.utils.sheet_to_json<Record<string, unknown>>(
+      wb.Sheets["Outcomes"]!,
+    );
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0]!.point_estimate).toBe(0.5);
+  });
 });
 
 describe("workbookToArrayBuffer", () => {


### PR DESCRIPTION
<!-- PR title: export: tolerate dict-or-array JSON-LD shapes in the investigation-hierarchy export -->

## Summary

JSON-LD compaction emits a bare object for a single-valued property and an array for two or more, unless the property is declared `"@container": "@set"` in the vocabulary context, in which case it is always an array. Because the context controls this per property (and a new vocabulary version can flip it), any object-property field in the investigation hierarchy can arrive at the export as either shape.

This is the export half of #178 (the UI side of VMR#34). A companion change to the investigation parser and the detail-page display covers the read/display side (#200); #178 closes when both land.

## What changed

A small `ensureArray` / `first` pair normalises every object-property read in the row builders, applied across four resilience classes:

- **Coded concept columns** (e.g. `studyDesign`, `documentType`, implementer type, fidelity) emit all values, `; `-joined, via `ensureArray`.
- **Scalar columns** (intervention duration, sample size, attrition, cost): emit all values via `collapseCodedValues` (a lone value kept as-is with numerics preserved; two or more `; `-joined), rather than dropping the extras. Sample size, attrition and cost are gathered through the blank-node resolver (`resolveMany`) first.
- **Structural refs** (blank-node lookups, resolver, `refId`) tolerate a single-element-array wrapper.
- **JSON-LD containers**: repeatable ones (`hasFinding`, `hasArmData`, `hasEffectEstimate`) process every entry via `ensureArray(...).filter(isDict)`; singular ones (`hasOutcome`) take `first`. `hasFinding` is also normalised at the workbook entry point.

The coded concept columns join all values with `; ` so multiple codes are preserved; intervention duration likewise keeps all values (a single value kept as-is, multiple `; `-joined); the genuinely single-valued blocks (outcome, effect metric) take the first value. This is serialization resilience, not a new cardinality model: the export tolerates whichever shape each field arrives in, independent of how the data is serialized.

## Validation performed

- Typecheck clean (`tsc --noEmit`); 906 tests pass (`vitest run`), including new shape-tolerance and multi-value cases through the public `buildFindingRows` / `generateWorkbook` / `buildAllRows` contract.
- Real-data validation over the local ingest (ESEA + EEF only): ran the export over all 3,620 coded references loaded in a local repository instance (the complete local set, past the export endpoint's 10,000-row cap), through the real `buildAllRows` / `generateWorkbook` resolving against the ESEA v1.1 vocabulary. Against this data the `studyDesign` cell census reconciles exactly with the database: 3,620 rows built (none skipped), 4 with no study design, 3,162 single bare dict (one label), 454 array (58 genuine multi-distinct that join to distinct labels e.g. "Randomised Controlled Trial; Quasi-experimental study", plus 396 repeated-code arrays joined as-is). Zero `studyDesign` garbage cells; single dicts and arrays both materialise correctly through the SheetJS write path.
- Multi-value scan (FYI, scoped to the locally-ingested ESEA + EEF data; not a claim about production or future ingests): in this local set (3,620 references / 7,240 investigation enhancements) no record carries a multi-valued `duration`, `sampleSize`, `attrition`, or `cost`, and `hasOutcome` / `effectSizeMetric` are singular throughout; the fields that do carry multiples here (`educationTheme`, `studyDesign`, `setting`) are all on the join path. So within this data the duration change is a no-op; its value is forward-looking resilience for shapes the export could still receive.
- Earlier staging regression: a phonics search (21 records) exported through the full in-browser pipeline (server job, blob JSONL, client-side build); three sheets, switched concept columns resolve to prefLabels, no console errors.
- Pre-existing behaviour, not introduced here: 14 `ci_lower`/`ci_upper` cells render `NaN` because the source data carries the literal string `"NaN"` and `round5Cell` passes non-numeric values through unchanged. Byte-identical to `main` (same expression, same helper).
