### PR TITLE
parser/display: tolerate dict-or-array shapes, preserve multi-values, and add study design

### DIFF
--- a/src/components/finding/ContextDetails.tsx
+++ b/src/components/finding/ContextDetails.tsx
@@ -18,6 +18,7 @@ function collectEvidence(context: ContextData) {
     ...evidenceFrom("Setting", context.settings),
     ...evidenceFrom("Participants", context.participants),
     ...evidenceFrom("Country", context.countries),
+    ...evidenceFrom("Region", context.countryLevel1s),
   ];
 }
 
@@ -56,10 +57,10 @@ export function ContextDetails({
             <span>{context.countries.map((c) => countryName(c.value)).join(", ")}</span>
           </div>
         )}
-        {context.countryLevel1 && (
+        {context.countryLevel1s && context.countryLevel1s.length > 0 && (
           <div class="lg-field">
             <span class="lg-label">Region</span>
-            <span>{context.countryLevel1.value}</span>
+            <span>{context.countryLevel1s.map((r) => r.value).join(", ")}</span>
           </div>
         )}
       </div>

--- a/src/components/finding/FindingCard.tsx
+++ b/src/components/finding/FindingCard.tsx
@@ -44,10 +44,10 @@ interface FindingCardProps {
 
 function hasSampleData(finding: FindingData): boolean {
   return Boolean(
-    finding.sampleSize ||
-      finding.attrition ||
-      finding.cost ||
-      finding.groupDifferences ||
+    finding.sampleSizes?.length ||
+      finding.attritions?.length ||
+      finding.costs?.length ||
+      finding.groupDifferences?.length ||
       (finding.sampleFeatures && finding.sampleFeatures.length > 0),
   );
 }

--- a/src/components/finding/InterventionDetails.tsx
+++ b/src/components/finding/InterventionDetails.tsx
@@ -42,13 +42,13 @@ function collectEvidence(intervention: InterventionData): SourceEvidenceEntry[] 
       "Implementation fidelity",
       intervention.implementationFidelities,
     ),
-    ...evidenceFrom("Implementation name", intervention.implementationName),
+    ...evidenceFrom("Implementation name", intervention.implementationNames),
     ...evidenceFrom(
       "Implementation description",
       intervention.implementationDescriptions,
     ),
-    ...evidenceFrom("Funder", intervention.funderIntervention),
-    ...evidenceFrom("Duration", intervention.duration),
+    ...evidenceFrom("Funder", intervention.funderInterventions),
+    ...evidenceFrom("Duration", intervention.durations),
   ];
 }
 
@@ -110,9 +110,9 @@ export function InterventionDetails({
         </div>
       )}
 
