### PR TITLE
Select references on the search results page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import Router from "preact-router";
 import { AuthProvider } from "./auth/AuthContext";
 import { CommunityProvider } from "./community/CommunityContext";
 import { AiSummaryProvider } from "./components/ai-summary/AiSummaryProvider";
+import { SelectionProvider } from "./components/search/SelectionProvider";
 import { AppShell } from "./components/layout/AppShell";
 import { SearchPage } from "./pages/SearchPage";
 import { VisualisePage } from "./pages/VisualisePage";
@@ -22,14 +23,16 @@ export function App() {
     <AuthProvider>
       <CommunityProvider>
         <AiSummaryProvider>
-          <AppShell>
-            <Router onChange={emitUrlChange}>
-              <RecordDetailPage path="/:community/references/:id" />
-              <VisualisePage path="/:community/visualise" />
-              <SearchPage path="/:community" />
-              <NotFoundPage default />
-            </Router>
-          </AppShell>
+          <SelectionProvider>
+            <AppShell>
+              <Router onChange={emitUrlChange}>
+                <RecordDetailPage path="/:community/references/:id" />
+                <VisualisePage path="/:community/visualise" />
+                <SearchPage path="/:community" />
+                <NotFoundPage default />
+              </Router>
+            </AppShell>
+          </SelectionProvider>
         </AiSummaryProvider>
       </CommunityProvider>
     </AuthProvider>

--- a/src/components/ai-summary/AiSummaryButton.tsx
+++ b/src/components/ai-summary/AiSummaryButton.tsx
@@ -8,7 +8,7 @@ interface AiSummaryButtonProps {
   disabledReason?: string;
 }
 
-/** "Generate AI summary" entry point shown above the results list. */
+/** "Generate AI summary" entry point in the search results meta bar. */
 export function AiSummaryButton({
   onClick,
   disabled = false,
@@ -22,13 +22,9 @@ export function AiSummaryButton({
   );
   // Tooltip wrapper lives outside the disabled button so the bubble still
   // appears on hover (disabled buttons don't receive pointer events).
-  return (
-    <div class="gen-row">
-      {disabled && disabledReason ? (
-        <Tooltip text={disabledReason}>{button}</Tooltip>
-      ) : (
-        button
-      )}
-    </div>
+  return disabled && disabledReason ? (
+    <Tooltip text={disabledReason}>{button}</Tooltip>
+  ) : (
+    button
   );
 }

--- a/src/components/ai-summary/ai-summary.css
+++ b/src/components/ai-summary/ai-summary.css
@@ -2,27 +2,21 @@
    (components/common/Drawer.css); these are the AI-specific content styles,
    ported from the mid-fi design and reusing the system's tokens. */
 
-/* ── Generate button (above results) ──────────────────────── */
-.gen-row {
-  max-width: 960px;
-  /* The search hero already pads 36px below the search bar; pull up so the
-     button lands at the design's ~16px gap instead of stacking both. */
-  margin: calc(var(--spacing-md) - 36px) auto var(--spacing-md);
-  display: flex;
-  justify-content: flex-end;
-}
+/* ── Generate button (in the results meta bar) ────────────── */
 .gen-btn {
   display: inline-flex;
   align-items: center;
-  gap: var(--spacing-sm);
+  gap: 6px;
   background: var(--color-accent);
   border: 1px solid var(--color-accent);
   color: #fff;
   border-radius: var(--radius-sm);
   font-family: var(--font-body);
-  font-size: var(--font-size-small);
+  /* Match the meta bar's Export/Refine buttons so the row aligns. */
+  font-size: var(--font-size-xs);
+  line-height: 1.2;
   font-weight: 500;
-  padding: 8px 14px;
+  padding: 7px 12px;
   cursor: pointer;
   transition: background 0.12s, box-shadow 0.12s;
 }
@@ -37,6 +31,9 @@
 .ai-beta {
   font-family: var(--font-mono);
   font-size: 9px;
+  /* line-height 1 keeps the badge within the button's text line so it doesn't
+     make the button taller than the sibling Export/Refine buttons. */
+  line-height: 1;
   letter-spacing: 0.08em;
   font-weight: 600;
   background: var(--color-accent);

--- a/src/components/search/ResultRow.css
+++ b/src/components/search/ResultRow.css
@@ -22,6 +22,34 @@
   background: var(--color-bg-hover);
 }
 
+/* Selection: a checkbox gutter is added as the first grid column, so the
+   left-column content and pills shift one column to the right. */
+.result-row--selectable {
+  grid-template-columns: auto 1fr auto;
+}
+
+.result-row--selectable .row-pills {
+  grid-column: 2;
+}
+
+.result-row.is-selected,
+.result-row.is-selected:nth-child(even) {
+  background: var(--color-accent-light);
+}
+
+/* The checkbox raises above the stretched-link overlay (like .doi-link) so a
+   tick toggles selection instead of navigating to the record. */
+.row-check {
+  position: relative;
+  z-index: 2;
+  align-self: start;
+  width: 16px;
+  height: 16px;
+  margin: 3px 0 0;
+  accent-color: var(--color-accent);
+  cursor: pointer;
+}
+
 .result-row:last-of-type {
   border-bottom: none;
   border-bottom-left-radius: 4px;

--- a/src/components/search/ResultRow.tsx
+++ b/src/components/search/ResultRow.tsx
@@ -28,6 +28,10 @@ interface ResultRowProps {
   findingsAndEstimates?: boolean;
   // Concept schemes whose members are dropped from pills (e.g. geo).
   pillExcludedSchemes?: readonly string[];
+  // When true, renders a selection checkbox in a left column.
+  selectable?: boolean;
+  selected?: boolean;
+  onToggle?: () => void;
 }
 
 const MAX_AUTHORS_SHOWN = 3;
@@ -78,6 +82,9 @@ export function ResultRow({
   codingInstitution: codingConfig,
   findingsAndEstimates = true,
   pillExcludedSchemes = NO_PILL_EXCLUSIONS,
+  selectable = false,
+  selected = false,
+  onToggle,
 }: ResultRowProps) {
   const bib = extractBibliographic(reference);
   const doi = extractDoi(reference.identifiers);
@@ -149,7 +156,23 @@ export function ResultRow({
   // clickable above the overlay; .row-right and stat-badges deliberately
   // stay un-positioned so their clicks fall through to the row link.
   return (
-    <article class="result-row">
+    <article
+      class={`result-row${selectable ? " result-row--selectable" : ""}${
+        selectable && selected ? " is-selected" : ""
+      }`}
+    >
+      {selectable && (
+        <input
+          type="checkbox"
+          class="row-check"
+          checked={selected}
+          aria-label={selected ? `Deselect ${title}` : `Select ${title}`}
+          onChange={() => onToggle?.()}
+          // Raised above the stretched-link overlay (see CSS); stop the click
+          // from bubbling to the row so it never navigates to the record.
+          onClick={(e) => e.stopPropagation()}
+        />
+      )}
       <a
         class="row-link"
         href={`/${communitySlug}/references/${reference.id}`}

--- a/src/components/search/SelectionBanner.css
+++ b/src/components/search/SelectionBanner.css
@@ -1,0 +1,42 @@
+.sel-banner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--color-accent-light);
+  border-bottom: 1px solid var(--color-border);
+  font-size: var(--font-size-small);
+  color: var(--color-text-primary);
+}
+
+.sel-banner__action {
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--color-accent);
+  font-size: inherit;
+  font-weight: 600;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.sel-banner__action:hover {
+  text-decoration: none;
+}
+
+.sel-banner__clear {
+  padding: 2px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm, 4px);
+  background: var(--color-bg-surface);
+  color: var(--color-text-secondary);
+  font-size: inherit;
+  cursor: pointer;
+}
+
+.sel-banner__clear:hover {
+  color: var(--color-text-primary);
+  border-color: var(--color-border-strong, var(--color-border));
+}

--- a/src/components/search/SelectionBanner.tsx
+++ b/src/components/search/SelectionBanner.tsx
@@ -1,0 +1,40 @@
+import "./SelectionBanner.css";
+
+export interface SelectionBannerContent {
+  /** e.g. "20 selected" or "All 1,854 selected". */
+  countLabel: string;
+  /** Optional escalation (extend a manual selection to every match). */
+  selectAll?: { label: string; onAction: () => void };
+  onClear: () => void;
+}
+
+/**
+ * The selection summary row shown below the meta bar while a selection is
+ * active: the count, an optional "select all matches" escalation, and Clear.
+ * `content` is null when nothing is selected.
+ */
+export function SelectionBanner({
+  content,
+}: {
+  content: SelectionBannerContent | null;
+}) {
+  if (content === null) return null;
+
+  return (
+    <div class="sel-banner">
+      <span class="sel-banner__count">{content.countLabel}</span>
+      {content.selectAll && (
+        <button
+          type="button"
+          class="sel-banner__action"
+          onClick={content.selectAll.onAction}
+        >
+          {content.selectAll.label}
+        </button>
+      )}
+      <button type="button" class="sel-banner__clear" onClick={content.onClear}>
+        Clear
+      </button>
+    </div>
+  );
+}

--- a/src/components/search/SelectionBanner.tsx
+++ b/src/components/search/SelectionBanner.tsx
@@ -33,7 +33,7 @@ export function SelectionBanner({
         </button>
       )}
       <button type="button" class="sel-banner__clear" onClick={content.onClear}>
-        Clear
+        Clear all
       </button>
     </div>
   );

--- a/src/components/search/SelectionControls.css
+++ b/src/components/search/SelectionControls.css
@@ -1,0 +1,24 @@
+.sel-master-box {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+}
+
+.sel-master {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  accent-color: var(--color-accent);
+  cursor: pointer;
+}
+
+.sel-master-label {
+  font-size: var(--font-size-small);
+  color: var(--color-text-secondary);
+}
+
+.sel-master:disabled {
+  cursor: default;
+  opacity: 0.5;
+}

--- a/src/components/search/SelectionControls.tsx
+++ b/src/components/search/SelectionControls.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from "preact/hooks";
+import type { MasterState } from "@/hooks/useReferenceSelection";
+import "./SelectionControls.css";
+
+interface SelectionControlsProps {
+  master: MasterState;
+  onMasterToggle: () => void;
+  /** Disables the master checkbox (e.g. no results to select). */
+  disabled?: boolean;
+}
+
+/** The per-page selection control in the meta bar (selects/deselects this page). */
+export function SelectionControls({
+  master,
+  onMasterToggle,
+  disabled = false,
+}: SelectionControlsProps) {
+  const boxRef = useRef<HTMLInputElement>(null);
+
+  // `indeterminate` is a DOM property, not an attribute, so it can't be set in
+  // JSX — reflect the "some selected" state onto the native checkbox here.
+  useEffect(() => {
+    if (boxRef.current) boxRef.current.indeterminate = master === "some";
+  }, [master]);
+
+  // When the whole page is selected, the checkbox deselects it.
+  const label = master === "all" ? "Deselect this page" : "Select this page";
+
+  return (
+    <label class="sel-master-box">
+      <input
+        ref={boxRef}
+        type="checkbox"
+        class="sel-master"
+        checked={master === "all"}
+        disabled={disabled}
+        aria-label={label}
+        onChange={onMasterToggle}
+      />
+      <span class="sel-master-label">{label}</span>
+    </label>
+  );
+}

--- a/src/components/search/SelectionProvider.tsx
+++ b/src/components/search/SelectionProvider.tsx
@@ -1,0 +1,52 @@
+import { createContext, type ComponentChildren } from "preact";
+import { useCallback, useContext, useRef } from "preact/hooks";
+import {
+  useReferenceSelection,
+  type ReferenceSelection,
+} from "@/hooks/useReferenceSelection";
+
+export interface SelectionContextValue extends ReferenceSelection {
+  /**
+   * Clear the selection when the search identity changes. The identity should
+   * encode community + query + filters (not page/sort). Called from the search
+   * page; because this provider lives above the router it isn't remounted on
+   * navigation, so paging/sorting keeps the selection and only a genuinely new
+   * search clears it.
+   */
+  syncSearchIdentity: (identity: string) => void;
+}
+
+const SelectionCtx = createContext<SelectionContextValue | undefined>(undefined);
+
+/**
+ * Owns reference selection above the router so it survives navigation (paging,
+ * sorting, visiting a record and returning). Mirrors AiSummaryProvider.
+ */
+export function SelectionProvider({ children }: { children: ComponentChildren }) {
+  const selection = useReferenceSelection();
+  const identityRef = useRef<string | null>(null);
+  const { clear } = selection;
+
+  const syncSearchIdentity = useCallback(
+    (identity: string) => {
+      if (identityRef.current === identity) return;
+      identityRef.current = identity;
+      clear();
+    },
+    [clear],
+  );
+
+  return (
+    <SelectionCtx.Provider value={{ ...selection, syncSearchIdentity }}>
+      {children}
+    </SelectionCtx.Provider>
+  );
+}
+
+export function useSelectionContext(): SelectionContextValue {
+  const value = useContext(SelectionCtx);
+  if (value === undefined) {
+    throw new Error("useSelectionContext must be used within a SelectionProvider");
+  }
+  return value;
+}

--- a/src/components/search/selectionEnabled.ts
+++ b/src/components/search/selectionEnabled.ts
@@ -1,0 +1,16 @@
+import type { Community } from "@/types/models";
+import { aiSummariesEnabled } from "@/components/ai-summary/aiSummariesEnabled";
+
+export function selectionEnabled(
+  community: Community | null,
+  aiSummaryWriter: boolean,
+): boolean {
+  if (!community?.features.referenceSelection) return false;
+
+  // Without a consumer, selecting references is a dead end,
+  // so the whole layer stays hidden.
+  return (
+    community.features.exportExcel ||
+    aiSummariesEnabled(community, aiSummaryWriter)
+  );
+}

--- a/src/hooks/useReferenceSelection.ts
+++ b/src/hooks/useReferenceSelection.ts
@@ -1,0 +1,135 @@
+import { useCallback, useState } from "preact/hooks";
+
+/**
+ * How the selection is expressed:
+ * - `include`: exactly the ids in `included` are selected.
+ * - `all`: every reference matching the current search is selected, minus the
+ *   ids in `excluded`. The full matching set can't be enumerated client-side
+ *   (other pages aren't loaded), so it's a flag plus an exclusion set; a
+ *   consumer resolves the concrete list at submit time — `include` sends
+ *   `included`, `all` sends every matching id minus `excluded`.
+ */
+export type SelectionMode = "include" | "all";
+
+/** State of the master checkbox for the references currently on screen. */
+export type MasterState = "none" | "some" | "all";
+
+export interface ReferenceSelection {
+  mode: SelectionMode;
+  /** Selected ids (meaningful in `include` mode). */
+  included: ReadonlySet<string>;
+  /** Deselected ids after selecting everything (meaningful in `all` mode). */
+  excluded: ReadonlySet<string>;
+  /** Selected count given the total matching the search. */
+  count: (total: number) => number;
+  isSelected: (id: string) => boolean;
+  masterState: (visibleIds: string[]) => MasterState;
+  /** Toggle one row (adds/removes from `included`, or `excluded` in `all` mode). */
+  toggle: (id: string) => void;
+  /** Add or remove a whole page of ids, keeping any existing selection. */
+  setPageSelected: (visibleIds: string[], selected: boolean) => void;
+  /** Select every reference matching the search (`all` mode). */
+  selectAllPages: () => void;
+  clear: () => void;
+}
+
+interface SelectionState {
+  mode: SelectionMode;
+  included: Set<string>;
+  excluded: Set<string>;
+}
+
+const EMPTY: SelectionState = {
+  mode: "include",
+  included: new Set(),
+  excluded: new Set(),
+};
+
+function withToggled(set: ReadonlySet<string>, id: string): Set<string> {
+  const next = new Set(set);
+  if (next.has(id)) next.delete(id);
+  else next.add(id);
+  return next;
+}
+
+/**
+ * Holds reference selection, keyed by `reference.id` so it survives pagination
+ * and re-sorting. Mounted in `SelectionProvider` above the router so navigation
+ * doesn't drop it; the provider clears it when the search identity changes.
+ */
+export function useReferenceSelection(): ReferenceSelection {
+  const [state, setState] = useState<SelectionState>(EMPTY);
+
+  const isSelected = useCallback(
+    (id: string) =>
+      state.mode === "include" ? state.included.has(id) : !state.excluded.has(id),
+    [state],
+  );
+
+  const count = useCallback(
+    (total: number) =>
+      state.mode === "include"
+        ? state.included.size
+        : Math.max(0, total - state.excluded.size),
+    [state],
+  );
+
+  const masterState = useCallback(
+    (visibleIds: string[]): MasterState => {
+      if (visibleIds.length === 0) return "none";
+      const selected = visibleIds.filter(isSelected).length;
+      if (selected === 0) return "none";
+      if (selected === visibleIds.length) return "all";
+      return "some";
+    },
+    [isSelected],
+  );
+
+  const toggle = useCallback((id: string) => {
+    setState((s) =>
+      s.mode === "include"
+        ? { ...s, included: withToggled(s.included, id) }
+        : { ...s, excluded: withToggled(s.excluded, id) },
+    );
+  }, []);
+
+  const setPageSelected = useCallback((visibleIds: string[], selected: boolean) => {
+    setState((s) => {
+      if (s.mode === "include") {
+        const included = new Set(s.included);
+        for (const id of visibleIds) {
+          if (selected) included.add(id);
+          else included.delete(id);
+        }
+        return { ...s, included };
+      }
+      // In `all` mode, selecting means clearing exclusions, deselecting means
+      // adding them.
+      const excluded = new Set(s.excluded);
+      for (const id of visibleIds) {
+        if (selected) excluded.delete(id);
+        else excluded.add(id);
+      }
+      return { ...s, excluded };
+    });
+  }, []);
+
+  const selectAllPages = useCallback(() => {
+    setState({ mode: "all", included: new Set(), excluded: new Set() });
+  }, []);
+
+  const clear = useCallback(() => setState(EMPTY), []);
+
+  return {
+    mode: state.mode,
+    included: state.included,
+    excluded: state.excluded,
+    count,
+    isSelected,
+    masterState,
+    toggle,
+    setPageSelected,
+    selectAllPages,
+    clear,
+  };
+}

--- a/src/pages/SearchPage.css
+++ b/src/pages/SearchPage.css
@@ -85,6 +85,14 @@
   gap: var(--spacing-sm);
 }
 
+/* Vertical divider between the selection controls and the action buttons. */
+.search-results__meta-div {
+  width: 1px;
+  align-self: stretch;
+  margin: 2px var(--spacing-xs);
+  background: var(--color-border);
+}
+
 .search-results__meta-right {
   display: inline-flex;
   align-items: center;

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -453,14 +453,6 @@ function SearchPageInner({ community }: { community: Community }) {
         />
       </section>
 
-      {aiEnabled && hasResults && (
-        <AiSummaryButton
-          onClick={handleGenerateSummary}
-          disabled={aiDisabledReason !== undefined}
-          disabledReason={aiDisabledReason}
-        />
-      )}
-
       <section class="search-results">
         {showMetaBar && (
           <div class={`search-results__meta${isSelecting ? " is-selecting" : ""}`}>
@@ -494,34 +486,39 @@ function SearchPageInner({ community }: { community: Community }) {
                         ? formatResultsSummary(params.q, results.results.total)
                         : null
                 : null}
+              {results.results
+                && selectable
+                && (aiEnabled || community.features.exportExcel) && (
+                  <span class="search-results__meta-div" aria-hidden="true" />
+                )}
+              {aiEnabled && hasResults && (
+                <AiSummaryButton
+                  onClick={handleGenerateSummary}
+                  disabled={aiDisabledReason !== undefined}
+                  disabledReason={aiDisabledReason}
+                />
+              )}
+              {results.results && exportJob.status === "error" && (
+                <span class="search-results__export-status" role="alert">
+                  {exportJob.errorMessage ?? "Export failed."}
+                </span>
+              )}
+              {results.results && (
+                <span class="visually-hidden" role="status" aria-live="polite">
+                  {exportAnnouncement}
+                </span>
+              )}
+              {results.results && community.features.exportExcel && (
+                <ExportMenu
+                  disabled={exportDisabled}
+                  status={exportJob.status}
+                  onExport={handleExport}
+                  disabledReason={exportTooltip}
+                />
+              )}
             </span>
             {(refine || results.results) && (
               <span class="search-results__meta-right">
-                {results.results && exportJob.status === "error" && (
-                  <span
-                    class="search-results__export-status"
-                    role="alert"
-                  >
-                    {exportJob.errorMessage ?? "Export failed."}
-                  </span>
-                )}
-                {results.results && (
-                  <span
-                    class="visually-hidden"
-                    role="status"
-                    aria-live="polite"
-                  >
-                    {exportAnnouncement}
-                  </span>
-                )}
-                {results.results && community.features.exportExcel && (
-                  <ExportMenu
-                    disabled={exportDisabled}
-                    status={exportJob.status}
-                    onExport={handleExport}
-                    disabledReason={exportTooltip}
-                  />
-                )}
                 {refine && (
                   <RefineButton
                     count={refine.count}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -32,6 +32,13 @@ import { FilterDrawer, type AppliedFilters } from "@/components/filters/FilterDr
 import { AiSummaryButton } from "@/components/ai-summary/AiSummaryButton";
 import { useAiSummaryContext } from "@/components/ai-summary/AiSummaryProvider";
 import { aiSummariesEnabled } from "@/components/ai-summary/aiSummariesEnabled";
+import { SelectionControls } from "@/components/search/SelectionControls";
+import {
+  SelectionBanner,
+  type SelectionBannerContent,
+} from "@/components/search/SelectionBanner";
+import { selectionEnabled } from "@/components/search/selectionEnabled";
+import { useSelectionContext } from "@/components/search/SelectionProvider";
 import { deriveSummaryTerms } from "@/components/ai-summary/summaryTerms";
 import { formatTotal } from "@/utils/searchTotal";
 import { totalSelectedCount } from "@/components/filters/conceptSchemeFilterState";
@@ -161,6 +168,23 @@ function SearchPageInner({ community }: { community: Community }) {
   const results = useSearch(params);
   const exportJob = useSearchExport();
   const ai = useAiSummaryContext();
+
+  // Reference selection lives in a provider above the router so it survives
+  // navigation. The identity below excludes page + sort, so paging/sorting
+  // keeps the selection while a new community/query/filter clears it.
+  const selection = useSelectionContext();
+  const selectionIdentity = JSON.stringify({
+    community: community.slug,
+    q: params.q,
+    conceptFilters: params.conceptFilters,
+    countryCodes: params.countryCodes,
+    startYear: params.startYear,
+    endYear: params.endYear,
+  });
+  const { syncSearchIdentity } = selection;
+  useEffect(() => {
+    syncSearchIdentity(selectionIdentity);
+  }, [syncSearchIdentity, selectionIdentity]);
 
   // Kick off the vocabulary fetch on page mount (not on drawer open) via the
   // shared cache, so the Refine button is almost always ready by the time
@@ -317,6 +341,44 @@ function SearchPageInner({ community }: { community: Community }) {
   const { aiSummaryWriter } = useAuth();
   const aiEnabled = aiSummariesEnabled(community, aiSummaryWriter);
 
+  // Row selection is only offered when a consumer (export or AI summary) can
+  // act on it, and the community has opted in via the feature flag.
+  const selectable = selectionEnabled(community, aiSummaryWriter);
+  const visibleIds = results.results?.references.map((r) => r.id) ?? [];
+  const selectionTotal = results.results?.total ?? { count: 0, is_lower_bound: false };
+  const selectionCount = selection.count(selectionTotal.count);
+  const isSelecting = selectable && hasResults && selectionCount > 0;
+  const masterState = selection.masterState(visibleIds);
+  const multiPage = results.results !== null && selectionTotal.count > visibleIds.length;
+  // "All N selected." only when everything really is selected; once a page is
+  // deselected in all-mode there are exclusions, so fall back to the count.
+  const allSelected =
+    selection.mode === "all" && selection.excluded.size === 0;
+  const selectionStatusLabel = allSelected
+    ? `All ${formatTotal(selectionTotal)} selected.`
+    : `${selectionCount.toLocaleString()} selected.`;
+  // The master checkbox selects/deselects the current page, keeping any
+  // cross-page selection (the banner escalates to all matches).
+  function handleMasterToggle() {
+    selection.setPageSelected(visibleIds, masterState !== "all");
+  }
+  // Selection summary row: the count and Clear, plus — whenever more than one
+  // page exists and the selection isn't already everything (a manual subset, or
+  // all-minus-exclusions) — an escalation to select every match.
+  const selectionBanner: SelectionBannerContent | null = isSelecting
+    ? {
+        countLabel: selectionStatusLabel,
+        selectAll:
+          multiPage && !allSelected
+            ? {
+                label: `Select all ${formatTotal(selectionTotal)} references`,
+                onAction: selection.selectAllPages,
+              }
+            : undefined,
+        onClear: selection.clear,
+      }
+    : null;
+
   // Terms framing the summary: the free-text query plus any applied concept
   // filters (a map cell arrives here with those filters pre-applied).
   const aiTerms = deriveSummaryTerms(params, vocab.labels);
@@ -401,9 +463,16 @@ function SearchPageInner({ community }: { community: Community }) {
 
       <section class="search-results">
         {showMetaBar && (
-          <div class="search-results__meta">
+          <div class={`search-results__meta${isSelecting ? " is-selecting" : ""}`}>
             <span class="search-results__meta-left" aria-live="polite">
-              {showSummary
+              {selectable && results.results && (
+                <SelectionControls
+                  master={masterState}
+                  onMasterToggle={handleMasterToggle}
+                  disabled={!hasResults}
+                />
+              )}
+              {!isSelecting && showSummary
                 ? results.error
                   ? (
                     <>
@@ -473,6 +542,8 @@ function SearchPageInner({ community }: { community: Community }) {
           </div>
         )}
 
+        {selectable && <SelectionBanner content={selectionBanner} />}
+
         <div
           class={`search-results__list${
             results.loading && results.results !== null ? " is-updating" : ""
@@ -500,6 +571,9 @@ function SearchPageInner({ community }: { community: Community }) {
               codingInstitution={community.codingInstitution}
               findingsAndEstimates={community.features.findingsAndEstimates}
               pillExcludedSchemes={community.pillExcludedSchemes}
+              selectable={selectable}
+              selected={selection.isSelected(ref.id)}
+              onToggle={() => selection.toggle(ref.id)}
             />
           ))}
         </div>

--- a/src/services/communities.ts
+++ b/src/services/communities.ts
@@ -23,6 +23,9 @@ export const DEFAULT_FEATURES: CommunityFeatures = {
   // Off until a community's Excel export is built — the export is Education-shaped today.
   exportExcel: false,
   countryFacetFilter: true,
+  // Off until the consumers (AI summary / export of a selection) ship; turn on
+  // per community once those land.
+  referenceSelection: false,
 };
 
 // The HPV geographic ConceptSchemes (country + regional/classification). Full

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -11,6 +11,9 @@ export interface CommunityFeatures {
   exportExcel: boolean;
   // Whether the facet-backed country filter card is shown; needs a populated `countries` facet.
   countryFacetFilter: boolean;
+  // Gates the result-row selection UI (checkboxes + selection controls). Only
+  // useful alongside export or AI summaries, which consume the selection.
+  referenceSelection: boolean;
 }
 
 // One axis of the evidence map.

--- a/tests/components/search/ResultRow.test.tsx
+++ b/tests/components/search/ResultRow.test.tsx
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/preact";
+import { render, screen, fireEvent } from "@testing-library/preact";
 import { PILL_CAP, ResultRow } from "@/components/search/ResultRow";
 import { rawSourcePatterns } from "@/services/codingInstitution";
 import {
@@ -417,5 +417,41 @@ describe("ResultRow", () => {
     );
     expect(screen.queryByText("Cohort study")).not.toBeNull();
     expect(screen.queryByText("Nigeria")).toBeNull();
+  });
+
+  describe("selection", () => {
+    test("no checkbox unless selectable", () => {
+      render(<ResultRow communitySlug="esea" reference={makeRef()} />);
+      expect(screen.queryByRole("checkbox")).toBeNull();
+    });
+
+    test("checkbox toggles selection and does not sit inside the row link", () => {
+      const onToggle = vi.fn();
+      render(
+        <ResultRow
+          communitySlug="esea"
+          reference={makeRef()}
+          selectable
+          onToggle={onToggle}
+        />,
+      );
+      const box = screen.getByRole("checkbox", { name: /select on phonics/i });
+      fireEvent.click(box);
+      expect(onToggle).toHaveBeenCalledOnce();
+      // The checkbox is a sibling of the row link, not nested in it, so a tick
+      // can't also trigger navigation.
+      const rowLink = screen.getByRole("link", { name: /on phonics instruction/i });
+      expect(rowLink).not.toContainElement(box);
+    });
+
+    test("reflects selected state on the checkbox and the row", () => {
+      const { container } = render(
+        <ResultRow communitySlug="esea" reference={makeRef()} selectable selected />,
+      );
+      expect(
+        screen.getByRole("checkbox", { name: /deselect on phonics/i }),
+      ).toBeChecked();
+      expect(container.querySelector(".result-row")).toHaveClass("is-selected");
+    });
   });
 });

--- a/tests/components/search/SelectionBanner.test.tsx
+++ b/tests/components/search/SelectionBanner.test.tsx
@@ -1,0 +1,35 @@
+import { describe, test, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/preact";
+import { SelectionBanner } from "@/components/search/SelectionBanner";
+
+describe("SelectionBanner", () => {
+  test("renders nothing when there's no content", () => {
+    const { container } = render(<SelectionBanner content={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("shows the count and Clear, with no escalation when single-page", () => {
+    const onClear = vi.fn();
+    render(<SelectionBanner content={{ countLabel: "20 selected", onClear }} />);
+    expect(screen.getByText("20 selected")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /select all/i })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+    expect(onClear).toHaveBeenCalledOnce();
+  });
+
+  test("shows the escalation action and fires it", () => {
+    const onAction = vi.fn();
+    render(
+      <SelectionBanner
+        content={{
+          countLabel: "20 selected",
+          selectAll: { label: "Select all 1,854 references", onAction },
+          onClear: () => {},
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Select all 1,854 references" }));
+    expect(onAction).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/components/search/SelectionBanner.test.tsx
+++ b/tests/components/search/SelectionBanner.test.tsx
@@ -14,7 +14,7 @@ describe("SelectionBanner", () => {
     expect(screen.getByText("20 selected")).toBeTruthy();
     expect(screen.queryByRole("button", { name: /select all/i })).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+    fireEvent.click(screen.getByRole("button", { name: "Clear all" }));
     expect(onClear).toHaveBeenCalledOnce();
   });
 

--- a/tests/components/search/SelectionControls.test.tsx
+++ b/tests/components/search/SelectionControls.test.tsx
@@ -1,0 +1,45 @@
+import { describe, test, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/preact";
+import { SelectionControls } from "@/components/search/SelectionControls";
+
+function setup(overrides: Partial<Parameters<typeof SelectionControls>[0]> = {}) {
+  const onMasterToggle = vi.fn();
+  const view = render(
+    <SelectionControls master="none" onMasterToggle={onMasterToggle} {...overrides} />,
+  );
+  const master = () => screen.getByRole("checkbox") as HTMLInputElement;
+  return { onMasterToggle, master, ...view };
+}
+
+describe("SelectionControls", () => {
+  test("master checkbox reflects tri-state (none / indeterminate / all)", () => {
+    const { master, rerender } = setup({ master: "none" });
+    expect(master()).not.toBeChecked();
+    expect(master().indeterminate).toBe(false);
+
+    rerender(<SelectionControls master="some" onMasterToggle={() => {}} />);
+    expect(master().indeterminate).toBe(true);
+
+    rerender(<SelectionControls master="all" onMasterToggle={() => {}} />);
+    expect(master()).toBeChecked();
+    expect(master().indeterminate).toBe(false);
+  });
+
+  test("shows the 'Select this page' label and toggles on click", () => {
+    const { master, onMasterToggle } = setup();
+    expect(screen.getByText("Select this page")).toBeTruthy();
+    fireEvent.click(master());
+    expect(onMasterToggle).toHaveBeenCalledOnce();
+  });
+
+  test("label becomes 'Deselect this page' when the whole page is selected", () => {
+    setup({ master: "all" });
+    expect(screen.getByText("Deselect this page")).toBeTruthy();
+    expect(screen.queryByText("Select this page")).toBeNull();
+  });
+
+  test("master checkbox can be disabled", () => {
+    const { master } = setup({ disabled: true });
+    expect(master()).toBeDisabled();
+  });
+});

--- a/tests/components/search/SelectionProvider.test.tsx
+++ b/tests/components/search/SelectionProvider.test.tsx
@@ -1,0 +1,66 @@
+import { describe, test, expect } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/preact";
+import { useEffect, useState } from "preact/hooks";
+import {
+  SelectionProvider,
+  useSelectionContext,
+} from "@/components/search/SelectionProvider";
+
+// A stand-in for SearchPage: reports its search identity and reflects the
+// selected count, and can be unmounted to simulate a route change.
+function Consumer({ identity }: { identity: string }) {
+  const sel = useSelectionContext();
+  const { syncSearchIdentity } = sel;
+  useEffect(() => {
+    syncSearchIdentity(identity);
+  }, [syncSearchIdentity, identity]);
+  return (
+    <div>
+      <span data-testid="count">{sel.count(1000)}</span>
+      <button type="button" onClick={() => sel.toggle("a")}>
+        toggle-a
+      </button>
+    </div>
+  );
+}
+
+function Harness() {
+  const [identity, setIdentity] = useState("hpv|q=x");
+  const [mounted, setMounted] = useState(true);
+  return (
+    <SelectionProvider>
+      {mounted && <Consumer identity={identity} />}
+      <button type="button" onClick={() => setMounted((m) => !m)}>
+        toggle-mount
+      </button>
+      <button type="button" onClick={() => setIdentity("hpv|q=y")}>
+        new-search
+      </button>
+    </SelectionProvider>
+  );
+}
+
+describe("SelectionProvider", () => {
+  test("keeps the selection when the consumer remounts (navigation)", () => {
+    render(<Harness />);
+    fireEvent.click(screen.getByText("toggle-a"));
+    expect(screen.getByTestId("count").textContent).toBe("1");
+
+    // Unmount + remount the consumer with the same identity — as a route change
+    // would. The selection must survive.
+    fireEvent.click(screen.getByText("toggle-mount"));
+    fireEvent.click(screen.getByText("toggle-mount"));
+    expect(screen.getByTestId("count").textContent).toBe("1");
+  });
+
+  test("clears the selection when the search identity changes", () => {
+    render(<Harness />);
+    fireEvent.click(screen.getByText("toggle-a"));
+    expect(screen.getByTestId("count").textContent).toBe("1");
+
+    act(() => {
+      fireEvent.click(screen.getByText("new-search"));
+    });
+    expect(screen.getByTestId("count").textContent).toBe("0");
+  });
+});

--- a/tests/components/search/selectionEnabled.test.ts
+++ b/tests/components/search/selectionEnabled.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect, vi } from "vitest";
+import { selectionEnabled } from "@/components/search/selectionEnabled";
+import { makeCommunity } from "../../fixtures";
+
+vi.mock("@/config", () => ({
+  SUMMARISER_BASE: "https://summariser.example",
+  SUMMARISER_MOCK: false,
+}));
+
+describe("selectionEnabled", () => {
+  test("off when the community hasn't opted in", () => {
+    const community = makeCommunity({
+      features: { referenceSelection: false, exportExcel: true },
+    });
+    expect(selectionEnabled(community, true)).toBe(false);
+  });
+
+  test("on when opted in and export is available", () => {
+    const community = makeCommunity({
+      features: { referenceSelection: true, exportExcel: true, aiSummaries: false },
+    });
+    expect(selectionEnabled(community, false)).toBe(true);
+  });
+
+  test("on when opted in and AI summaries are available (no export)", () => {
+    const community = makeCommunity({
+      features: { referenceSelection: true, exportExcel: false, aiSummaries: true },
+    });
+    expect(selectionEnabled(community, true)).toBe(true);
+  });
+
+  test("off when opted in but neither export nor AI is usable", () => {
+    const community = makeCommunity({
+      features: { referenceSelection: true, exportExcel: false, aiSummaries: true },
+    });
+    // No writer role ⇒ AI summaries unavailable ⇒ nothing to act on.
+    expect(selectionEnabled(community, false)).toBe(false);
+  });
+
+  test("off for a null community", () => {
+    expect(selectionEnabled(null, true)).toBe(false);
+  });
+});

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -65,6 +65,7 @@ export function makeCommunity(
       findingsAndEstimates: true,
       exportExcel: true,
       countryFacetFilter: true,
+      referenceSelection: false,
       ...features,
     },
     copy: {

--- a/tests/hooks/useReferenceSelection.test.tsx
+++ b/tests/hooks/useReferenceSelection.test.tsx
@@ -1,0 +1,81 @@
+import { describe, test, expect } from "vitest";
+import { renderHook, act } from "@testing-library/preact";
+import { useReferenceSelection } from "@/hooks/useReferenceSelection";
+
+describe("useReferenceSelection", () => {
+  test("include mode: toggle selects/deselects and counts", () => {
+    const { result } = renderHook(() => useReferenceSelection());
+
+    act(() => result.current.toggle("a"));
+    act(() => result.current.toggle("b"));
+    expect(result.current.isSelected("a")).toBe(true);
+    expect(result.current.isSelected("c")).toBe(false);
+    expect(result.current.count(100)).toBe(2);
+
+    act(() => result.current.toggle("a"));
+    expect(result.current.isSelected("a")).toBe(false);
+    expect(result.current.count(100)).toBe(1);
+  });
+
+  test("setPageSelected adds a page without dropping the existing selection", () => {
+    const { result } = renderHook(() => useReferenceSelection());
+    act(() => result.current.setPageSelected(["a", "b"], true));
+    // A later page is added, not replaced.
+    act(() => result.current.setPageSelected(["c", "d"], true));
+    expect(result.current.count(100)).toBe(4);
+    expect(result.current.isSelected("a")).toBe(true);
+    expect(result.current.isSelected("d")).toBe(true);
+
+    // Deselecting a page removes just those ids.
+    act(() => result.current.setPageSelected(["a", "b"], false));
+    expect(result.current.count(100)).toBe(2);
+    expect(result.current.isSelected("a")).toBe(false);
+    expect(result.current.isSelected("c")).toBe(true);
+  });
+
+  test("setPageSelected in 'all' mode deselects via exclusions", () => {
+    const { result } = renderHook(() => useReferenceSelection());
+    act(() => result.current.selectAllPages());
+    act(() => result.current.setPageSelected(["x", "y"], false));
+    expect(result.current.count(1000)).toBe(998);
+    expect(result.current.isSelected("x")).toBe(false);
+    // Re-selecting the page clears those exclusions.
+    act(() => result.current.setPageSelected(["x", "y"], true));
+    expect(result.current.count(1000)).toBe(1000);
+  });
+
+  test("selectAllPages selects everything minus later exclusions", () => {
+    const { result } = renderHook(() => useReferenceSelection());
+
+    act(() => result.current.selectAllPages());
+    expect(result.current.mode).toBe("all");
+    expect(result.current.isSelected("anything")).toBe(true);
+    expect(result.current.count(1961)).toBe(1961);
+
+    // Deselecting in "all" mode records an exclusion.
+    act(() => result.current.toggle("x"));
+    expect(result.current.isSelected("x")).toBe(false);
+    expect(result.current.count(1961)).toBe(1960);
+  });
+
+  test("masterState reflects none / some / all of the visible ids", () => {
+    const { result } = renderHook(() => useReferenceSelection());
+    const visible = ["a", "b", "c"];
+    expect(result.current.masterState(visible)).toBe("none");
+    act(() => result.current.toggle("a"));
+    expect(result.current.masterState(visible)).toBe("some");
+    act(() => result.current.toggle("b"));
+    act(() => result.current.toggle("c"));
+    expect(result.current.masterState(visible)).toBe("all");
+    expect(result.current.masterState([])).toBe("none");
+  });
+
+  test("clear resets everything", () => {
+    const { result } = renderHook(() => useReferenceSelection());
+    act(() => result.current.selectAllPages());
+    act(() => result.current.clear());
+    expect(result.current.mode).toBe("include");
+    expect(result.current.count(100)).toBe(0);
+    expect(result.current.isSelected("a")).toBe(false);
+  });
+});

--- a/tests/pages/SearchPage.test.tsx
+++ b/tests/pages/SearchPage.test.tsx
@@ -4,6 +4,7 @@ import { SearchPage } from "@/pages/SearchPage";
 import { CommunityProvider } from "@/community/CommunityContext";
 import { AuthProvider } from "@/auth/AuthContext";
 import { AiSummaryProvider } from "@/components/ai-summary/AiSummaryProvider";
+import { SelectionProvider } from "@/components/search/SelectionProvider";
 import type { SearchResult } from "@/types/models";
 import {
   OUTCOME_SCHEME_FIXTURE,
@@ -17,7 +18,9 @@ function renderSearchPage() {
     <AuthProvider>
       <CommunityProvider>
         <AiSummaryProvider>
-          <SearchPage />
+          <SelectionProvider>
+            <SearchPage />
+          </SelectionProvider>
         </AiSummaryProvider>
       </CommunityProvider>
     </AuthProvider>,

--- a/tests/pages/SearchPageSelection.integration.test.tsx
+++ b/tests/pages/SearchPageSelection.integration.test.tsx
@@ -1,0 +1,76 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/preact";
+import { App } from "@/App";
+import type { SearchResult } from "@/types/models";
+import { makeReference, makeVocabResult } from "../fixtures";
+
+vi.mock("@/services/apiClient", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/services/apiClient")>();
+  return { ...actual, searchReferences: vi.fn() };
+});
+vi.mock("@/hooks/useVocabulary", () => ({ useVocabulary: vi.fn() }));
+// Selection ships dark (referenceSelection defaults off); force the gate on so
+// this test exercises the selection UI regardless of the community flag.
+vi.mock("@/components/search/selectionEnabled", () => ({
+  selectionEnabled: () => true,
+}));
+
+import { searchReferences } from "@/services/apiClient";
+import { useVocabulary } from "@/hooks/useVocabulary";
+
+const mockSearch = vi.mocked(searchReferences);
+const mockVocab = vi.mocked(useVocabulary);
+
+const PAGE_SIZE = 20;
+const TOTAL = 40;
+
+function pageResult(page: number): SearchResult {
+  const refs = Array.from({ length: PAGE_SIZE }, (_, i) =>
+    makeReference({ id: `p${page}-r${i}`, bibliographic: { title: `p${page}-r${i}` } }),
+  );
+  return {
+    total: { count: TOTAL, is_lower_bound: false },
+    page: { count: PAGE_SIZE, number: page },
+    references: refs,
+  };
+}
+
+beforeEach(() => {
+  mockVocab.mockReturnValue(makeVocabResult());
+  mockSearch.mockImplementation((_q, filters) =>
+    Promise.resolve(pageResult(filters?.page ?? 1)),
+  );
+  history.pushState({}, "", "/hpv?q=hpv");
+});
+
+async function gotoPage(n: number) {
+  fireEvent.click(screen.getByRole("button", { name: `Page ${n}` }));
+  await waitFor(() =>
+    expect(screen.getByRole("checkbox", { name: new RegExp(`p${n}-r0$`) })).toBeInTheDocument(),
+  );
+}
+
+describe("cross-page selection persistence", () => {
+  test("a page deselected after 'select all' stays deselected on return", async () => {
+    render(<App />);
+    await waitFor(() =>
+      expect(screen.getByRole("checkbox", { name: /p1-r0$/ })).toBeInTheDocument(),
+    );
+
+    // Select this page, then escalate to all matches.
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select this page" }));
+    fireEvent.click(screen.getByRole("button", { name: /select all 40 references/i }));
+    expect(screen.getByText("All 40 selected.")).toBeInTheDocument();
+
+    // Go to page 2 (all selected there), deselect the whole page.
+    await gotoPage(2);
+    expect(screen.getByRole("checkbox", { name: "Deselect p2-r0" })).toBeChecked();
+    fireEvent.click(screen.getByRole("checkbox", { name: "Deselect this page" }));
+    expect(screen.getByRole("checkbox", { name: "Select p2-r0" })).not.toBeChecked();
+
+    // Away to page 1 and back to page 2 — the deselection must survive.
+    await gotoPage(1);
+    await gotoPage(2);
+    expect(screen.getByRole("checkbox", { name: "Select p2-r0" })).not.toBeChecked();
+  });
+});


### PR DESCRIPTION
Closes #197.

Adds reference selection to the search results page — the foundation for AI-summarising / exporting a chosen subset (#198, #199).

- Row checkboxes + a "Select this page" master checkbox (tri-state).
- Selection summary row: count, "Select all N references" escalation, and Clear all.
- Gmail-style include/exclude model so "select all then deselect a few" works; selection persists across paging and sorting, resets on a new search.
- State lives in a `SelectionProvider` above the router so navigation doesn't drop it.
- Gated by a `referenceSelection` community feature flag (**off by default**) and only shown when export or AI summaries are available. Enable per community once #198/#199 land.
- Meta bar restyled to match the design: "Generate AI summary" and "Export" moved into the left cluster (next to the selection controls, with a divider).

## Heads-up: meta-bar change is NOT behind the selection flag

The button relocation above applies to communities with AI summaries / Excel export, independent of `referenceSelection`. So **HPV community users will see the change immediately on deploy** — "Generate AI summary" moves from its own row into the results meta bar and "Export" moves from the right cluster to the left — even though the selection checkboxes stay off until the flag is enabled.

## Known dependency

Cross-page selection is only as reliable as pagination stability, and the search backend currently returns non-deterministic page ordering (relevance ties have no tiebreaker). Tracked in **destiny-evidence/destiny-repository#770** — until that lands, revisiting a page can show different references, which can make a deselected page appear selected again. The selection logic itself is correct (covered by an integration test with stable ids).