-      {intervention.implementationName && (
+      {intervention.implementationNames && intervention.implementationNames.length > 0 && (
         <LabeledField label="Implementation name">
-          {intervention.implementationName.value}
+          {intervention.implementationNames.map((n) => n.value).join("; ")}
         </LabeledField>
       )}
 
@@ -122,15 +122,15 @@ export function InterventionDetails({
         </LabeledField>
       ))}
 
-      {intervention.funderIntervention && (
+      {intervention.funderInterventions && intervention.funderInterventions.length > 0 && (
         <LabeledField label="Funder">
-          {intervention.funderIntervention.value}
+          {intervention.funderInterventions.map((f) => f.value).join("; ")}
         </LabeledField>
       )}
 
-      {intervention.duration && (
+      {intervention.durations && intervention.durations.length > 0 && (
         <LabeledField label="Duration">
-          {intervention.duration.value}
+          {intervention.durations.map((d) => d.value).join("; ")}
         </LabeledField>
       )}
 

--- a/src/components/finding/InterventionDetails.tsx
+++ b/src/components/finding/InterventionDetails.tsx
@@ -4,9 +4,13 @@ import {
   type SourceEvidenceEntry,
 } from "./SourceEvidenceToggle";
 import { LabeledField } from "../common/LabeledField";
-import { conceptsToTags, toHierarchicalTag } from "@/services/conceptLabels";
+import { conceptsToTags } from "@/services/conceptLabels";
 import { evidenceFrom } from "@/services/sourceEvidence";
-import type { InterventionData } from "@/types/investigation";
+import type {
+  CodedAnnotation,
+  InterventionData,
+  ResolvedConcept,
+} from "@/types/investigation";
 import "../common/LabeledField.css";
 
 interface InterventionDetailsProps {
@@ -16,24 +20,33 @@ interface InterventionDetailsProps {
   definitions?: Map<string, string>;
 }
 
-function themeEvidence(intervention: InterventionData): SourceEvidenceEntry[] {
-  const themes = intervention.educationThemes ?? [];
-  const multiple = themes.length > 1;
-  return themes
-    .filter((t) => t.supportingText)
-    .map((t) => ({
-      label: multiple ? `Theme: ${t.value.label ?? t.value.uri}` : "Theme",
-      text: t.supportingText ?? "",
+function conceptEvidence(
+  label: string,
+  annotations: CodedAnnotation<ResolvedConcept>[] | undefined,
+): SourceEvidenceEntry[] {
+  const all = annotations ?? [];
+  const multiple = all.length > 1;
+  return all
+    .filter((a) => a.supportingText)
+    .map((a) => ({
+      label: multiple ? `${label}: ${a.value.label ?? a.value.uri}` : label,
+      text: a.supportingText ?? "",
     }));
 }
 
 function collectEvidence(intervention: InterventionData): SourceEvidenceEntry[] {
   return [
-    ...themeEvidence(intervention),
-    ...evidenceFrom("Implementer", intervention.implementerType),
-    ...evidenceFrom("Implementation fidelity", intervention.implementationFidelity),
+    ...conceptEvidence("Theme", intervention.educationThemes),
+    ...conceptEvidence("Implementer", intervention.implementerTypes),
+    ...conceptEvidence(
+      "Implementation fidelity",
+      intervention.implementationFidelities,
+    ),
     ...evidenceFrom("Implementation name", intervention.implementationName),
-    ...evidenceFrom("Implementation description", intervention.implementationDescriptions),
+    ...evidenceFrom(
+      "Implementation description",
+      intervention.implementationDescriptions,
+    ),
     ...evidenceFrom("Funder", intervention.funderIntervention),
     ...evidenceFrom("Duration", intervention.duration),
   ];
@@ -47,6 +60,18 @@ export function InterventionDetails({
 }: InterventionDetailsProps) {
   const themeTags = conceptsToTags(
     intervention.educationThemes,
+    labels,
+    broader,
+    definitions,
+  );
+  const implementerTags = conceptsToTags(
+    intervention.implementerTypes,
+    labels,
+    broader,
+    definitions,
+  );
+  const fidelityTags = conceptsToTags(
+    intervention.implementationFidelities,
     labels,
     broader,
     definitions,
@@ -73,35 +98,15 @@ export function InterventionDetails({
         </>
       )}
 
-      {intervention.implementerType && (
+      {implementerTags.length > 0 && (
         <div class="labeled-field">
-          <TagGroup
-            label="Implementer"
-            tags={[
-              toHierarchicalTag(
-                intervention.implementerType.value,
-                labels,
-                broader,
-                definitions,
-              ),
-            ]}
-          />
+          <TagGroup label="Implementer" tags={implementerTags} />
         </div>
       )}
 
-      {intervention.implementationFidelity && (
+      {fidelityTags.length > 0 && (
         <div class="labeled-field">
-          <TagGroup
-            label="Implementation fidelity"
-            tags={[
-              toHierarchicalTag(
-                intervention.implementationFidelity.value,
-                labels,
-                broader,
-                definitions,
-              ),
-            ]}
-          />
+          <TagGroup label="Implementation fidelity" tags={fidelityTags} />
         </div>
       )}
 

--- a/src/components/finding/SampleDetails.tsx
+++ b/src/components/finding/SampleDetails.tsx
@@ -6,7 +6,7 @@ import type { FindingData } from "@/types/investigation";
 
 type SampleFields = Pick<
   FindingData,
-  "sampleSize" | "attrition" | "cost" | "groupDifferences" | "sampleFeatures"
+  "sampleSizes" | "attritions" | "costs" | "groupDifferences" | "sampleFeatures"
 >;
 
 interface SampleDetailsProps {
@@ -18,9 +18,9 @@ interface SampleDetailsProps {
 
 function collectEvidence(finding: SampleFields) {
   return [
-    ...evidenceFrom("Size", finding.sampleSize),
-    ...evidenceFrom("Attrition", finding.attrition),
-    ...evidenceFrom("Cost", finding.cost),
+    ...evidenceFrom("Size", finding.sampleSizes),
+    ...evidenceFrom("Attrition", finding.attritions),
+    ...evidenceFrom("Cost", finding.costs),
     ...evidenceFrom("Group differences", finding.groupDifferences),
     ...evidenceFrom("Features", finding.sampleFeatures),
   ];
@@ -41,45 +41,41 @@ export function SampleDetails({
   const evidenceEntries = collectEvidence(finding);
 
   const hasAny =
-    finding.sampleSize ||
-    finding.attrition ||
-    finding.cost ||
-    finding.groupDifferences ||
+    finding.sampleSizes?.length ||
+    finding.attritions?.length ||
+    finding.costs?.length ||
+    finding.groupDifferences?.length ||
     featureTags.length > 0;
   if (!hasAny) return null;
 
   return (
     <>
       <div class="sample-details__grid lg-field-grid">
-        {finding.sampleSize && (
+        {finding.sampleSizes && finding.sampleSizes.length > 0 && (
           <div class="sample-details__field lg-field">
             <span class="sample-details__field-label lg-label">Size</span>
-            <span>
-              {finding.sampleSize.value}
-            </span>
+            <span>{finding.sampleSizes.map((s) => s.value).join("; ")}</span>
           </div>
         )}
         {featureTags.length > 0 && (
           <TagGroup label="Features" tags={featureTags} />
         )}
-        {finding.attrition && (
+        {finding.attritions && finding.attritions.length > 0 && (
           <div class="sample-details__field lg-field">
             <span class="sample-details__field-label lg-label">Attrition</span>
-            <span>
-              {finding.attrition.value}
-            </span>
+            <span>{finding.attritions.map((a) => a.value).join("; ")}</span>
           </div>
         )}
-        {finding.cost && (
+        {finding.costs && finding.costs.length > 0 && (
           <div class="sample-details__field lg-field">
             <span class="sample-details__field-label lg-label">Cost</span>
-            <span>{finding.cost.value}</span>
+            <span>{finding.costs.map((c) => c.value).join("; ")}</span>
           </div>
         )}
-        {finding.groupDifferences && (
+        {finding.groupDifferences && finding.groupDifferences.length > 0 && (
           <div class="sample-details__field sample-details__field--wide lg-field">
             <span class="sample-details__field-label lg-label">Group differences</span>
-            <span>{finding.groupDifferences.value}</span>
+            <span>{finding.groupDifferences.map((g) => g.value).join("; ")}</span>
           </div>
         )}
       </div>

--- a/src/components/investigation/InvestigationCard.css
+++ b/src/components/investigation/InvestigationCard.css
@@ -84,6 +84,10 @@
   margin: var(--spacing-md) 0;
 }
 
+.investigation-card .tag-group + .tag-group {
+  margin-top: var(--spacing-sm);
+}
+
 .investigation-card__vocab-error {
   font-size: var(--font-size-sm);
   color: var(--color-text-tertiary);

--- a/src/components/investigation/InvestigationCard.tsx
+++ b/src/components/investigation/InvestigationCard.tsx
@@ -18,7 +18,8 @@ interface InvestigationCardProps {
   doi: string | null;
   abstract?: AbstractContentEnhancement | null;
   publicationYear: number | null;
-  documentType?: CodedAnnotation<ResolvedConcept>;
+  documentTypes: CodedAnnotation<ResolvedConcept>[];
+  studyDesigns: CodedAnnotation<ResolvedConcept>[];
   codingInstitution?: string | null;
   isRetracted: boolean;
   hasInvestigation: boolean;
@@ -65,7 +66,8 @@ export function InvestigationCard({
   doi,
   abstract = null,
   publicationYear,
-  documentType,
+  documentTypes,
+  studyDesigns,
   codingInstitution,
   isRetracted,
   hasInvestigation,
@@ -73,7 +75,10 @@ export function InvestigationCard({
 }: InvestigationCardProps) {
   const venueText = formatVenue(venue, pagination);
   const hasInvestigationContent =
-    documentType || vocabUnavailable || codingInstitution;
+    documentTypes.length > 0 ||
+    studyDesigns.length > 0 ||
+    vocabUnavailable ||
+    codingInstitution;
 
   return (
     <>
@@ -123,10 +128,16 @@ export function InvestigationCard({
                 Vocabulary unavailable — some labels could not be resolved.
               </p>
             )}
-            {documentType && (
+            {documentTypes.length > 0 && (
               <TagGroup
                 label="Doc Type"
-                tags={[documentType.value.label ?? documentType.value.uri]}
+                tags={documentTypes.map((d) => d.value.label ?? d.value.uri)}
+              />
+            )}
+            {studyDesigns.length > 0 && (
+              <TagGroup
+                label="Study Design"
+                tags={studyDesigns.map((d) => d.value.label ?? d.value.uri)}
               />
             )}
             {codingInstitution && (

--- a/src/components/investigation/InvestigationCard.tsx
+++ b/src/components/investigation/InvestigationCard.tsx
@@ -58,6 +58,17 @@ function formatAuthors(
   return year ? `${names} (${year})` : names;
 }
 
+function dedupeByUri(
+  annotations: CodedAnnotation<ResolvedConcept>[],
+): CodedAnnotation<ResolvedConcept>[] {
+  const seen = new Set<string>();
+  return annotations.filter((a) => {
+    if (seen.has(a.value.uri)) return false;
+    seen.add(a.value.uri);
+    return true;
+  });
+}
+
 export function InvestigationCard({
   title,
   authors,
@@ -74,9 +85,15 @@ export function InvestigationCard({
   vocabUnavailable,
 }: InvestigationCardProps) {
   const venueText = formatVenue(venue, pagination);
+  const docTypeTags = dedupeByUri(documentTypes).map(
+    (d) => d.value.label ?? d.value.uri,
+  );
+  const studyDesignTags = dedupeByUri(studyDesigns).map(
+    (d) => d.value.label ?? d.value.uri,
+  );
   const hasInvestigationContent =
-    documentTypes.length > 0 ||
-    studyDesigns.length > 0 ||
+    docTypeTags.length > 0 ||
+    studyDesignTags.length > 0 ||
     vocabUnavailable ||
     codingInstitution;
 
@@ -128,17 +145,11 @@ export function InvestigationCard({
                 Vocabulary unavailable — some labels could not be resolved.
               </p>
             )}
-            {documentTypes.length > 0 && (
-              <TagGroup
-                label="Doc Type"
-                tags={documentTypes.map((d) => d.value.label ?? d.value.uri)}
-              />
+            {docTypeTags.length > 0 && (
+              <TagGroup label="Doc Type" tags={docTypeTags} />
             )}
-            {studyDesigns.length > 0 && (
-              <TagGroup
-                label="Study Design"
-                tags={studyDesigns.map((d) => d.value.label ?? d.value.uri)}
-              />
+            {studyDesignTags.length > 0 && (
+              <TagGroup label="Study Design" tags={studyDesignTags} />
             )}
             {codingInstitution && (
               <p

--- a/src/components/search/ResultRow.tsx
+++ b/src/components/search/ResultRow.tsx
@@ -44,9 +44,9 @@ function formatAuthors(authors: { display_name: string }[]): string {
   return `${head}, +${authors.length - MAX_AUTHORS_SHOWN} more`;
 }
 
-// Document type first, then per-finding context/intervention/outcome concepts
-// and sample features. De-duped by URI; insertion order preserved so the
-// document type pill leads.
+// Investigation-level concepts (document type, study design) first, then
+// per-finding context/intervention/outcome concepts and sample features.
+// De-duped by URI; insertion order preserved so investigation pills lead.
 function aggregatePillConcepts(
   inv: InvestigationData,
 ): CodedAnnotation<ResolvedConcept>[] {
@@ -61,7 +61,8 @@ function aggregatePillConcepts(
   };
   const addAll = (xs?: CodedAnnotation<ResolvedConcept>[]) => xs?.forEach(add);
 
-  if (inv.documentType) add(inv.documentType);
+  addAll(inv.documentTypes);
+  addAll(inv.studyDesigns);
   for (const f of inv.findings) {
     addAll(f.context?.educationLevels);
     addAll(f.context?.settings);

--- a/src/pages/RecordDetailPage.tsx
+++ b/src/pages/RecordDetailPage.tsx
@@ -135,7 +135,8 @@ export function RecordDetailPage({ id }: RecordDetailPageProps) {
           doi={doi}
           abstract={abstract}
           publicationYear={bibliographic?.publication_year ?? null}
-          documentType={investigation?.documentType}
+          documentTypes={investigation?.documentTypes ?? []}
+          studyDesigns={investigation?.studyDesigns ?? []}
           codingInstitution={codingInstitution}
           isRetracted={isRetracted}
           hasInvestigation={hasLinkedData}

--- a/src/services/export/buildRows.ts
+++ b/src/services/export/buildRows.ts
@@ -206,6 +206,18 @@ function joinCodedValues(annotations: unknown): string {
 }
 
 /**
+ * Scalar `@value` cell: a lone value kept typed (numeric stays numeric),
+ * two or more `; `-joined so an extra coded value is never dropped.
+ */
+function collapseCodedValues(annotations: unknown): CellValue {
+  const values = ensureArray(annotations)
+    .map((a) => codedValue(a))
+    .filter((v): v is string | number | boolean => v != null);
+  if (values.length <= 1) return values[0] ?? null;
+  return values.map((v) => String(v)).join("; ");
+}
+
+/**
  * Concatenate the `supportingText` field of each annotation with ` | `
  * between entries.
  */
@@ -375,14 +387,15 @@ export function buildFindingRows(
   vocab: ConceptResolver,
 ): ArmRow[] {
   const resolve = makeResolver(buildBlankNodeLookup(findings));
+  const resolveMany = (value: unknown): PlainRecord[] => ensureArray(value).map(resolve);
   const rows: ArmRow[] = [];
   for (let i = 0; i < findings.length; i++) {
     const finding = findings[i]!;
     const armId = armIds[i]!;
     const ctx = resolve(finding["hasContext"]);
-    const sampleSize = resolve(finding["sampleSize"]);
-    const attrition = resolve(finding["attrition"]);
-    const cost = resolve(finding["cost"]);
+    const sampleSizes = resolveMany(finding["sampleSize"]);
+    const attritions = resolveMany(finding["attrition"]);
+    const costs = resolveMany(finding["cost"]);
     const intervention = resolve(finding["evaluates"]);
     const control = resolve(finding["comparedTo"]);
     rows.push({
@@ -391,19 +404,19 @@ export function buildFindingRows(
       intervention_name: typeof intervention["name"] === "string" ? (intervention["name"] as string) : null,
       intervention_description: flattenDescription(intervention["description"]),
       control_description: flattenDescription(control["description"]),
-      intervention_duration_value: codedValue(first(intervention["duration"])),
-      intervention_duration_supportingText: supportingText(first(intervention["duration"])),
+      intervention_duration_value: collapseCodedValues(intervention["duration"]),
+      intervention_duration_supportingText: joinSupportingTexts(intervention["duration"]),
       intervention_educationTheme: joinCodedIds(intervention["educationTheme"], vocab),
       intervention_educationTheme_supportingText: joinSupportingTexts(intervention["educationTheme"]),
       intervention_implementationFidelity: joinCodedIds(ensureArray(intervention["implementationFidelity"]), vocab),
       intervention_implementationFidelity_supportingText: joinSupportingTexts(ensureArray(intervention["implementationFidelity"])),
       intervention_implementerType: joinCodedIds(ensureArray(intervention["implementerType"]), vocab),
       intervention_implementerType_supportingText: joinSupportingTexts(ensureArray(intervention["implementerType"])),
-      sampleSize_value: codedValue(sampleSize),
-      sampleSize_supportingText: supportingText(sampleSize),
-      attrition_value: codedValue(attrition),
-      attrition_supportingText: supportingText(attrition),
-      cost_value: codedValue(cost),
+      sampleSize_value: collapseCodedValues(sampleSizes),
+      sampleSize_supportingText: joinSupportingTexts(sampleSizes),
+      attrition_value: collapseCodedValues(attritions),
+      attrition_supportingText: joinSupportingTexts(attritions),
+      cost_value: collapseCodedValues(costs),
       context_country: joinCodedValues(ctx["country"]),
       context_countryLevel1: joinCodedValues(ctx["countryLevel1"]),
       context_educationLevel: joinCodedIds(ctx["educationLevel"], vocab),

--- a/src/services/export/buildRows.ts
+++ b/src/services/export/buildRows.ts
@@ -106,6 +106,17 @@ const ARM_KEY_FIELDS = [
 
 type PlainRecord = Record<string, unknown>;
 
+/** Normalise a JSON-LD value to a list: absent → [], array → itself, single → [value]. */
+export function ensureArray(v: unknown): unknown[] {
+  if (v === undefined || v === null) return [];
+  return Array.isArray(v) ? v : [v];
+}
+
+/** Take the first element of an array (any type), else the value itself. */
+function first(v: unknown): unknown {
+  return Array.isArray(v) ? v[0] : v;
+}
+
 /**
  * Round numeric cells to 5 decimal places.
  * Pass-through for non-finite numbers and non-numeric values.
@@ -176,8 +187,7 @@ function supportingText(annotation: unknown): string | null {
  * delimiter-separated string.
  */
 function joinCodedIds(annotations: unknown, vocab: ConceptResolver): string {
-  const list = Array.isArray(annotations) ? annotations : [];
-  return list
+  return ensureArray(annotations)
     .map((a) => codedId(a, vocab))
     .filter((v): v is string | number | boolean => v != null && v !== "")
     .join("; ");
@@ -188,8 +198,7 @@ function joinCodedIds(annotations: unknown, vocab: ConceptResolver): string {
  * stringifying numerics. Nullish entries are dropped.
  */
 function joinCodedValues(annotations: unknown): string {
-  const list = Array.isArray(annotations) ? annotations : [];
-  return list
+  return ensureArray(annotations)
     .map((a) => codedValue(a))
     .filter((v): v is string | number | boolean => v != null)
     .map((v) => String(v))
@@ -201,8 +210,7 @@ function joinCodedValues(annotations: unknown): string {
  * between entries.
  */
 function joinSupportingTexts(annotations: unknown): string {
-  const list = Array.isArray(annotations) ? annotations : [];
-  return list
+  return ensureArray(annotations)
     .map((a) => supportingText(a))
     .filter((v): v is string => v != null && v !== "")
     .join(" | ");
@@ -213,11 +221,12 @@ function joinSupportingTexts(annotations: unknown): string {
  * dict (`{"@id": "_:foo", ...}`) or a bare string ref (`"_:foo"`).
  */
 function refId(value: unknown): string | null {
-  if (isDict(value)) {
-    const id = value["@id"];
+  const v = first(value);
+  if (isDict(v)) {
+    const id = v["@id"];
     return typeof id === "string" ? id : null;
   }
-  if (typeof value === "string") return value;
+  if (typeof v === "string") return v;
   return null;
 }
 
@@ -231,10 +240,11 @@ function buildBlankNodeLookup(findings: Finding[]): Map<string, PlainRecord> {
   const lookup = new Map<string, PlainRecord>();
   for (const finding of findings) {
     for (const key of ["comparedTo", "evaluates", "hasContext", "sampleSize", "attrition", "cost"] as const) {
-      const value = finding[key];
-      if (isDict(value)) {
-        const id = value["@id"];
-        if (typeof id === "string") lookup.set(id, value);
+      for (const value of ensureArray(finding[key])) {
+        if (isDict(value)) {
+          const id = value["@id"];
+          if (typeof id === "string") lookup.set(id, value as PlainRecord);
+        }
       }
     }
   }
@@ -251,8 +261,9 @@ type Resolver = (value: unknown) => PlainRecord;
  */
 function makeResolver(lookup: Map<string, PlainRecord>): Resolver {
   return (value) => {
-    if (typeof value === "string") return lookup.get(value) ?? {};
-    if (isDict(value)) return value;
+    const v = first(value);
+    if (typeof v === "string") return lookup.get(v) ?? {};
+    if (isDict(v)) return v;
     return {};
   };
 }
@@ -332,7 +343,6 @@ export function buildInvestigationRow(
   vocab: ConceptResolver,
   codingInstitution?: CodingInstitutionConfig,
 ): InvestigationRow {
-  const docType = investigation.documentType ?? {};
   const authors = bibliographic?.authorship
     ? bibliographic.authorship.map((a) => a.display_name).join("; ")
     : null;
@@ -344,8 +354,8 @@ export function buildInvestigationRow(
     publication_year: bibliographic?.publication_year ?? null,
     doi: extractDoi(reference.identifiers ?? null),
     openalex_id: extractOpenAlexId(reference.identifiers ?? null),
-    documentType: codedId(docType, vocab),
-    studyDesign: codedId(investigation.studyDesign ?? {}, vocab),
+    documentType: joinCodedIds(ensureArray(investigation.documentType), vocab),
+    studyDesign: joinCodedIds(ensureArray(investigation.studyDesign), vocab),
     vocabulary: linked.content.vocabulary_uri,
   };
 }
@@ -381,14 +391,14 @@ export function buildFindingRows(
       intervention_name: typeof intervention["name"] === "string" ? (intervention["name"] as string) : null,
       intervention_description: flattenDescription(intervention["description"]),
       control_description: flattenDescription(control["description"]),
-      intervention_duration_value: codedValue(intervention["duration"]),
-      intervention_duration_supportingText: supportingText(intervention["duration"]),
+      intervention_duration_value: codedValue(first(intervention["duration"])),
+      intervention_duration_supportingText: supportingText(first(intervention["duration"])),
       intervention_educationTheme: joinCodedIds(intervention["educationTheme"], vocab),
       intervention_educationTheme_supportingText: joinSupportingTexts(intervention["educationTheme"]),
-      intervention_implementationFidelity: codedId(intervention["implementationFidelity"], vocab),
-      intervention_implementationFidelity_supportingText: supportingText(intervention["implementationFidelity"]),
-      intervention_implementerType: codedId(intervention["implementerType"], vocab),
-      intervention_implementerType_supportingText: supportingText(intervention["implementerType"]),
+      intervention_implementationFidelity: joinCodedIds(ensureArray(intervention["implementationFidelity"]), vocab),
+      intervention_implementationFidelity_supportingText: joinSupportingTexts(ensureArray(intervention["implementationFidelity"])),
+      intervention_implementerType: joinCodedIds(ensureArray(intervention["implementerType"]), vocab),
+      intervention_implementerType_supportingText: joinSupportingTexts(ensureArray(intervention["implementerType"])),
       sampleSize_value: codedValue(sampleSize),
       sampleSize_supportingText: supportingText(sampleSize),
       attrition_value: codedValue(attrition),
@@ -425,11 +435,12 @@ export function buildOutcomeRows(
   for (let i = 0; i < findings.length; i++) {
     const finding = findings[i]!;
     const armId = armIds[i]!;
-    const outcomeBlock = isDict(finding["hasOutcome"]) ? (finding["hasOutcome"] as PlainRecord) : {};
+    const outcomeRaw = first(finding["hasOutcome"]);
+    const outcomeBlock = isDict(outcomeRaw) ? (outcomeRaw as PlainRecord) : {};
     const outcomeConcepts = joinCodedIds(outcomeBlock["outcome"], vocab);
     const outcomeConceptsSupporting = joinSupportingTexts(outcomeBlock["outcome"]);
 
-    const armData = Array.isArray(finding["hasArmData"]) ? (finding["hasArmData"] as PlainRecord[]) : [];
+    const armData = ensureArray(finding["hasArmData"]).filter(isDict) as PlainRecord[];
     const armLookup = new Map<string, PlainRecord>();
     for (const arm of armData) {
       const id = refId(arm["forCondition"]);
@@ -438,9 +449,9 @@ export function buildOutcomeRows(
     const interventionArm = armLookup.get(refId(finding["evaluates"]) ?? "") ?? {};
     const controlArm = armLookup.get(refId(finding["comparedTo"]) ?? "") ?? {};
 
-    const effectEstimates = Array.isArray(finding["hasEffectEstimate"])
-      ? (finding["hasEffectEstimate"] as PlainRecord[])
-      : [{}];
+    const estimates = ensureArray(finding["hasEffectEstimate"]).filter(isDict) as PlainRecord[];
+    // findings with no effect estimate still emit one row (outcome/arm data preserved)
+    const effectEstimates = estimates.length ? estimates : [{}];
     for (const effect of effectEstimates) {
       const baselineAdjusted = effect["baselineAdjusted"];
       rows.push({
@@ -450,7 +461,7 @@ export function buildOutcomeRows(
         outcome_description: typeof outcomeBlock["description"] === "string" ? (outcomeBlock["description"] as string) : null,
         outcome_concepts: outcomeConcepts,
         outcome_concepts_supportingText: outcomeConceptsSupporting,
-        effect_metric: label(effect["effectSizeMetric"], vocab) as CellValue,
+        effect_metric: label(first(effect["effectSizeMetric"]), vocab) as CellValue,
         point_estimate: round5Cell((effect["pointEstimate"] ?? null) as CellValue),
         ci_lower: round5Cell((effect["confidenceIntervalLower"] ?? null) as CellValue),
         ci_upper: round5Cell((effect["confidenceIntervalUpper"] ?? null) as CellValue),

--- a/src/services/export/generate.ts
+++ b/src/services/export/generate.ts
@@ -13,12 +13,14 @@ import {
   buildFindingRows,
   buildInvestigationRow,
   buildOutcomeRows,
+  ensureArray,
 } from "./buildRows.ts";
 import { buildReferenceRows, HPV_SHEET_NAME } from "./buildHpvRows.ts";
 import {
   extractBibliographic,
   extractLinkedDataEnhancement,
   getInvestigation,
+  isDict,
 } from "@/services/referenceUtils";
 import type {
   CodingInstitutionConfig,
@@ -130,7 +132,7 @@ export async function buildAllRows(
     const bibliographic = extractBibliographic(reference);
     const referenceId = String(reference.id);
     const inv: Investigation = getInvestigation(linked.content.data);
-    const findings = (Array.isArray(inv["hasFinding"]) ? inv["hasFinding"] : []) as Finding[];
+    const findings = ensureArray(inv["hasFinding"]).filter(isDict) as Finding[];
     const armIds = assignArmIds(findings);
     investigation.push(
       buildInvestigationRow(

--- a/src/services/export/types.ts
+++ b/src/services/export/types.ts
@@ -47,8 +47,8 @@ export interface InvestigationRow {
   publication_year: number | null;
   doi: string | null;
   openalex_id: string | null;
-  documentType: CellValue;
-  studyDesign: CellValue;
+  documentType: string;
+  studyDesign: string;
   vocabulary: string;
 }
 
@@ -62,10 +62,10 @@ export interface ArmRow {
   intervention_duration_supportingText: string | null;
   intervention_educationTheme: string;
   intervention_educationTheme_supportingText: string;
-  intervention_implementationFidelity: CellValue;
-  intervention_implementationFidelity_supportingText: string | null;
-  intervention_implementerType: CellValue;
-  intervention_implementerType_supportingText: string | null;
+  intervention_implementationFidelity: string;
+  intervention_implementationFidelity_supportingText: string;
+  intervention_implementerType: string;
+  intervention_implementerType_supportingText: string;
   sampleSize_value: CellValue;
   sampleSize_supportingText: string | null;
   attrition_value: CellValue;

--- a/src/services/investigationParser.ts
+++ b/src/services/investigationParser.ts
@@ -1,5 +1,5 @@
 import { expandCompactUri } from "./vocabulary/contextService";
-import { getInvestigation, isDict } from "./referenceUtils";
+import { ensureArray, getInvestigation, isDict } from "./referenceUtils";
 import type {
   InvestigationData,
   CodedAnnotation,
@@ -18,11 +18,6 @@ import type {
 type Dict = Record<string, unknown>;
 
 const SKIP_STATUSES = ["notReported", "notApplicable"];
-
-function ensureArray(v: unknown): unknown[] {
-  if (v === undefined || v === null) return [];
-  return Array.isArray(v) ? v : [v];
-}
 
 function shouldSkip(node: Dict, prefixes: Map<string, string>): boolean {
   const status = node["status"];

--- a/src/services/investigationParser.ts
+++ b/src/services/investigationParser.ts
@@ -258,8 +258,7 @@ export function parseAppliedConcepts(
   prefixes: Map<string, string>,
   labels: Map<string, string>,
 ): ResolvedConcept[] {
-  const raw = investigation["hasAppliedConcept"];
-  const items = Array.isArray(raw) ? raw : [];
+  const items = ensureArray(investigation["hasAppliedConcept"]);
   return items
     .map((v) => resolveConceptRef(v, prefixes, labels))
     .filter((c): c is ResolvedConcept => c !== undefined);

--- a/src/services/investigationParser.ts
+++ b/src/services/investigationParser.ts
@@ -180,11 +180,15 @@ function parseIntervention(
     duration: parseOptional(node, "duration", (n) =>
       resolveNumericAnnotation(n, prefixes),
     ),
-    implementerType: parseOptional(node, "implementerType", (n) =>
-      resolveConceptAnnotation(n, prefixes, labels),
+    implementerTypes: resolveConceptAnnotations(
+      node["implementerType"],
+      prefixes,
+      labels,
     ),
-    implementationFidelity: parseOptional(node, "implementationFidelity", (n) =>
-      resolveConceptAnnotation(n, prefixes, labels),
+    implementationFidelities: resolveConceptAnnotations(
+      node["implementationFidelity"],
+      prefixes,
+      labels,
     ),
     implementationName: parseOptional(node, "implementationName", (n) =>
       resolveStringAnnotation(n, prefixes),

--- a/src/services/investigationParser.ts
+++ b/src/services/investigationParser.ts
@@ -269,7 +269,7 @@ function parseArm(node: Dict): ArmData {
   const numField = (key: string) => resolveNumericValue(node[key]);
   return {
     id: getString(node["@id"]) ?? "",
-    conditionRef: getIdRef(node["forCondition"]),
+    conditionRef: getIdRef(first(node["forCondition"])),
     n: numField("n"),
     mean: numField("mean"),
     sd: numField("sd"),
@@ -296,8 +296,16 @@ function parseEffectEstimate(
     confidenceLevel: resolveNumericValue(node["confidenceLevel"]),
     ciLower: resolveNumericValue(node["confidenceIntervalLower"]),
     ciUpper: resolveNumericValue(node["confidenceIntervalUpper"]),
-    effectSizeMetric: resolveConceptRef(node["effectSizeMetric"], prefixes, labels),
-    estimateSource: resolveConceptRef(node["estimateSource"], prefixes, labels),
+    effectSizeMetric: resolveConceptRef(
+      first(node["effectSizeMetric"]),
+      prefixes,
+      labels,
+    ),
+    estimateSource: resolveConceptRef(
+      first(node["estimateSource"]),
+      prefixes,
+      labels,
+    ),
     baselineAdjusted:
       typeof node["baselineAdjusted"] === "boolean"
         ? (node["baselineAdjusted"] as boolean)
@@ -330,11 +338,15 @@ function parseSingleFinding(
   prefixes: Map<string, string>,
   labels: Map<string, string>,
 ): FindingData {
-  const interv = resolveRef(raw["evaluates"], blankNodes, (n) =>
+  const interv = resolveRef(first(raw["evaluates"]), blankNodes, (n) =>
     parseIntervention(n, prefixes, labels),
   );
-  const ctrl = resolveRef(raw["comparedTo"], blankNodes, parseControlCondition);
-  const ctx = resolveRef(raw["hasContext"], blankNodes, (n) =>
+  const ctrl = resolveRef(
+    first(raw["comparedTo"]),
+    blankNodes,
+    parseControlCondition,
+  );
+  const ctx = resolveRef(first(raw["hasContext"]), blankNodes, (n) =>
     parseContext(n, prefixes, labels),
   );
 
@@ -403,9 +415,10 @@ function parseFindings(
   for (const raw of rawFindings) {
     if (!isDict(raw)) continue;
     for (const key of ["evaluates", "comparedTo", "hasContext", "sampleSize"]) {
-      const child = raw[key];
-      if (isDict(child) && typeof child["@id"] === "string") {
-        blankNodes.set(child["@id"] as string, child);
+      for (const child of ensureArray(raw[key]).filter(isDict)) {
+        if (typeof child["@id"] === "string") {
+          blankNodes.set(child["@id"] as string, child);
+        }
       }
     }
   }

--- a/src/services/investigationParser.ts
+++ b/src/services/investigationParser.ts
@@ -452,8 +452,15 @@ export function parseInvestigation(
   const investigation = getInvestigation(data);
 
   return {
-    documentType: parseOptional(investigation, "documentType", (n) =>
-      resolveConceptAnnotation(n, prefixes, labels),
+    documentTypes: resolveConceptAnnotations(
+      investigation["documentType"],
+      prefixes,
+      labels,
+    ),
+    studyDesigns: resolveConceptAnnotations(
+      investigation["studyDesign"],
+      prefixes,
+      labels,
     ),
     isRetracted: investigation["isRetracted"] === true,
     findings: parseFindings(investigation, prefixes, labels),

--- a/src/services/investigationParser.ts
+++ b/src/services/investigationParser.ts
@@ -1,5 +1,5 @@
 import { expandCompactUri } from "./vocabulary/contextService";
-import { ensureArray, getInvestigation, isDict } from "./referenceUtils";
+import { ensureArray, first, getInvestigation, isDict } from "./referenceUtils";
 import type {
   InvestigationData,
   CodedAnnotation,
@@ -117,16 +117,12 @@ function resolveStringAnnotations(
     .filter((a): a is StringAnnotation => a !== null);
 }
 
-/**
- * Read an optional nested annotation from `raw[key]`. Returns undefined when
- * the field is absent or not a dict; otherwise delegates to `parse`.
- */
 function parseOptional<T>(
   raw: Dict,
   key: string,
   parse: (node: Dict) => T | null,
 ): T | undefined {
-  const node = raw[key];
+  const node = first(raw[key]);
   return isDict(node) ? parse(node) ?? undefined : undefined;
 }
 
@@ -348,7 +344,7 @@ function parseSingleFinding(
 
   // sampleSize can also be a blank-node reference for later findings
   let sampleSize: NumericAnnotation | undefined;
-  const ssNode = raw["sampleSize"];
+  const ssNode = first(raw["sampleSize"]);
   if (isDict(ssNode)) {
     sampleSize = resolveNumericAnnotation(ssNode, prefixes) ?? undefined;
   } else if (typeof ssNode === "string") {

--- a/src/services/investigationParser.ts
+++ b/src/services/investigationParser.ts
@@ -117,6 +117,42 @@ function resolveStringAnnotations(
     .filter((a): a is StringAnnotation => a !== null);
 }
 
+function resolveNumericAnnotations(
+  raw: unknown,
+  prefixes: Map<string, string>,
+): NumericAnnotation[] {
+  return ensureArray(raw)
+    .filter(isDict)
+    .map((n) => resolveNumericAnnotation(n, prefixes))
+    .filter((a): a is NumericAnnotation => a !== null);
+}
+
+/**
+ * Resolve a list of annotations whose entries may be blank-node string
+ * references (e.g. "_:sampleSize") to a definition carried on a sibling
+ * finding. Inline dicts parse directly; string refs resolve via the registry
+ * built during pass 1.
+ */
+function resolveAnnotationsWithRefs<T>(
+  raw: unknown,
+  blankNodes: Map<string, Dict>,
+  resolve: (node: Dict) => T | null,
+): T[] {
+  return ensureArray(raw)
+    .map((node) => {
+      if (isDict(node)) return resolve(node);
+      if (typeof node === "string") {
+        const found = blankNodes.get(node);
+        if (found) return resolve(found);
+        console.warn(
+          `[investigationParser] Unresolved blank-node reference: ${node}`,
+        );
+      }
+      return null;
+    })
+    .filter((a): a is T => a !== null);
+}
+
 function parseOptional<T>(
   raw: Dict,
   key: string,
@@ -171,15 +207,22 @@ function parseIntervention(
     node["implementationDescription"],
     prefixes,
   );
+  const durations = resolveNumericAnnotations(node["duration"], prefixes);
+  const implementationNames = resolveStringAnnotations(
+    node["implementationName"],
+    prefixes,
+  );
+  const funderInterventions = resolveStringAnnotations(
+    node["funderIntervention"],
+    prefixes,
+  );
 
   return {
     id: getString(node["@id"]) ?? "",
     name: getString(node["name"]),
     descriptions: descriptions.length > 0 ? descriptions : undefined,
     educationThemes: educationThemes.length > 0 ? educationThemes : undefined,
-    duration: parseOptional(node, "duration", (n) =>
-      resolveNumericAnnotation(n, prefixes),
-    ),
+    durations: durations.length > 0 ? durations : undefined,
     implementerTypes: resolveConceptAnnotations(
       node["implementerType"],
       prefixes,
@@ -190,16 +233,14 @@ function parseIntervention(
       prefixes,
       labels,
     ),
-    implementationName: parseOptional(node, "implementationName", (n) =>
-      resolveStringAnnotation(n, prefixes),
-    ),
+    implementationNames:
+      implementationNames.length > 0 ? implementationNames : undefined,
     implementationDescriptions:
       implementationDescriptions.length > 0
         ? implementationDescriptions
         : undefined,
-    funderIntervention: parseOptional(node, "funderIntervention", (n) =>
-      resolveStringAnnotation(n, prefixes),
-    ),
+    funderInterventions:
+      funderInterventions.length > 0 ? funderInterventions : undefined,
   };
 }
 
@@ -227,15 +268,17 @@ function parseContext(
   );
   const participants = resolveStringAnnotations(node["participants"], prefixes);
   const countries = resolveStringAnnotations(node["country"], prefixes);
+  const countryLevel1s = resolveStringAnnotations(
+    node["countryLevel1"],
+    prefixes,
+  );
 
   return {
     id: getString(node["@id"]) ?? "",
     educationLevels: educationLevels.length > 0 ? educationLevels : undefined,
     settings: settings.length > 0 ? settings : undefined,
     countries: countries.length > 0 ? countries : undefined,
-    countryLevel1: parseOptional(node, "countryLevel1", (n) =>
-      resolveStringAnnotation(n, prefixes),
-    ),
+    countryLevel1s: countryLevel1s.length > 0 ? countryLevel1s : undefined,
     participants: participants.length > 0 ? participants : undefined,
   };
 }
@@ -357,21 +400,23 @@ function parseSingleFinding(
     parseOutcome(n, prefixes, labels),
   );
 
-  // sampleSize can also be a blank-node reference for later findings
-  let sampleSize: NumericAnnotation | undefined;
-  const ssNode = first(raw["sampleSize"]);
-  if (isDict(ssNode)) {
-    sampleSize = resolveNumericAnnotation(ssNode, prefixes) ?? undefined;
-  } else if (typeof ssNode === "string") {
-    const resolved = blankNodes.get(ssNode);
-    if (resolved) {
-      sampleSize = resolveNumericAnnotation(resolved, prefixes) ?? undefined;
-    } else {
-      console.warn(
-        `[investigationParser] Unresolved blank-node reference: ${ssNode}`,
-      );
-    }
-  }
+  // sampleSize, attrition, and cost are sample-level scalars that can be
+  // factored out into a shared blank node and referenced by later findings.
+  const sampleSizes = resolveAnnotationsWithRefs(
+    raw["sampleSize"],
+    blankNodes,
+    (n) => resolveNumericAnnotation(n, prefixes),
+  );
+  const attritions = resolveAnnotationsWithRefs(raw["attrition"], blankNodes, (n) =>
+    resolveNumericAnnotation(n, prefixes),
+  );
+  const costs = resolveAnnotationsWithRefs(raw["cost"], blankNodes, (n) =>
+    resolveStringAnnotation(n, prefixes),
+  );
+  const groupDifferences = resolveStringAnnotations(
+    raw["groupDifferences"],
+    prefixes,
+  );
 
   const sampleFeatures = resolveConceptAnnotations(
     raw["sampleFeatures"],
@@ -392,14 +437,11 @@ function parseSingleFinding(
     context: ctx.data,
     contextRef: ctx.ref,
     outcome: outcome ?? null,
-    sampleSize,
-    attrition: parseOptional(raw, "attrition", (n) =>
-      resolveNumericAnnotation(n, prefixes),
-    ),
-    cost: parseOptional(raw, "cost", (n) => resolveStringAnnotation(n, prefixes)),
-    groupDifferences: parseOptional(raw, "groupDifferences", (n) =>
-      resolveStringAnnotation(n, prefixes),
-    ),
+    sampleSizes: sampleSizes.length > 0 ? sampleSizes : undefined,
+    attritions: attritions.length > 0 ? attritions : undefined,
+    costs: costs.length > 0 ? costs : undefined,
+    groupDifferences:
+      groupDifferences.length > 0 ? groupDifferences : undefined,
     sampleFeatures: sampleFeatures.length > 0 ? sampleFeatures : undefined,
     arms: arms.length > 0 ? arms : undefined,
     effectEstimates: effectEstimates.length > 0 ? effectEstimates : undefined,
@@ -417,7 +459,14 @@ function parseFindings(
   const blankNodes = new Map<string, Dict>();
   for (const raw of rawFindings) {
     if (!isDict(raw)) continue;
-    for (const key of ["evaluates", "comparedTo", "hasContext", "sampleSize"]) {
+    for (const key of [
+      "evaluates",
+      "comparedTo",
+      "hasContext",
+      "sampleSize",
+      "attrition",
+      "cost",
+    ]) {
       for (const child of ensureArray(raw[key]).filter(isDict)) {
         if (typeof child["@id"] === "string") {
           blankNodes.set(child["@id"] as string, child);

--- a/src/services/referenceUtils.ts
+++ b/src/services/referenceUtils.ts
@@ -17,12 +17,23 @@ export function isDict(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
+export function ensureArray(v: unknown): unknown[] {
+  if (v === undefined || v === null) return [];
+  return Array.isArray(v) ? v : [v];
+}
+
+export function first(v: unknown): unknown {
+  return Array.isArray(v) ? v[0] : v;
+}
+
 // The investigation node of a linked-data `data` dict: `hasInvestigation` when
-// present, else the dict itself (vocabularies that omit the wrapper).
+// present (dict or array-wrapped, take first), else the dict itself
+// (vocabularies that omit the wrapper).
 export function getInvestigation(
   data: Record<string, unknown>,
 ): Record<string, unknown> {
-  return isDict(data["hasInvestigation"]) ? data["hasInvestigation"] : data;
+  const inv = first(data["hasInvestigation"]);
+  return isDict(inv) ? inv : data;
 }
 
 /**
@@ -134,16 +145,12 @@ export function extractFindingsAndEstimatesCount(
   const ld = extractLinkedData(reference);
   if (!ld) return null;
   const investigation = getInvestigation(ld.data);
-  const rawFindings = Array.isArray(investigation["hasFinding"])
-    ? investigation["hasFinding"]
-    : [];
+  const findings = ensureArray(investigation["hasFinding"]).filter(isDict);
   let estimates = 0;
-  for (const f of rawFindings) {
-    if (isDict(f) && Array.isArray(f["hasEffectEstimate"])) {
-      estimates += f["hasEffectEstimate"].length;
-    }
+  for (const f of findings) {
+    estimates += ensureArray(f["hasEffectEstimate"]).filter(isDict).length;
   }
-  return { findings: rawFindings.length, estimates };
+  return { findings: findings.length, estimates };
 }
 
 export function extractDoi(

--- a/src/types/investigation.ts
+++ b/src/types/investigation.ts
@@ -23,12 +23,12 @@ export interface InterventionData {
   name?: string;
   descriptions?: string[];
   educationThemes?: CodedAnnotation<ResolvedConcept>[];
-  duration?: NumericAnnotation;
+  durations?: NumericAnnotation[];
   implementerTypes?: CodedAnnotation<ResolvedConcept>[];
   implementationFidelities?: CodedAnnotation<ResolvedConcept>[];
-  implementationName?: StringAnnotation;
+  implementationNames?: StringAnnotation[];
   implementationDescriptions?: StringAnnotation[];
-  funderIntervention?: StringAnnotation;
+  funderInterventions?: StringAnnotation[];
 }
 
 export interface ControlConditionData {
@@ -41,7 +41,7 @@ export interface ContextData {
   educationLevels?: CodedAnnotation<ResolvedConcept>[];
   settings?: CodedAnnotation<ResolvedConcept>[];
   countries?: StringAnnotation[];
-  countryLevel1?: StringAnnotation;
+  countryLevel1s?: StringAnnotation[];
   participants?: StringAnnotation[];
 }
 
@@ -90,10 +90,10 @@ export interface FindingData {
   context: ContextData | null;
   contextRef?: string;
   outcome: OutcomeData | null;
-  sampleSize?: NumericAnnotation;
-  attrition?: NumericAnnotation;
-  cost?: StringAnnotation;
-  groupDifferences?: StringAnnotation;
+  sampleSizes?: NumericAnnotation[];
+  attritions?: NumericAnnotation[];
+  costs?: StringAnnotation[];
+  groupDifferences?: StringAnnotation[];
   sampleFeatures?: CodedAnnotation<ResolvedConcept>[];
   effectEstimates?: EffectEstimateData[];
   arms?: ArmData[];

--- a/src/types/investigation.ts
+++ b/src/types/investigation.ts
@@ -100,7 +100,8 @@ export interface FindingData {
 }
 
 export interface InvestigationData {
-  documentType?: CodedAnnotation<ResolvedConcept>;
+  documentTypes: CodedAnnotation<ResolvedConcept>[];
+  studyDesigns: CodedAnnotation<ResolvedConcept>[];
   isRetracted: boolean;
   findings: FindingData[];
   // Flat investigation-level concept refs (hasAppliedConcept). Bare URI

--- a/src/types/investigation.ts
+++ b/src/types/investigation.ts
@@ -24,8 +24,8 @@ export interface InterventionData {
   descriptions?: string[];
   educationThemes?: CodedAnnotation<ResolvedConcept>[];
   duration?: NumericAnnotation;
-  implementerType?: CodedAnnotation<ResolvedConcept>;
-  implementationFidelity?: CodedAnnotation<ResolvedConcept>;
+  implementerTypes?: CodedAnnotation<ResolvedConcept>[];
+  implementationFidelities?: CodedAnnotation<ResolvedConcept>[];
   implementationName?: StringAnnotation;
   implementationDescriptions?: StringAnnotation[];
   funderIntervention?: StringAnnotation;

--- a/tests/components/finding/ContextDetails.test.tsx
+++ b/tests/components/finding/ContextDetails.test.tsx
@@ -1,0 +1,44 @@
+import { describe, test, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/preact";
+import { ContextDetails } from "@/components/finding/ContextDetails";
+import type { ContextData } from "@/types/investigation";
+
+function renderContext(context: ContextData) {
+  return render(
+    <ContextDetails context={context} labels={new Map()} broader={new Map()} />,
+  );
+}
+
+describe("ContextDetails", () => {
+  test("joins multiple regions into a single comma-separated Region field", () => {
+    renderContext({
+      id: "_:ctx",
+      countryLevel1s: [{ value: "California" }, { value: "Texas" }],
+    });
+    expect(screen.getByText("Region")).toBeDefined();
+    expect(screen.getByText("California, Texas")).toBeDefined();
+  });
+
+  test("renders a lone region value", () => {
+    renderContext({
+      id: "_:ctx",
+      countryLevel1s: [{ value: "California" }],
+    });
+    expect(screen.getByText("California")).toBeDefined();
+  });
+
+  test("surfaces region supporting text in the Source evidence toggle", () => {
+    const { container } = renderContext({
+      id: "_:ctx",
+      countryLevel1s: [
+        { value: "California", supportingText: "Study sites were in California" },
+      ],
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Source evidence/ }));
+    const evidenceLabels = [
+      ...container.querySelectorAll(".source-evidence__section-label"),
+    ].map((e) => e.textContent ?? "");
+    expect(evidenceLabels).toContain("Region");
+    expect(screen.getByText("Study sites were in California")).toBeDefined();
+  });
+});

--- a/tests/components/finding/InterventionDetails.test.tsx
+++ b/tests/components/finding/InterventionDetails.test.tsx
@@ -120,4 +120,21 @@ describe("InterventionDetails", () => {
     fireEvent.click(screen.getByRole("button", { name: /Source evidence/ }));
     expect(evidenceLabels(container)).toEqual(["Implementer"]);
   });
+
+  test("joins multiple durations into a single Duration field", () => {
+    renderDetails(makeIntervention({ durations: [{ value: 6 }, { value: 12 }] }));
+    expect(screen.getByText("Duration")).toBeDefined();
+    expect(screen.getByText("6; 12")).toBeDefined();
+  });
+
+  test("joins multiple implementation names and funders each into one field", () => {
+    renderDetails(
+      makeIntervention({
+        implementationNames: [{ value: "Programme A" }, { value: "Programme B" }],
+        funderInterventions: [{ value: "Wellcome" }, { value: "Nuffield" }],
+      }),
+    );
+    expect(screen.getByText("Programme A; Programme B")).toBeDefined();
+    expect(screen.getByText("Wellcome; Nuffield")).toBeDefined();
+  });
 });

--- a/tests/components/finding/InterventionDetails.test.tsx
+++ b/tests/components/finding/InterventionDetails.test.tsx
@@ -1,0 +1,123 @@
+import { describe, test, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/preact";
+import { InterventionDetails } from "@/components/finding/InterventionDetails";
+import type {
+  CodedAnnotation,
+  InterventionData,
+  ResolvedConcept,
+} from "@/types/investigation";
+
+function concept(
+  uri: string,
+  label: string,
+  supportingText?: string,
+): CodedAnnotation<ResolvedConcept> {
+  return {
+    value: { uri, label },
+    ...(supportingText ? { supportingText } : {}),
+  };
+}
+
+function makeIntervention(
+  overrides: Partial<InterventionData> = {},
+): InterventionData {
+  return {
+    id: "_:int",
+    implementerTypes: [],
+    implementationFidelities: [],
+    ...overrides,
+  };
+}
+
+function renderDetails(intervention: InterventionData) {
+  return render(
+    <InterventionDetails
+      intervention={intervention}
+      labels={new Map()}
+      broader={new Map()}
+    />,
+  );
+}
+
+function evidenceLabels(container: Element): string[] {
+  return [...container.querySelectorAll(".source-evidence__section-label")].map(
+    (e) => e.textContent ?? "",
+  );
+}
+
+describe("InterventionDetails", () => {
+  test("renders a single implementer type tag", () => {
+    renderDetails(
+      makeIntervention({ implementerTypes: [concept("u:teacher", "Teacher")] }),
+    );
+    expect(screen.getByText("Implementer")).toBeDefined();
+    expect(screen.getByText("Teacher")).toBeDefined();
+  });
+
+  test("renders a tag per implementer type when there are several", () => {
+    renderDetails(
+      makeIntervention({
+        implementerTypes: [
+          concept("u:teacher", "Teacher"),
+          concept("u:ta", "Teaching Assistant"),
+        ],
+      }),
+    );
+    expect(screen.getByText("Teacher")).toBeDefined();
+    expect(screen.getByText("Teaching Assistant")).toBeDefined();
+  });
+
+  test("renders a single implementation fidelity tag", () => {
+    renderDetails(
+      makeIntervention({
+        implementationFidelities: [concept("u:high", "High fidelity")],
+      }),
+    );
+    expect(screen.getByText("Implementation fidelity")).toBeDefined();
+    expect(screen.getByText("High fidelity")).toBeDefined();
+  });
+
+  test("renders a tag per implementation fidelity when there are several", () => {
+    renderDetails(
+      makeIntervention({
+        implementationFidelities: [
+          concept("u:high", "High fidelity"),
+          concept("u:partial", "Partial fidelity"),
+        ],
+      }),
+    );
+    expect(screen.getByText("High fidelity")).toBeDefined();
+    expect(screen.getByText("Partial fidelity")).toBeDefined();
+  });
+
+  test("disambiguates multiple implementer evidence entries by label", () => {
+    const { container } = renderDetails(
+      makeIntervention({
+        implementerTypes: [
+          concept("u:teacher", "Teacher", "Delivered by classroom teachers"),
+          concept(
+            "u:ta",
+            "Teaching Assistant",
+            "Supported by teaching assistants",
+          ),
+        ],
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Source evidence/ }));
+    const labels = evidenceLabels(container);
+    expect(labels).toContain("Implementer: Teacher");
+    expect(labels).toContain("Implementer: Teaching Assistant");
+  });
+
+  test("uses a plain label for a single implementer evidence entry", () => {
+    const { container } = renderDetails(
+      makeIntervention({
+        implementerTypes: [
+          concept("u:teacher", "Teacher", "Delivered by classroom teachers"),
+        ],
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Source evidence/ }));
+    expect(evidenceLabels(container)).toEqual(["Implementer"]);
+  });
+});

--- a/tests/components/finding/SampleDetails.test.tsx
+++ b/tests/components/finding/SampleDetails.test.tsx
@@ -1,0 +1,41 @@
+import { describe, test, expect } from "vitest";
+import { render, screen } from "@testing-library/preact";
+import { SampleDetails } from "@/components/finding/SampleDetails";
+import type { FindingData } from "@/types/investigation";
+
+type SampleFields = Pick<
+  FindingData,
+  "sampleSizes" | "attritions" | "costs" | "groupDifferences" | "sampleFeatures"
+>;
+
+function renderSample(finding: SampleFields) {
+  return render(
+    <SampleDetails finding={finding} labels={new Map()} broader={new Map()} />,
+  );
+}
+
+describe("SampleDetails", () => {
+  test("joins each multi-valued scalar into a single field", () => {
+    renderSample({
+      sampleSizes: [{ value: 42 }, { value: 59 }],
+      attritions: [{ value: 8 }, { value: 15 }],
+      costs: [{ value: "Reported" }, { value: "Not reported" }],
+      groupDifferences: [{ value: "Comparable" }, { value: "Age imbalance" }],
+    });
+    expect(screen.getByText("42; 59")).toBeDefined();
+    expect(screen.getByText("8; 15")).toBeDefined();
+    expect(screen.getByText("Reported; Not reported")).toBeDefined();
+    expect(screen.getByText("Comparable; Age imbalance")).toBeDefined();
+  });
+
+  test("renders a lone value without a separator", () => {
+    const { container } = renderSample({ sampleSizes: [{ value: 42 }] });
+    expect(screen.getByText("42")).toBeDefined();
+    expect(container.textContent).not.toContain(";");
+  });
+
+  test("renders nothing when there is no sample data", () => {
+    const { container } = renderSample({});
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/tests/components/investigation/InvestigationCard.test.tsx
+++ b/tests/components/investigation/InvestigationCard.test.tsx
@@ -153,6 +153,28 @@ describe("InvestigationCard", () => {
     expect(container.querySelector(".tag-group")).toBeNull();
   });
 
+  test("dedupes repeated concept URIs in doc type and study design tags", () => {
+    render(
+      <InvestigationCard
+        {...DEFAULT_PROPS}
+        documentTypes={[
+          { value: { uri: "u:ja", label: "Journal Article" } },
+          { value: { uri: "u:ja", label: "Journal Article" } },
+        ]}
+        studyDesigns={[
+          { value: { uri: "u:qed", label: "Quasi-experimental study" } },
+          { value: { uri: "u:rct", label: "Randomised Controlled Trial" } },
+          { value: { uri: "u:qed", label: "Quasi-experimental study" } },
+          { value: { uri: "u:rct", label: "Randomised Controlled Trial" } },
+          { value: { uri: "u:rct", label: "Randomised Controlled Trial" } },
+        ]}
+      />,
+    );
+    expect(screen.getAllByText("Journal Article")).toHaveLength(1);
+    expect(screen.getAllByText("Quasi-experimental study")).toHaveLength(1);
+    expect(screen.getAllByText("Randomised Controlled Trial")).toHaveLength(1);
+  });
+
   test("shows retracted banner when isRetracted is true", () => {
     render(<InvestigationCard {...DEFAULT_PROPS} isRetracted={true} />);
 

--- a/tests/components/investigation/InvestigationCard.test.tsx
+++ b/tests/components/investigation/InvestigationCard.test.tsx
@@ -18,12 +18,15 @@ const DEFAULT_PROPS = {
   doi: "10.1234/test.2024",
   abstract: null,
   publicationYear: 2024,
-  documentType: {
-    value: {
-      uri: "https://vocab.esea.education/C00008",
-      label: "Journal Article",
+  documentTypes: [
+    {
+      value: {
+        uri: "https://vocab.esea.education/C00008",
+        label: "Journal Article",
+      },
     },
-  },
+  ],
+  studyDesigns: [],
   isRetracted: false,
   hasInvestigation: true,
   vocabUnavailable: false,
@@ -96,6 +99,60 @@ describe("InvestigationCard", () => {
     expect(screen.getByText("Journal Article")).toBeDefined();
   });
 
+  test("renders multiple document type tags", () => {
+    render(
+      <InvestigationCard
+        {...DEFAULT_PROPS}
+        documentTypes={[
+          {
+            value: {
+              uri: "https://vocab.esea.education/C00008",
+              label: "Journal Article",
+            },
+          },
+          {
+            value: { uri: "https://vocab.esea.education/C9", label: "Report" },
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText("Journal Article")).toBeDefined();
+    expect(screen.getByText("Report")).toBeDefined();
+  });
+
+  test("renders a Study Design tag group, one tag per design", () => {
+    render(
+      <InvestigationCard
+        {...DEFAULT_PROPS}
+        studyDesigns={[
+          { value: { uri: "https://vocab.esea.education/C1", label: "RCT" } },
+          {
+            value: {
+              uri: "https://vocab.esea.education/C2",
+              label: "Quasi-experimental",
+            },
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText("Study Design")).toBeDefined();
+    expect(screen.getByText("RCT")).toBeDefined();
+    expect(screen.getByText("Quasi-experimental")).toBeDefined();
+  });
+
+  test("renders no Study Design group when there are no study designs", () => {
+    render(<InvestigationCard {...DEFAULT_PROPS} />);
+    expect(screen.queryByText("Study Design")).toBeNull();
+  });
+
+  test("renders no divider when doc type and study design are both empty", () => {
+    const { container } = render(
+      <InvestigationCard {...DEFAULT_PROPS} documentTypes={[]} studyDesigns={[]} />,
+    );
+    expect(container.querySelector(".investigation-card__divider")).toBeNull();
+    expect(container.querySelector(".tag-group")).toBeNull();
+  });
+
   test("shows retracted banner when isRetracted is true", () => {
     render(<InvestigationCard {...DEFAULT_PROPS} isRetracted={true} />);
 
@@ -119,7 +176,7 @@ describe("InvestigationCard", () => {
       <InvestigationCard
         {...DEFAULT_PROPS}
         hasInvestigation={false}
-        documentType={undefined}
+        documentTypes={[]}
       />,
     );
 
@@ -131,7 +188,7 @@ describe("InvestigationCard", () => {
     render(
       <InvestigationCard
         {...DEFAULT_PROPS}
-        documentType={undefined}
+        documentTypes={[]}
         vocabUnavailable={true}
       />,
     );
@@ -162,7 +219,8 @@ describe("InvestigationCard", () => {
         pagination={null}
         doi={null}
         publicationYear={null}
-        documentType={undefined}
+        documentTypes={[]}
+        studyDesigns={[]}
         isRetracted={false}
         hasInvestigation={false}
         vocabUnavailable={false}

--- a/tests/components/search/ResultRow.test.tsx
+++ b/tests/components/search/ResultRow.test.tsx
@@ -199,6 +199,26 @@ describe("ResultRow", () => {
     expect(pills?.querySelector(".tag-group__tag--more")).toBeNull();
   });
 
+  test("includes study design among the result pills (ESEA walk)", () => {
+    vocabState.labels = new Map([["http://ex/QED", "Quasi-experimental design"]]);
+    vocabState.broader = new Map();
+    vocabState.definitions = new Map();
+    contextState.context = { prefixes: new Map() };
+
+    const ref = makeRef({
+      investigation: {
+        studyDesign: { codedValue: { "@id": "http://ex/QED" } },
+        hasFinding: [],
+      },
+    });
+    const { container } = render(
+      <ResultRow communitySlug="esea" reference={ref} />,
+    );
+    const pills = container.querySelector(".row-pills");
+    expect(pills).not.toBeNull();
+    expect(pills).toHaveTextContent("Quasi-experimental design");
+  });
+
   test("caps pill list at PILL_CAP and renders +N more", () => {
     const overflow = 4;
     const labels = new Map<string, string>();

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -129,7 +129,7 @@ export function makeRichFinding(overrides: Partial<FindingData> = {}): FindingDa
         { value: { uri: "u:theme", label: "Cooperative Learning" } },
       ],
       descriptions: ["Students work in small groups"],
-      duration: { value: 5, supportingText: "5 weeks" },
+      durations: [{ value: 5, supportingText: "5 weeks" }],
     },
     interventionRef: "_:int",
     control: { id: "_:ctrl", description: "Business as usual" },
@@ -144,7 +144,7 @@ export function makeRichFinding(overrides: Partial<FindingData> = {}): FindingDa
       name: "Math test",
       outcomes: [{ value: { uri: "u:2", label: "Basic Skills" } }],
     },
-    sampleSize: { value: 50 },
+    sampleSizes: [{ value: 50 }],
     ...overrides,
   };
 }
@@ -185,7 +185,7 @@ export function makeSharedContext(
       name: "Cooperative Learning",
       educationThemes: [{ value: { uri: "u:1", label: "Literacy" } }],
       descriptions: ["Students work in small groups"],
-      duration: { value: 5 },
+      durations: [{ value: 5 }],
     } satisfies InterventionData,
     control: {
       id: "_:ctrl",

--- a/tests/services/export/buildRows.test.ts
+++ b/tests/services/export/buildRows.test.ts
@@ -396,6 +396,39 @@ describe("buildFindingRows", () => {
     expect(outRows[0]!.intervention_n).toBe(100);
     expect(outRows[0]!.control_n).toBe(95);
   });
+
+  test("joins multiple sampleSize/attrition/cost values instead of dropping extras", () => {
+    const findings: Finding[] = [
+      {
+        sampleSize: [
+          { codedValue: { "@value": 100 }, supportingText: "arm A" },
+          { codedValue: { "@value": 120 }, supportingText: "arm B" },
+        ],
+        attrition: [{ codedValue: { "@value": 5 } }, { codedValue: { "@value": 8 } }],
+        cost: [{ codedValue: { "@value": 1000 } }, { codedValue: { "@value": 2000 } }],
+      },
+    ];
+    const rows = buildFindingRows("ref-1", findings, [1], VOCAB);
+    expect(rows[0]!.sampleSize_value).toBe("100; 120");
+    expect(rows[0]!.sampleSize_supportingText).toBe("arm A | arm B");
+    expect(rows[0]!.attrition_value).toBe("5; 8");
+    expect(rows[0]!.cost_value).toBe("1000; 2000");
+  });
+
+  test("resolves and joins sampleSize given as multiple blank-node refs", () => {
+    const findings: Finding[] = [
+      {
+        sampleSize: [
+          { "@id": "_:ss1", codedValue: { "@value": 100 } },
+          { "@id": "_:ss2", codedValue: { "@value": 120 } },
+        ],
+      },
+      // later finding reaches the same nodes by bare ref (the common real-data shape)
+      { sampleSize: ["_:ss1", "_:ss2"] },
+    ];
+    const rows = buildFindingRows("ref-1", findings, [1, 2], VOCAB);
+    expect(rows[1]!.sampleSize_value).toBe("100; 120");
+  });
 });
 
 describe("buildOutcomeRows", () => {
@@ -500,6 +533,23 @@ describe("buildOutcomeRows", () => {
     expect(armRows[0]!.intervention_duration_value).toBe(40);
     const outRows = buildOutcomeRows("ref-1", findings, [1], VOCAB);
     expect(outRows[0]!.effect_metric).toBe("Standardised Mean Difference");
+  });
+
+  test("joins multiple durations rather than dropping all but the first", () => {
+    const findings: Finding[] = [
+      {
+        evaluates: {
+          "@id": "_:i1",
+          duration: [
+            { codedValue: { "@value": 5 }, supportingText: "5 weeks" },
+            { codedValue: { "@value": 10 }, supportingText: "10 weeks" },
+          ],
+        },
+      },
+    ];
+    const rows = buildFindingRows("ref-1", findings, [1], VOCAB);
+    expect(rows[0]!.intervention_duration_value).toBe("5; 10");
+    expect(rows[0]!.intervention_duration_supportingText).toBe("5 weeks | 10 weeks");
   });
 
   test("tolerates single-dict hasArmData/hasEffectEstimate and array-wrapped hasOutcome (@set shape)", () => {

--- a/tests/services/export/buildRows.test.ts
+++ b/tests/services/export/buildRows.test.ts
@@ -93,6 +93,10 @@ const LABELS = new Map([
   ["https://vocab.esea.education/ImplementerScheme/Teacher", "Teacher"],
   ["https://vocab.esea.education/FidelityScheme/High", "High"],
   ["https://vocab.esea.education/EffectMetricScheme/SMD", "Standardised Mean Difference"],
+  ["https://vocab.esea.education/StudyDesignScheme/QED", "Quasi-Experimental Design"],
+  ["https://vocab.esea.education/ImplementerScheme/NGO", "NGO"],
+  ["https://vocab.esea.education/ImplementationFidelityScheme/High", "High Fidelity"],
+  ["https://vocab.esea.education/ImplementationFidelityScheme/Partial", "Partial Fidelity"],
 ]);
 
 const VOCAB: ConceptResolver = { prefixes: PREFIXES, labels: LABELS };
@@ -219,6 +223,29 @@ describe("buildInvestigationRow", () => {
     expect(buildInvestigationRow(ref, null, linked, {}, VOCAB, coding).source).toBe("EEF");
     expect(buildInvestigationRow(ref, null, linked, {}, VOCAB).source).toBeNull();
   });
+
+  test("joins multiple study designs; single document type unchanged", () => {
+    const linked = linkedEnh({});
+    const bib = bibEnh();
+    const ref = makeRef({ enhancements: [bib, linked] });
+    const row = buildInvestigationRow(
+      ref,
+      bib.content,
+      linked,
+      {
+        documentType: { codedValue: { "@id": "esea:DocumentTypeScheme/C00008" } },
+        studyDesign: [
+          { codedValue: { "@id": "esea:StudyDesignScheme/RCT" } },
+          { codedValue: { "@id": "esea:StudyDesignScheme/QED" } },
+        ],
+      },
+      VOCAB,
+    );
+    expect(row.documentType).toBe("Journal Article");
+    expect(row.studyDesign).toBe(
+      "Randomised Controlled Trial; Quasi-Experimental Design",
+    );
+  });
 });
 
 describe("buildFindingRows", () => {
@@ -291,6 +318,83 @@ describe("buildFindingRows", () => {
     expect(rows[0]!.intervention_educationTheme).toBe(
       "Literacy; esea:UnknownScheme/X",
     );
+  });
+
+  test("joins multiple implementer types and fidelity, with their supporting text", () => {
+    const findings: Finding[] = [
+      {
+        evaluates: {
+          "@id": "_:i1",
+          implementerType: [
+            { codedValue: { "@id": "esea:ImplementerScheme/Teacher" }, supportingText: "p. 1" },
+            { codedValue: { "@id": "esea:ImplementerScheme/NGO" }, supportingText: "p. 2" },
+          ],
+          implementationFidelity: [
+            { codedValue: { "@id": "esea:ImplementationFidelityScheme/High" }, supportingText: "p. 4" },
+            { codedValue: { "@id": "esea:ImplementationFidelityScheme/Partial" }, supportingText: "p. 5" },
+          ],
+        },
+      },
+    ];
+    const rows = buildFindingRows("ref-1", findings, [1], VOCAB);
+    expect(rows[0]!.intervention_implementerType).toBe("Teacher; NGO");
+    expect(rows[0]!.intervention_implementerType_supportingText).toBe("p. 1 | p. 2");
+    // implementationFidelity is a separate read/type, so pin it too.
+    expect(rows[0]!.intervention_implementationFidelity).toBe("High Fidelity; Partial Fidelity");
+    expect(rows[0]!.intervention_implementationFidelity_supportingText).toBe("p. 4 | p. 5");
+  });
+
+  test("tolerates a single dict (not array) for multi-valued concept and value columns", () => {
+    const findings: Finding[] = [
+      {
+        evaluates: {
+          "@id": "_:i1",
+          // no @set upstream → a single value compacts to a bare dict, not [dict]
+          educationTheme: { codedValue: { "@id": "esea:EducationThemeScheme/Literacy" } },
+        },
+        hasContext: {
+          "@id": "_:ctx",
+          country: { codedValue: { "@value": "USA" } },
+          educationLevel: {
+            codedValue: { "@id": "esea:EducationLevelScheme/Primary" },
+            supportingText: "p. 3",
+          },
+        },
+      },
+    ];
+    const rows = buildFindingRows("ref-1", findings, [1], VOCAB);
+    expect(rows[0]!.intervention_educationTheme).toBe("Literacy");
+    expect(rows[0]!.context_country).toBe("USA");
+    expect(rows[0]!.context_educationLevel).toBe("Primary");
+    expect(rows[0]!.context_educationLevel_supportingText).toBe("p. 3");
+  });
+
+  test("resolves structural refs wrapped in single-element arrays (@set shape)", () => {
+    const findings: Finding[] = [
+      {
+        evaluates: [{ "@id": "_:i1", name: "Wrapped intervention" }],
+        comparedTo: [{ "@id": "_:c1", name: "Control" }],
+        hasArmData: [
+          { forCondition: ["_:i1"], n: 100 },
+          { forCondition: ["_:c1"], n: 95 },
+        ],
+        hasEffectEstimate: [{ pointEstimate: 0.5 }],
+      },
+      // later finding reuses the array-defined intervention/control by bare ref
+      { evaluates: "_:i1", comparedTo: "_:c1" },
+    ];
+    // Drive arm IDs through the real assignArmIds path (not a hardcoded [1, 2]),
+    // which production calls before row-building and which depends on the same
+    // makeResolver/buildBlankNodeLookup/refId helpers this task changes. Both
+    // findings share one arm tuple, so the real flow dedupes to a single row.
+    const armIds = assignArmIds(findings);
+    expect(armIds).toEqual([1, 1]);
+    const armRows = buildFindingRows("ref-1", findings, armIds, VOCAB);
+    expect(armRows).toHaveLength(1);
+    expect(armRows[0]!.intervention_name).toBe("Wrapped intervention");
+    const outRows = buildOutcomeRows("ref-1", findings, armIds, VOCAB);
+    expect(outRows[0]!.intervention_n).toBe(100);
+    expect(outRows[0]!.control_n).toBe(95);
   });
 });
 
@@ -381,5 +485,37 @@ describe("buildOutcomeRows", () => {
     const rows = buildOutcomeRows("ref-1", findings, [1], VOCAB);
     expect(rows[0]!.intervention_n).toBe(50);
     expect(rows[0]!.control_n).toBe(48);
+  });
+
+  test("resolves effect metric and duration wrapped in an array (@set shape)", () => {
+    const findings: Finding[] = [
+      {
+        evaluates: { "@id": "_:i1", duration: [{ codedValue: { "@value": 40 } }] },
+        hasEffectEstimate: [
+          { effectSizeMetric: ["esea:EffectMetricScheme/SMD"], pointEstimate: 0.2 },
+        ],
+      },
+    ];
+    const armRows = buildFindingRows("ref-1", findings, [1], VOCAB);
+    expect(armRows[0]!.intervention_duration_value).toBe(40);
+    const outRows = buildOutcomeRows("ref-1", findings, [1], VOCAB);
+    expect(outRows[0]!.effect_metric).toBe("Standardised Mean Difference");
+  });
+
+  test("tolerates single-dict hasArmData/hasEffectEstimate and array-wrapped hasOutcome (@set shape)", () => {
+    const findings: Finding[] = [
+      {
+        evaluates: { "@id": "_:i1" },
+        comparedTo: { "@id": "_:c1" },
+        hasOutcome: [{ name: "Reading" }],            // array wrap of a singular block → first
+        hasArmData: { forCondition: "_:i1", n: 100 }, // single dict of a repeatable container → all
+        hasEffectEstimate: { pointEstimate: 0.5 },    // single dict of a repeatable container → all
+      },
+    ];
+    const rows = buildOutcomeRows("ref-1", findings, [1], VOCAB);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.outcome_name).toBe("Reading");
+    expect(rows[0]!.point_estimate).toBe(0.5);
+    expect(rows[0]!.intervention_n).toBe(100);
   });
 });

--- a/tests/services/export/generate.test.ts
+++ b/tests/services/export/generate.test.ts
@@ -161,6 +161,25 @@ describe("generateWorkbook", () => {
     expect(rows).toHaveLength(1);
     expect(rows[0]!["Reference ID"]).toBe("ref-1");
   });
+
+  test("tolerates a single-dict hasFinding (no @set) and still emits arm/outcome rows", async () => {
+    const ref = syntheticReference("ref-1");
+    // A 1-finding investigation compacts hasFinding to a bare dict (no @set).
+    const ld = ref.enhancements!.find(
+      (e) => e.content.enhancement_type === "linked_data",
+    )!;
+    const inv = (ld.content as unknown as {
+      data: { hasInvestigation: { hasFinding: unknown } };
+    }).data.hasInvestigation;
+    inv.hasFinding = (inv.hasFinding as unknown[])[0];
+
+    const wb = await generateWorkbook([ref], MINIMAL_VOCAB, { variant: "esea" });
+    const outcomes = XLSX.utils.sheet_to_json<Record<string, unknown>>(
+      wb.Sheets["Outcomes"]!,
+    );
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0]!.point_estimate).toBe(0.5);
+  });
 });
 
 describe("workbookToArrayBuffer", () => {

--- a/tests/services/investigationParser.test.ts
+++ b/tests/services/investigationParser.test.ts
@@ -529,6 +529,102 @@ describe("parseInvestigation", () => {
     expect(result.findings[1].sampleSize?.value).toBe(47);
   });
 
+  test("resolves structural refs arriving as single-element arrays", () => {
+    const data = makeData({
+      hasFinding: [
+        {
+          "@type": "Finding",
+          evaluates: [
+            { "@id": "_:int", "@type": "Intervention", name: "Wrapped intervention" },
+          ],
+          comparedTo: [
+            { "@id": "_:ctrl", "@type": "ControlCondition", description: "Wrapped control" },
+          ],
+          hasContext: [{ "@id": "_:ctx", "@type": "Context" }],
+          hasOutcome: { "@type": "Outcome" },
+        },
+      ],
+    });
+    const f = parseInvestigation(data, PREFIXES, LABELS).findings[0];
+    expect(f.intervention?.name).toBe("Wrapped intervention");
+    expect(f.control?.description).toBe("Wrapped control");
+    expect(f.context).not.toBeNull();
+  });
+
+  test("resolves an array-wrapped blank-node structural ref across findings", () => {
+    const data = makeData({
+      hasFinding: [
+        {
+          "@type": "Finding",
+          evaluates: [
+            { "@id": "_:int", "@type": "Intervention", name: "Shared intervention" },
+          ],
+          hasContext: { "@id": "_:ctx", "@type": "Context" },
+          hasOutcome: { "@type": "Outcome" },
+        },
+        {
+          "@type": "Finding",
+          evaluates: ["_:int"],
+          hasOutcome: { "@type": "Outcome" },
+        },
+      ],
+    });
+    const result = parseInvestigation(data, PREFIXES, LABELS);
+    expect(result.findings[0].intervention?.name).toBe("Shared intervention");
+    expect(result.findings[1].intervention?.name).toBe("Shared intervention");
+    expect(result.findings[1].interventionRef).toBe("_:int");
+  });
+
+  test("resolves arm forCondition arriving as an array", () => {
+    const data = makeData({
+      hasFinding: [
+        {
+          "@type": "Finding",
+          hasArmData: [
+            {
+              "@id": "_:armI",
+              "@type": "ObservedResult",
+              forCondition: ["_:int"],
+              n: 100,
+            },
+          ],
+        },
+      ],
+    });
+    const arm = parseInvestigation(data, PREFIXES, LABELS).findings[0].arms![0];
+    expect(arm.conditionRef).toBe("_:int");
+  });
+
+  test("resolves effectSizeMetric and estimateSource arriving as arrays of CURIE strings", () => {
+    const labels = new Map([
+      ...LABELS,
+      ["https://vocab.evidence-repository.org/HEDGES_G", "Hedges' g"],
+      [
+        "https://vocab.evidence-repository.org/COMPUTED",
+        "Computed from summary statistics",
+      ],
+    ]);
+    const data = makeData({
+      hasFinding: [
+        {
+          "@type": "Finding",
+          hasEffectEstimate: [
+            {
+              "@type": "EffectEstimate",
+              pointEstimate: -0.48,
+              effectSizeMetric: ["evrepo:HEDGES_G"],
+              estimateSource: ["evrepo:COMPUTED"],
+            },
+          ],
+        },
+      ],
+    });
+    const ee = parseInvestigation(data, PREFIXES, labels).findings[0]
+      .effectEstimates![0];
+    expect(ee.effectSizeMetric?.label).toBe("Hedges' g");
+    expect(ee.estimateSource?.label).toBe("Computed from summary statistics");
+  });
+
   test("parses effect estimates with CI bounds, metric, and adjustment flags", () => {
     const labels = new Map([
       ...LABELS,

--- a/tests/services/investigationParser.test.ts
+++ b/tests/services/investigationParser.test.ts
@@ -507,8 +507,10 @@ describe("parseInvestigation", () => {
 
     const result = parseInvestigation(data, PREFIXES, LABELS);
     const f = result.findings[0];
-    expect(f.intervention?.implementerType?.value.label).toBe("Cooperative Learning");
-    expect(f.intervention?.implementationFidelity?.value.label).toBe(
+    expect(f.intervention?.implementerTypes?.[0].value.label).toBe(
+      "Cooperative Learning",
+    );
+    expect(f.intervention?.implementationFidelities?.[0].value.label).toBe(
       "Cooperative Learning",
     );
     expect(f.intervention?.implementationName?.value).toBe("Impl name");
@@ -520,6 +522,37 @@ describe("parseInvestigation", () => {
     expect(f.groupDifferences?.value).toBe("Balanced");
     expect(f.sampleFeatures).toHaveLength(1);
     expect(f.sampleFeatures?.[0].value.label).toBe("Cooperative Learning");
+  });
+
+  test("parses multiple implementerTypes from an array", () => {
+    const data = makeData({
+      hasFinding: [
+        {
+          "@type": "Finding",
+          evaluates: {
+            "@id": "_:int",
+            "@type": "Intervention",
+            implementerType: [
+              {
+                "@type": "ImplementerTypeCodingAnnotation",
+                codedValue: { "@id": "esea:C00086" },
+                status: "evrepo:coded",
+              },
+              {
+                "@type": "ImplementerTypeCodingAnnotation",
+                codedValue: { "@id": "esea:C00004" },
+                status: "evrepo:coded",
+              },
+            ],
+          },
+        },
+      ],
+    });
+    const f = parseInvestigation(data, PREFIXES, LABELS).findings[0];
+    expect(f.intervention?.implementerTypes?.map((i) => i.value.label)).toEqual([
+      "Cooperative Learning",
+      "Upper Secondary",
+    ]);
   });
 
   test("resolves sampleSize blank node references across findings", () => {

--- a/tests/services/investigationParser.test.ts
+++ b/tests/services/investigationParser.test.ts
@@ -338,8 +338,8 @@ describe("parseInvestigation", () => {
     expect(finding.intervention?.educationThemes?.[0].value.label).toBe(
       "Cooperative Learning",
     );
-    expect(finding.intervention?.duration?.value).toBe(5);
-    expect(finding.intervention?.duration?.supportingText).toBe("5 weeks");
+    expect(finding.intervention?.durations?.[0]?.value).toBe(5);
+    expect(finding.intervention?.durations?.[0]?.supportingText).toBe("5 weeks");
     expect(finding.control?.description).toBe("Business as usual");
     expect(finding.context?.educationLevels).toHaveLength(1);
     expect(finding.context?.settings).toHaveLength(1);
@@ -350,8 +350,8 @@ describe("parseInvestigation", () => {
     expect(finding.outcome?.outcomes?.[0].supportingText).toBe(
       "primary outcome",
     );
-    expect(finding.sampleSize?.value).toBe(50);
-    expect(finding.attrition?.value).toBe(12);
+    expect(finding.sampleSizes?.[0]?.value).toBe(50);
+    expect(finding.attritions?.[0]?.value).toBe(12);
   });
 
   test("resolves blank node references across findings", () => {
@@ -429,7 +429,7 @@ describe("parseInvestigation", () => {
     const result = parseInvestigation(data, PREFIXES, LABELS);
     const finding = result.findings[0];
     expect(finding.intervention?.educationThemes).toBeUndefined();
-    expect(finding.sampleSize).toBeUndefined();
+    expect(finding.sampleSizes).toBeUndefined();
   });
 
   test("parses new intervention, context, and finding fields", () => {
@@ -513,13 +513,13 @@ describe("parseInvestigation", () => {
     expect(f.intervention?.implementationFidelities?.[0].value.label).toBe(
       "Cooperative Learning",
     );
-    expect(f.intervention?.implementationName?.value).toBe("Impl name");
+    expect(f.intervention?.implementationNames?.[0]?.value).toBe("Impl name");
     expect(f.intervention?.implementationDescriptions?.[0].value).toBe("Impl desc");
-    expect(f.intervention?.funderIntervention?.value).toBe("Funder X");
+    expect(f.intervention?.funderInterventions?.[0]?.value).toBe("Funder X");
     expect(f.context?.countries?.[0].value).toBe("Netherlands");
-    expect(f.context?.countryLevel1?.value).toBe("North Holland");
-    expect(f.cost?.value).toBe("Not reported");
-    expect(f.groupDifferences?.value).toBe("Balanced");
+    expect(f.context?.countryLevel1s?.[0]?.value).toBe("North Holland");
+    expect(f.costs?.[0]?.value).toBe("Not reported");
+    expect(f.groupDifferences?.[0]?.value).toBe("Balanced");
     expect(f.sampleFeatures).toHaveLength(1);
     expect(f.sampleFeatures?.[0].value.label).toBe("Cooperative Learning");
   });
@@ -583,11 +583,49 @@ describe("parseInvestigation", () => {
     });
 
     const result = parseInvestigation(data, PREFIXES, LABELS);
-    expect(result.findings[0].sampleSize?.value).toBe(47);
-    expect(result.findings[1].sampleSize?.value).toBe(47);
+    expect(result.findings[0].sampleSizes?.[0]?.value).toBe(47);
+    expect(result.findings[1].sampleSizes?.[0]?.value).toBe(47);
   });
 
-  test("takes the first value of a scalar field arriving as an array (cost)", () => {
+  test("resolves attrition and cost blank-node references across findings", () => {
+    const data = makeData({
+      hasFinding: [
+        {
+          "@type": "Finding",
+          evaluates: { "@id": "_:int", "@type": "Intervention" },
+          hasContext: { "@id": "_:ctx", "@type": "Context" },
+          attrition: {
+            "@id": "_:attr",
+            "@type": "NumericCodingAnnotation",
+            codedValue: { "@type": "xsd:integer", "@value": 9 },
+            status: "evrepo:coded",
+          },
+          cost: {
+            "@id": "_:cost",
+            "@type": "StringCodingAnnotation",
+            codedValue: { "@type": "xsd:string", "@value": "Not reported" },
+            status: "evrepo:coded",
+          },
+          hasOutcome: { "@type": "Outcome" },
+        },
+        {
+          "@type": "Finding",
+          evaluates: "_:int",
+          hasContext: "_:ctx",
+          attrition: "_:attr",
+          cost: "_:cost",
+          hasOutcome: { "@type": "Outcome" },
+        },
+      ],
+    });
+    const result = parseInvestigation(data, PREFIXES, LABELS);
+    expect(result.findings[0].attritions?.[0]?.value).toBe(9);
+    expect(result.findings[0].costs?.[0]?.value).toBe("Not reported");
+    expect(result.findings[1].attritions?.[0]?.value).toBe(9);
+    expect(result.findings[1].costs?.[0]?.value).toBe("Not reported");
+  });
+
+  test("preserves all values of a scalar field arriving as an array (cost)", () => {
     const data = makeData({
       hasFinding: [
         {
@@ -608,10 +646,10 @@ describe("parseInvestigation", () => {
       ],
     });
     const f = parseInvestigation(data, PREFIXES, LABELS).findings[0];
-    expect(f.cost?.value).toBe("Reported");
+    expect(f.costs?.map((c) => c.value)).toEqual(["Reported", "Not reported"]);
   });
 
-  test("takes the first value of sampleSize arriving as an array", () => {
+  test("preserves all values of sampleSize arriving as an array", () => {
     const data = makeData({
       hasFinding: [
         {
@@ -632,7 +670,61 @@ describe("parseInvestigation", () => {
       ],
     });
     const f = parseInvestigation(data, PREFIXES, LABELS).findings[0];
-    expect(f.sampleSize?.value).toBe(50);
+    expect(f.sampleSizes?.map((s) => s.value)).toEqual([50, 100]);
+  });
+
+  test("preserves all values for the widened scalar fields arriving as arrays", () => {
+    const num = (v: number) => ({
+      "@type": "NumericCodingAnnotation",
+      codedValue: { "@type": "xsd:integer", "@value": v },
+      status: "evrepo:coded",
+    });
+    const str = (v: string) => ({
+      "@type": "StringCodingAnnotation",
+      codedValue: { "@type": "xsd:string", "@value": v },
+      status: "evrepo:coded",
+    });
+    const data = makeData({
+      hasFinding: [
+        {
+          "@type": "Finding",
+          evaluates: {
+            "@id": "_:int",
+            "@type": "Intervention",
+            duration: [num(6), num(12)],
+            implementationName: [str("Programme A"), str("Programme B")],
+            funderIntervention: [str("Wellcome"), str("Nuffield")],
+          },
+          hasContext: {
+            "@id": "_:ctx",
+            "@type": "Context",
+            countryLevel1: [str("California"), str("Texas")],
+          },
+          hasOutcome: { "@type": "Outcome" },
+          attrition: [num(8), num(15)],
+          groupDifferences: [str("Comparable"), str("Age imbalance")],
+        },
+      ],
+    });
+    const f = parseInvestigation(data, PREFIXES, LABELS).findings[0];
+    expect(f.intervention?.durations?.map((d) => d.value)).toEqual([6, 12]);
+    expect(f.intervention?.implementationNames?.map((n) => n.value)).toEqual([
+      "Programme A",
+      "Programme B",
+    ]);
+    expect(f.intervention?.funderInterventions?.map((v) => v.value)).toEqual([
+      "Wellcome",
+      "Nuffield",
+    ]);
+    expect(f.context?.countryLevel1s?.map((r) => r.value)).toEqual([
+      "California",
+      "Texas",
+    ]);
+    expect(f.attritions?.map((a) => a.value)).toEqual([8, 15]);
+    expect(f.groupDifferences?.map((g) => g.value)).toEqual([
+      "Comparable",
+      "Age imbalance",
+    ]);
   });
 
   test("resolves a blank-node sampleSize wrapped in a single-element array", () => {
@@ -658,8 +750,8 @@ describe("parseInvestigation", () => {
       ],
     });
     const result = parseInvestigation(data, PREFIXES, LABELS);
-    expect(result.findings[0].sampleSize?.value).toBe(47);
-    expect(result.findings[1].sampleSize?.value).toBe(47);
+    expect(result.findings[0].sampleSizes?.[0]?.value).toBe(47);
+    expect(result.findings[1].sampleSizes?.[0]?.value).toBe(47);
   });
 
   test("resolves structural refs arriving as single-element arrays", () => {

--- a/tests/services/investigationParser.test.ts
+++ b/tests/services/investigationParser.test.ts
@@ -119,6 +119,32 @@ describe("parseInvestigation", () => {
     ]);
   });
 
+  test("resolves a single hasAppliedConcept arriving as a bare URI string", () => {
+    const data = makeData({
+      hasAppliedConcept: "https://vocab.esea.education/C00086",
+    });
+    const result = parseInvestigation(data, PREFIXES, LABELS);
+    expect(result.appliedConcepts).toEqual([
+      {
+        uri: "https://vocab.esea.education/C00086",
+        label: "Cooperative Learning",
+      },
+    ]);
+  });
+
+  test("resolves a single hasAppliedConcept arriving as a bare {@id} object", () => {
+    const data = makeData({
+      hasAppliedConcept: { "@id": "https://vocab.esea.education/C00086" },
+    });
+    const result = parseInvestigation(data, PREFIXES, LABELS);
+    expect(result.appliedConcepts).toEqual([
+      {
+        uri: "https://vocab.esea.education/C00086",
+        label: "Cooperative Learning",
+      },
+    ]);
+  });
+
   test("extractIsRetracted returns true when set", () => {
     const data = makeData({ isRetracted: true });
     expect(extractIsRetracted(data)).toBe(true);

--- a/tests/services/investigationParser.test.ts
+++ b/tests/services/investigationParser.test.ts
@@ -41,17 +41,17 @@ describe("parseInvestigation", () => {
 
     const result = parseInvestigation(data, PREFIXES, LABELS);
 
-    expect(result.documentType).toBeDefined();
-    expect(result.documentType!.value.uri).toBe(
+    expect(result.documentTypes).toHaveLength(1);
+    expect(result.documentTypes[0].value.uri).toBe(
       "https://vocab.esea.education/C00008",
     );
-    expect(result.documentType!.value.label).toBe("Journal Article");
+    expect(result.documentTypes[0].value.label).toBe("Journal Article");
   });
 
-  test("returns undefined documentType when not present", () => {
+  test("returns empty documentTypes when not present", () => {
     const data = makeData({});
     const result = parseInvestigation(data, PREFIXES, LABELS);
-    expect(result.documentType).toBeUndefined();
+    expect(result.documentTypes).toEqual([]);
   });
 
   test("skips documentType with notReported status", () => {
@@ -64,7 +64,7 @@ describe("parseInvestigation", () => {
     });
 
     const result = parseInvestigation(data, PREFIXES, LABELS);
-    expect(result.documentType).toBeUndefined();
+    expect(result.documentTypes).toEqual([]);
   });
 
   test("skips documentType with notApplicable status", () => {
@@ -77,7 +77,81 @@ describe("parseInvestigation", () => {
     });
 
     const result = parseInvestigation(data, PREFIXES, LABELS);
-    expect(result.documentType).toBeUndefined();
+    expect(result.documentTypes).toEqual([]);
+  });
+
+  test("parses multiple documentTypes from an array", () => {
+    const data = makeData({
+      documentType: [
+        {
+          "@type": "DocumentTypeCodingAnnotation",
+          codedValue: { "@id": "esea:C00008" },
+          status: "evrepo:coded",
+        },
+        {
+          "@type": "DocumentTypeCodingAnnotation",
+          codedValue: { "@id": "esea:C00086" },
+          status: "evrepo:coded",
+        },
+      ],
+    });
+    const result = parseInvestigation(data, PREFIXES, LABELS);
+    expect(result.documentTypes.map((d) => d.value.label)).toEqual([
+      "Journal Article",
+      "Cooperative Learning",
+    ]);
+  });
+
+  test("parses a single studyDesign dict", () => {
+    const data = makeData({
+      studyDesign: {
+        "@type": "StudyDesignCodingAnnotation",
+        codedValue: { "@id": "esea:C00086" },
+        status: "evrepo:coded",
+      },
+    });
+    const result = parseInvestigation(data, PREFIXES, LABELS);
+    expect(result.studyDesigns).toHaveLength(1);
+    expect(result.studyDesigns[0].value.label).toBe("Cooperative Learning");
+  });
+
+  test("parses multiple studyDesigns from an array", () => {
+    const data = makeData({
+      studyDesign: [
+        {
+          "@type": "StudyDesignCodingAnnotation",
+          codedValue: { "@id": "esea:C00086" },
+          status: "evrepo:coded",
+        },
+        {
+          "@type": "StudyDesignCodingAnnotation",
+          codedValue: { "@id": "esea:C00004" },
+          status: "evrepo:coded",
+        },
+      ],
+    });
+    const result = parseInvestigation(data, PREFIXES, LABELS);
+    expect(result.studyDesigns.map((d) => d.value.label)).toEqual([
+      "Cooperative Learning",
+      "Upper Secondary",
+    ]);
+  });
+
+  test("returns empty studyDesigns when absent", () => {
+    const result = parseInvestigation(makeData({}), PREFIXES, LABELS);
+    expect(result.studyDesigns).toEqual([]);
+  });
+
+  test("skips a studyDesign marked notReported", () => {
+    const data = makeData({
+      studyDesign: {
+        "@type": "StudyDesignCodingAnnotation",
+        codedValue: { "@id": "esea:C00086" },
+        status: "evrepo:notReported",
+      },
+    });
+    const result = parseInvestigation(data, PREFIXES, LABELS);
+    expect(result.studyDesigns).toEqual([]);
   });
 
   test("parses isRetracted flag", () => {
@@ -167,7 +241,7 @@ describe("parseInvestigation", () => {
     };
 
     const result = parseInvestigation(data, PREFIXES, LABELS);
-    expect(result.documentType?.value.label).toBe("Journal Article");
+    expect(result.documentTypes[0]?.value.label).toBe("Journal Article");
   });
 
   test("returns empty findings when hasFinding is absent", () => {
@@ -783,9 +857,9 @@ describe("parseInvestigation", () => {
     });
 
     const result = parseInvestigation(data, PREFIXES, LABELS);
-    expect(result.documentType?.value.uri).toBe(
+    expect(result.documentTypes[0]?.value.uri).toBe(
       "https://vocab.esea.education/C99999",
     );
-    expect(result.documentType?.value.label).toBeUndefined();
+    expect(result.documentTypes[0]?.value.label).toBeUndefined();
   });
 });

--- a/tests/services/investigationParser.test.ts
+++ b/tests/services/investigationParser.test.ts
@@ -454,6 +454,81 @@ describe("parseInvestigation", () => {
     expect(result.findings[1].sampleSize?.value).toBe(47);
   });
 
+  test("takes the first value of a scalar field arriving as an array (cost)", () => {
+    const data = makeData({
+      hasFinding: [
+        {
+          "@type": "Finding",
+          cost: [
+            {
+              "@type": "StringCodingAnnotation",
+              codedValue: { "@type": "xsd:string", "@value": "Reported" },
+              status: "evrepo:coded",
+            },
+            {
+              "@type": "StringCodingAnnotation",
+              codedValue: { "@type": "xsd:string", "@value": "Not reported" },
+              status: "evrepo:coded",
+            },
+          ],
+        },
+      ],
+    });
+    const f = parseInvestigation(data, PREFIXES, LABELS).findings[0];
+    expect(f.cost?.value).toBe("Reported");
+  });
+
+  test("takes the first value of sampleSize arriving as an array", () => {
+    const data = makeData({
+      hasFinding: [
+        {
+          "@type": "Finding",
+          sampleSize: [
+            {
+              "@type": "NumericCodingAnnotation",
+              codedValue: { "@type": "xsd:integer", "@value": 50 },
+              status: "evrepo:coded",
+            },
+            {
+              "@type": "NumericCodingAnnotation",
+              codedValue: { "@type": "xsd:integer", "@value": 100 },
+              status: "evrepo:coded",
+            },
+          ],
+        },
+      ],
+    });
+    const f = parseInvestigation(data, PREFIXES, LABELS).findings[0];
+    expect(f.sampleSize?.value).toBe(50);
+  });
+
+  test("resolves a blank-node sampleSize wrapped in a single-element array", () => {
+    const data = makeData({
+      hasFinding: [
+        {
+          "@type": "Finding",
+          evaluates: { "@id": "_:int", "@type": "Intervention" },
+          hasContext: { "@id": "_:ctx", "@type": "Context" },
+          sampleSize: {
+            "@id": "_:sampleSize",
+            "@type": "NumericCodingAnnotation",
+            codedValue: { "@type": "xsd:integer", "@value": 47 },
+            status: "evrepo:coded",
+          },
+          hasOutcome: { "@type": "Outcome" },
+        },
+        {
+          "@type": "Finding",
+          sampleSize: ["_:sampleSize"],
+          hasOutcome: { "@type": "Outcome" },
+        },
+      ],
+    });
+    const result = parseInvestigation(data, PREFIXES, LABELS);
+    expect(result.findings[0].sampleSize?.value).toBe(47);
+    expect(result.findings[1].sampleSize?.value).toBe(47);
+  });
+
   test("parses effect estimates with CI bounds, metric, and adjustment flags", () => {
     const labels = new Map([
       ...LABELS,

--- a/tests/services/referenceUtils.test.ts
+++ b/tests/services/referenceUtils.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from "vitest";
 import {
   extractAbstract,
   extractBibliographic,
+  extractFindingsAndEstimatesCount,
   extractLatestEnhancement,
   extractLinkedData,
   extractLinkedDataEnhancement,
@@ -9,7 +10,9 @@ import {
   extractOpenAlexId,
   extractOtherIdentifier,
   formatPagination,
+  getInvestigation,
 } from "@/services/referenceUtils";
+import { makeReference } from "../fixtures";
 import type {
   Reference,
   Enhancement,
@@ -421,5 +424,69 @@ describe("extractAbstract", () => {
       ],
     };
     expect(extractAbstract(ref)).toBe(duplicateOnly);
+  });
+});
+
+describe("getInvestigation", () => {
+  test("unwraps a bare-dict hasInvestigation", () => {
+    expect(getInvestigation({ hasInvestigation: { marker: "inv" } })).toEqual({
+      marker: "inv",
+    });
+  });
+
+  test("takes the first element of an array-wrapped hasInvestigation", () => {
+    expect(getInvestigation({ hasInvestigation: [{ marker: "inv" }] })).toEqual({
+      marker: "inv",
+    });
+  });
+
+  test("falls back to the root when the wrapper is omitted", () => {
+    const root = { studyDesign: { "@id": "esea:C1" } };
+    expect(getInvestigation(root)).toBe(root);
+  });
+});
+
+describe("extractFindingsAndEstimatesCount", () => {
+  test("returns null when the reference has no linked-data enhancement", () => {
+    expect(extractFindingsAndEstimatesCount(makeReference({}))).toBeNull();
+  });
+
+  test("counts a bare-dict single finding and its bare-dict estimate", () => {
+    const ref = makeReference({
+      investigation: {
+        hasFinding: { hasEffectEstimate: { pointEstimate: 0.3 } },
+      },
+    });
+    expect(extractFindingsAndEstimatesCount(ref)).toEqual({
+      findings: 1,
+      estimates: 1,
+    });
+  });
+
+  test("counts array-form findings and estimates unchanged", () => {
+    const ref = makeReference({
+      investigation: {
+        hasFinding: [
+          { hasEffectEstimate: [{}, {}] },
+          { hasEffectEstimate: [{}] },
+        ],
+      },
+    });
+    expect(extractFindingsAndEstimatesCount(ref)).toEqual({
+      findings: 2,
+      estimates: 3,
+    });
+  });
+
+  test("ignores non-dict entries in a findings array", () => {
+    const ref = makeReference({
+      investigation: {
+        hasFinding: [{ hasEffectEstimate: {} }, "stray"],
+      },
+    });
+    expect(extractFindingsAndEstimatesCount(ref)).toEqual({
+      findings: 1,
+      estimates: 1,
+    });
   });
 });


### PR DESCRIPTION
## Summary

For a property without `@container: @set`, JSON-LD compaction emits a bare object when it has a single value and an array when it has two or more, so an object-property field in the investigation hierarchy can arrive at the UI as either shape. Because the published context can change which properties carry `@set`, that shape is not stable across vocabulary versions either. The investigation parser and detail-page display previously assumed fixed shapes.

This is conceptually the parser + display half of #178 (the UI side of the vocabulary-mapping-robot change, VMR#34). The companion export change (#194) covers the write side. Because #194 is merged into this branch and has not yet landed on `main`, the GitHub diff for this PR also includes the export commits; they drop out of the diff once #194 merges. #178 closes when both land. Net-new UI: study design was filterable but never parsed or displayed, and now renders.

## What changed

The normalisation primitives `ensureArray` (take all) and `first` (take the first of any element type: dict, blank-node string, or bare CURIE) are hosted in `referenceUtils` and imported by the parser. Reads are made shape-tolerant across the same classes the export uses:

- **`referenceUtils`**: `getInvestigation` takes the first of an array-wrapped `hasInvestigation` (it was dict-only, so an array fell through to treating the enhancement root as the investigation); `extractFindingsAndEstimatesCount` counts a bare-dict single finding or estimate (it was array-only, rendering "0 findings / 0 estimates" for an unwrapped single).
- **Scalar and single-string annotation fields** (duration, sample size, attrition, cost, group differences, implementation name, funder, region) resolve to arrays and preserve every value rather than dropping to the first. The fields the export also emits (duration, sample size, attrition, cost, region) line up with its column join; group differences, implementation name, and funder are display-only. A field that arrives as a single object renders exactly as before.
- **Structural refs** (`evaluates` / `comparedTo` / `hasContext`, effect-estimate concept refs, arm `forCondition`) stay single via `first`, tolerating a single-element-array wrapper; the blank-node registry also registers array-wrapped definitions.
- **Applied concepts** (HPV `hasAppliedConcept`) tolerate a single bare URI or object, not just an array.
- **Coded concept fields go data-driven**: document type and study design (investigation), implementer type and implementation fidelity (intervention) are read as arrays and render every value as a tag. A single value looks exactly like before.

New and adjusted display:

- **Study design** renders as a tag group on the detail card and as result-row pills.
- **`InvestigationCard`** gates the metadata block with length checks so an empty array no longer emits an orphan divider, dedupes repeated concept codes by URI (multi-annotation data can repeat a code), and spaces stacked tag groups (the card only ever rendered one group before).
- **`InterventionDetails`** disambiguates multiple source-evidence entries by concept label (e.g. `Implementer: <label>`) instead of repeating a bare field label.
- **Multi-valued scalars** render as one labelled field with values joined: `; ` for finding-level scalars, `, ` for Region (matching the adjacent Country field).
- **Region source evidence** now appears in the context "Source evidence" toggle alongside Country; previously the region was displayed but its supporting text was dropped.

Cardinality is left to the taxonomy: the UI renders whatever shape and count arrive rather than hardcoding single-vs-multiple. An earlier revision kept the scalar and single-string fields single and deferred widening them; following code review that deferral is closed, so these fields now preserve all values. To keep the display in step with the export for the fields it emits, `sampleSize`, `attrition`, and `cost` also resolve blank-node string references (a definition carried on a sibling finding), and `attrition`/`cost` join the parser's pass-1 blank-node registry, matching the export's lookup. Genuinely single fields (structural refs, outcome, effect-size metric) still take `first`.

Out of scope: all upstream decisions about taxonomy / vocabulary-mapping-robot behaviour, including the `@container: @set` context fix, the `allowMultiple` annotation, and SHACL validation. This PR defends the UI against the shape inconsistency rather than fixing its source. Also deferred: value-qualified source-evidence labels. The field itself joins its values (Duration renders `2; 6`), but in the expandable Source evidence panel a scalar whose values each carry supporting text lists one entry per value under a repeated plain label (two `Duration` entries) rather than tagging each with its value (`Duration: 2` / `Duration: 6`). No record in the ingested corpus carries a multi-valued scalar, so this is latent in production data.

## Validation performed

- Typecheck clean (`tsc --noEmit`); 952 tests pass (`vitest run`), including multi-value shape-tolerance cases through the public `parseInvestigation` contract, attrition/cost blank-node resolution across findings, and component cases for multi-value field joins, region source evidence, tag rendering, the empty-array divider gate, dedup, and source-evidence disambiguation.
- Live-validated against a local repository instance through the dev server and the repository's API with the staging ESEA v1.1 vocabulary: injected multi-valued scalars (duration, sample size, funder, implementation name, region, group differences) each render joined into a single field; a second finding referencing another finding's `attrition`/`cost` blank nodes resolves and displays both values (parity with the export); the context "Source evidence" toggle surfaces the region supporting text. Console clean, no unresolved-reference warnings.
- Study design: the detail page renders the Study Design tag group; a record with 5 study-design annotations across 2 distinct codes collapses to 2 deduped tags; stacked Doc Type and Study Design groups are spaced correctly; search result pills surface both study designs (deduped, within the existing pill cap with a "+N more" overflow).
- Corpus check (direct database query): in the locally-ingested ESEA and EEF data, no coded record carries more than 2 distinct study designs (58 have two, the rest one), and the scalar fields are not observed multi-valued, so the widening is a no-op on current data and forward-looking for future ingests. Not a claim about production or other communities.
- HPV regression, live against staging (no injection): the `/hpv` search list renders applied-concept pills with the `+N more` overflow; a 90+-concept detail page renders the full Taxonomy Codes card (every scheme, hierarchical tags such as `Age Group › 9–14 years`, labels resolved from HPV vocab v2.3); console clean. The applied-concepts change only adds single-value tolerance on top of the existing array handling, so nothing HPV-specific changed.
- HPV reference-level Excel export, live against staging: the workbook still builds correctly (one References sheet, bibliographic columns plus one column per scheme, labels resolved, multi-values `; `-joined). The HPV export builder is untouched here; its only JSON-LD-shape reads (`getInvestigation`, `parseAppliedConcepts`) run through the same hardened functions as the display, so it inherits the resilience rather than duplicating it.
